### PR TITLE
Improvements to nd.classify, various deprecation updates

### DIFF
--- a/nd/classify/classification_.py
+++ b/nd/classify/classification_.py
@@ -154,7 +154,8 @@ def _clustermean(ds, labels):
 def _build_X(ds, feature_dims=[]):
     variables = get_vars_for_dims(ds, ('y', 'x'))
     features = tuple(feature_dims) + ('variable',)
-    data = ds[variables].to_array().stack(feature=features).transpose('y', 'x', 'feature').values
+    data = ds[variables].to_array().stack(feature=features).transpose(
+        'y', 'x', 'feature', transpose_coords=True).values
     return data.reshape((-1, data.shape[-1]))
 
 

--- a/nd/classify/classification_.py
+++ b/nd/classify/classification_.py
@@ -184,8 +184,9 @@ class Classifier:
             The class labels to train the classifier.
         """
         # Ignore labels that are NaN or 0
-        ymask = np.array(np.logical_and(
-            ~np.isnan(labels), labels > 0)).reshape(-1)
+        ymask = ~np.isnan(labels)
+        np.greater(labels, 0, out=ymask, where=ymask)
+        ymask = ymask.reshape(-1)
         # Ignore values of ds that contain NaN
         X = _build_X(ds, feature_dims=self.feature_dims)[ymask]
         y = np.array(labels).reshape(-1)[ymask]

--- a/nd/classify/classification_.py
+++ b/nd/classify/classification_.py
@@ -6,10 +6,8 @@ except (ImportError, ModuleNotFoundError):
     raise ImportError('scikit-learn is required for this module.')
 
 import numpy as np
-import geopandas as gpd
-import rasterio.features
 from ..filters import BoxcarFilter
-from ..warp import get_transform, nrows, ncols, get_bounds
+from ..warp import nrows, ncols
 from ..utils import get_vars_for_dims
 
 
@@ -153,10 +151,11 @@ def _clustermean(ds, labels):
     return _means
 
 
-def _build_X(ds):
+def _build_X(ds, feature_dims=[]):
     variables = get_vars_for_dims(ds, ('y', 'x'))
-    data = ds[variables].to_array().transpose('y', 'x', 'variable').values
-    return data.reshape((-1, len(variables)))
+    features = tuple(feature_dims) + ('variable',)
+    data = ds[variables].to_array().stack(feature=features).transpose('y', 'x', 'feature').values
+    return data.reshape((-1, data.shape[-1]))
 
 
 class Classifier:
@@ -166,10 +165,13 @@ class Classifier:
     clf : sklearn classifier
         An initialized classifier object as provided by scikit-learn.
         Must provide methods ``fit`` and ``predict``.
+    feature_dims : list, optional
+        A list of additional dimensions to use as features.
     """
 
-    def __init__(self, clf):
+    def __init__(self, clf, feature_dims=[]):
         self.clf = clf
+        self.feature_dims = feature_dims
 
     def fit(self, ds, labels):
         """
@@ -180,12 +182,14 @@ class Classifier:
         labels : xarray.DataArray
             The class labels to train the classifier.
         """
-
-        mask = np.array(np.logical_and(
+        # Ignore labels that are NaN or 0
+        ymask = np.array(np.logical_and(
             ~np.isnan(labels), labels > 0)).reshape(-1)
-        X = _build_X(ds)[mask]
-        y = np.array(labels).reshape(-1)[mask]
-        self.clf.fit(X, y)
+        # Ignore values of ds that contain NaN
+        X = _build_X(ds, feature_dims=self.feature_dims)[ymask]
+        y = np.array(labels).reshape(-1)[ymask]
+        Xmask = ~np.isnan(X).any(axis=1)
+        self.clf.fit(X[Xmask], y[Xmask])
 
     def predict(self, ds, func='predict'):
         """
@@ -205,8 +209,11 @@ class Classifier:
 
         if func not in dir(self.clf):
             raise AttributeError('Classifier has no method {}.'.format(func))
-        X = _build_X(ds)
-        labels_flat = self.clf.__getattribute__(func)(X)
+        X = _build_X(ds, feature_dims=self.feature_dims)
+        # Skip prediction for NaN entries:
+        mask = ~np.isnan(X).any(axis=1)
+        labels_flat = np.empty(mask.shape) * np.nan
+        labels_flat[mask] = self.clf.__getattribute__(func)(X[mask])
         shape = (nrows(ds), ncols(ds))
         labels = xr.DataArray(labels_flat.reshape(shape), dims=('y', 'x'),
                               coords=ds.coords)

--- a/nd/io/netcdf_.py
+++ b/nd/io/netcdf_.py
@@ -28,7 +28,7 @@ def to_netcdf(ds, path, *args, **kwargs):
     return write.to_netcdf(path, *args, **kwargs)
 
 
-def open_netcdf(path, as_complex=True, *args, **kwargs):
+def open_netcdf(path, as_complex=False, *args, **kwargs):
     """Read a NetCDF file into an xarray Dataset.
 
     Wrapper function for `xarray.open_dataset` that preserves complex
@@ -38,6 +38,9 @@ def open_netcdf(path, as_complex=True, *args, **kwargs):
     ----------
     path : str
         The path of the NetCDF file to read.
+    as_complex : bool, optional
+        Whether or not to assemble real and imaginary parts into complex
+        (default: False).
     *args : list
         Extra positional arguments passed on to ``xarray.open_dataset``.
     **kwargs : dict

--- a/nd/io/tests/test_open.py
+++ b/nd/io/tests/test_open.py
@@ -43,10 +43,12 @@ def test_equivalent_formats():
     datasets = [open_dataset(f) for f in files]
 
 
-def test_write_read_netcdf(tmpdir):
+@pytest.mark.parametrize('cmplx', [True, False])
+def test_write_read_netcdf(tmpdir, cmplx):
     ds = generate_test_dataset()
-    ds = assemble_complex(ds)
+    if cmplx:
+        ds = assemble_complex(ds)
     path = str(tmpdir.join('test_dataset.nc'))
     to_netcdf(ds, path)
-    ds_read = open_dataset(path)
+    ds_read = open_dataset(path, as_complex=cmplx)
     xr_assert_equal(ds, ds_read)

--- a/nd/tiling/__init__.py
+++ b/nd/tiling/__init__.py
@@ -267,7 +267,7 @@ def _combine_along_last_dim(datasets, buffer):
         group = [d.isel(i) for d, i in zip(group, idx)]
 
         # Merge along concat_dim
-        combined = xr.auto_combine(group, concat_dim=concat_dim)
+        combined = xr.combine_nested(group, concat_dim=concat_dim)
         combined.attrs = _combined_attrs(group)
         merged.append(combined)
 

--- a/nd/tiling/tests/test_tiling.py
+++ b/nd/tiling/tests/test_tiling.py
@@ -75,7 +75,8 @@ def test_tile(tmpdir, chunks, buffer):
             assert t.dims[dim] <= val + 2*buffer_dict[dim]
 
     if buffer == 0 and len(chunks) == 1:
-        mf_data = xr.open_mfdataset(tile_files, engine='h5netcdf').compute()
+        mf_data = xr.open_mfdataset(
+            tile_files, engine='h5netcdf', combine='by_coords').compute()
         assert_equal_data(ds, mf_data)
 
     else:

--- a/nd/utils/__init__.py
+++ b/nd/utils/__init__.py
@@ -31,13 +31,16 @@ __all__ = ['str2date',
            ]
 
 
-def str2date(string, fmt=None):
+def str2date(string, fmt=None, tz=False):
     if fmt is None:
         date_object = parsedate(string)
     else:
         date_object = datetime.datetime.strptime(string, fmt)
-    if date_object.tzinfo is None:
-        date_object = date_object.replace(tzinfo=tzutc())
+    if tz:
+        if date_object.tzinfo is None:
+            date_object = date_object.replace(tzinfo=tzutc())
+    elif date_object.tzinfo is not None:
+        date_object = date_object.replace(tzinfo=None)
     return date_object
 
 

--- a/nd/utils/tests/test_utils.py
+++ b/nd/utils/tests/test_utils.py
@@ -15,11 +15,15 @@ from dateutil.tz import tzutc
     '%Y-%m-%d %H:%M:%S.%f',
     '%Y/%m/%dT%H:%M:%S.%fZ'
 ])
-def test_str2date(fmt):
-    d = datetime(2018, 1, 6, 12, 34, 56, tzinfo=tzutc())
+@pytest.mark.parametrize('tz', [
+    True, False
+])
+def test_str2date(fmt, tz):
+    tzinfo = tzutc() if tz else None
+    d = datetime(2018, 1, 6, 12, 34, 56, tzinfo=tzinfo)
     dstr = d.strftime(fmt)
-    assert_equal(utils.str2date(dstr), d)
-    assert_equal(utils.str2date(dstr, fmt=fmt), d)
+    assert_equal(utils.str2date(dstr, tz=tz), d)
+    assert_equal(utils.str2date(dstr, fmt=fmt, tz=tz), d)
 
 
 def test_dict_product():

--- a/nd/visualize/visualize_.py
+++ b/nd/visualize/visualize_.py
@@ -220,9 +220,16 @@ def write_video(ds, path, timestamp=True, width=None, height=None, fps=1,
 
     # Use coords rather than dims so it also works for DataArray
     if height is None:
-        height = ds.coords['y'].size
+        if width is not None:
+            # Determine height from given width
+            height = width * ds.coords['y'].size / ds.coords['x'].size
+        else:
+            # Both are None: Use original size of data
+            height = ds.coords['y'].size
+            width = ds.coords['x'].size
     if width is None:
-        width = ds.coords['x'].size
+        # Determine width from given height
+        width = height * ds.coords['x'].size / ds.coords['y'].size
 
     _, ext = os.path.splitext(path)
 

--- a/nd/warp/tests/test_warp.py
+++ b/nd/warp/tests/test_warp.py
@@ -445,7 +445,7 @@ def test_reprojection_nan_values():
         if not set(warped[v].dims).issuperset({'y', 'x'}):
             continue
         dim_order = tuple(set(warped[v].dims) - {'y', 'x'}) + ('y', 'x')
-        values = warped[v].transpose(*dim_order).values
+        values = warped[v].transpose(*dim_order, transpose_coords=True).values
         # Check that pixels strictly inside the original bounds are not NaN
         assert np.isnan(values[..., inside_bounds]).sum() == 0
         # Pixel outside of the original bounds should be mostly NaN,

--- a/nd/warp/warp_.py
+++ b/nd/warp/warp_.py
@@ -105,6 +105,8 @@ def get_crs(ds, format='crs'):
     crs = None
     if 'crs' in ds.attrs:
         crs = _parse_crs(ds.attrs['crs'])
+    elif 'coordinate_system_string' in ds.attrs:
+        crs = _parse_crs(ds.attrs['coordinate_system_string'])
     elif isinstance(ds, xr.Dataset) and 'crs' in ds.data_vars:
         for attr in ds['crs'].attrs:
             try:
@@ -560,7 +562,7 @@ def _reproject(ds, dst_crs=None, dst_transform=None, width=None, height=None,
             default_resampling = rasterio.warp.Resampling.nearest
         else:
             nodata = np.nan
-            default_resampling = rasterio.warp.Resampling.cubic
+            default_resampling = rasterio.warp.Resampling.bilinear
         if 'resampling' not in kwargs:
             kwargs['resampling'] = default_resampling
 

--- a/nd/warp/warp_.py
+++ b/nd/warp/warp_.py
@@ -568,7 +568,7 @@ def _reproject(ds, dst_crs=None, dst_transform=None, width=None, height=None,
 
         # Get values as numpy array such that last two axes are
         # y and x
-        values = da.transpose(*dim_order).values
+        values = da.transpose(*dim_order, transpose_coords=True).values
 
         # Flatten multidimensional data to ONE extra dimension
         if values.ndim > 2:

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ test = pytest
 [tool:pytest]
 addopts =
     --verbose
-    --duration=10
+    --durations=10


### PR DESCRIPTION
Updates to `nd.classify`:
- Filter `NaN` values before fitting and predicting
- Removed superfluous imports
- add `feature_dims` argument to `Classifier` class to allow for time series classification

Fixed deprecation warnings:
- Switched from `xr.auto_combine` to `xr.combine_nested`
- Made time zone information optional in `nd.utils.str2date`
- Always pass `transpose_coords=True` to `xr.Dataset.transpose()`

Other:
- New default: `as_complex=False` in nd.open_dataset
- fix width and height calculation in `nd.write_video()`