### PR TITLE
Fix RTD build, add Python 3.8 support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,5 +6,10 @@ sphinx:
 formats:
   - pdf
 
+python:
+  install:
+    - method: pip
+      path: .
+
 conda:
   environment: doc/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,5 +6,5 @@ sphinx:
 formats:
   - pdf
 
-python:
-  version: 3.7
+conda:
+  environment: doc/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,12 @@ formats:
   - pdf
 
 python:
+  version: 3.7
   install:
+    - requirements: doc/requirements.txt
     - method: pip
       path: .
+  system_packages: true
 
-conda:
-  environment: doc/environment.yml
+# conda:
+#   environment: doc/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
 
 formats:
   - pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+
+python:
+  version: 3.7

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,5 @@ python:
       path: .
   system_packages: true
 
-# conda:
-#   environment: doc/environment.yml
+conda:
+  environment: doc/environment.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,9 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  pytest pytest-cov coverage
+  pytest pytest-cov coverage rasterio
 - source activate test-environment
-- conda install cartopy rasterio
-- conda install ffmpeg
+- pip install cartopy ffmpeg
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 cache:
   directories:
   - "~/.cache/pip"
-dist: trusty
 language: python
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,8 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  pytest pytest-cov coverage rasterio ffmpeg
+  pytest pytest-cov coverage rasterio ffmpeg cartopy
 - source activate test-environment
-- pip install cartopy
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -n test-environment --force python=$TRAVIS_PYTHON_VERSION numpy
-  rasterio ffmpeg cartopy pytest pytest-cov coverage
+  rasterio ffmpeg cartopy pytest pytest-cov coverage -c conda-forge
 - source activate test-environment
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  pytest pytest-cov coverage rasterio
+  pytest pytest-cov coverage rasterio ffmpeg
 - source activate test-environment
-- pip install cartopy ffmpeg
+- pip install cartopy
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  pytest pytest-cov coverage cartopy ffmpeg
+  pytest pytest-cov coverage cartopy ffmpeg rasterio
 - source activate test-environment
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 cache:
   directories:
   - "~/.cache/pip"
@@ -17,13 +16,12 @@ before_install:
 - sudo apt-get update -q
 - nc-config --version
 - h5cc -showconfig
-matrix:
+jobs:
   include:
   - python: 3.5
   - python: 3.6
   - python: 3.7
-    dist: xenial
-    sudo: true
+  - python: 3.8
 install:
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ install:
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
   pytest pytest-cov coverage
 - source activate test-environment
-- conda install ffmpeg rasterio
+- conda install cartopy rasterio
+- conda install ffmpeg
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,9 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  rasterio ffmpeg cartopy
+- conda create -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
+  rasterio ffmpeg cartopy pytest pytest-cov coverage
 - source activate test-environment
-- pip install pytest pytest-cov coverage
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
+- conda create -n test-environment --force python=$TRAVIS_PYTHON_VERSION numpy
   rasterio ffmpeg cartopy pytest pytest-cov coverage
 - source activate test-environment
 - pip install scikit-learn scikit-image codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  pytest pytest-cov coverage rasterio ffmpeg cartopy
+  rasterio ffmpeg cartopy
 - source activate test-environment
+- pip install pytest pytest-cov coverage
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
-  pytest pytest-cov coverage cartopy ffmpeg rasterio
+  pytest pytest-cov coverage
 - source activate test-environment
+- conda install ffmpeg rasterio
 - pip install scikit-learn scikit-image codecov
 - export CPLUS_INCLUDE_PATH=/usr/include/gdal
 - export C_INCLUDE_PATH=/usr/include/gdal

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,8 +29,6 @@ autodoc_mock_imports = [
     # 'matplotlib',
     # 'cython_gsl',
     'shapely',
-    'shapely.geometry',
-    'shapely.affinity',
     'pyproj',
     'cartopy',
     'sklearn',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,9 +40,9 @@ autodoc_mock_imports = [
     'lxml',
     'skimage',
     'geopandas',
-    'nd._filters',
-    'nd._warp',
-    'nd._change',
+    # 'nd._filters',
+    # 'nd._warp',
+    # 'nd._change',
     ]
 autodoc_warningiserror = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ autodoc_mock_imports = [
     'sklearn',
     'scipy',
     'rasterio',
+    'rasterio.features',
     'imageio',
     'affine',
     'cv2',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,12 @@ import glob
 from operator import attrgetter
 import inspect
 import subprocess
+from unittest.mock import Mock
+
+
+MOCK_MODULES = ['rasterio']
+for m in MOCK_MODULES:
+    sys.modules[m] = Mock()
 
 
 # Mock imports for autodoc
@@ -34,7 +40,6 @@ autodoc_mock_imports = [
     'sklearn',
     'scipy',
     'rasterio',
-    'rasterio.features',
     'imageio',
     'affine',
     'cv2',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,12 +18,12 @@ import glob
 from operator import attrgetter
 import inspect
 import subprocess
-# from unittest.mock import Mock
+from unittest.mock import Mock
 
 
-# MOCK_MODULES = ['rasterio']
-# for m in MOCK_MODULES:
-#     sys.modules[m] = Mock()
+MOCK_MODULES = ['nd._filters', 'nd._warp', 'nd._change']
+for m in MOCK_MODULES:
+    sys.modules[m] = Mock()
 
 
 # Mock imports for autodoc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,12 +18,12 @@ import glob
 from operator import attrgetter
 import inspect
 import subprocess
-from unittest.mock import Mock
+# from unittest.mock import Mock
 
 
-MOCK_MODULES = ['rasterio']
-for m in MOCK_MODULES:
-    sys.modules[m] = Mock()
+# MOCK_MODULES = ['rasterio']
+# for m in MOCK_MODULES:
+#     sys.modules[m] = Mock()
 
 
 # Mock imports for autodoc
@@ -46,9 +46,9 @@ autodoc_mock_imports = [
     'lxml',
     'skimage',
     'geopandas',
-    'nd._filters',
-    'nd._warp',
-    'nd._change',
+    # 'nd._filters',
+    # 'nd._warp',
+    # 'nd._change',
     ]
 autodoc_warningiserror = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,9 +40,9 @@ autodoc_mock_imports = [
     'lxml',
     'skimage',
     'geopandas',
-    # 'nd._filters',
-    # 'nd._warp',
-    # 'nd._change',
+    'nd._filters',
+    'nd._warp',
+    'nd._change',
     ]
 autodoc_warningiserror = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,6 +30,7 @@ autodoc_mock_imports = [
     # 'cython_gsl',
     'shapely',
     'shapely.geometry',
+    'shapely.affinity',
     'pyproj',
     'cartopy',
     'sklearn',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,8 @@ autodoc_mock_imports = [
     ]
 autodoc_warningiserror = False
 
+autosummary_mock_imports = autodoc_mock_imports
+
 
 try:
     import nd

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,12 +18,6 @@ import glob
 from operator import attrgetter
 import inspect
 import subprocess
-from unittest.mock import Mock
-
-
-MOCK_MODULES = ['nd._filters', 'nd._warp', 'nd._change']
-for m in MOCK_MODULES:
-    sys.modules[m] = Mock()
 
 
 # Mock imports for autodoc
@@ -35,6 +29,7 @@ autodoc_mock_imports = [
     # 'matplotlib',
     # 'cython_gsl',
     'shapely',
+    'fiona',
     'pyproj',
     'cartopy',
     'sklearn',
@@ -46,9 +41,9 @@ autodoc_mock_imports = [
     'lxml',
     'skimage',
     'geopandas',
-    # 'nd._filters',
-    # 'nd._warp',
-    # 'nd._change',
+    'nd._filters',
+    'nd._warp',
+    'nd._change',
     ]
 autodoc_warningiserror = False
 

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - sphinx=2.2.1
   - gsl
   - numpy

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,5 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - sphinx=2.2.1
   - gsl
   - numpy
-  - rasterio

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,5 +2,6 @@ name: ndtest
 channels:
   - conda-forge
 dependencies:
+  - python=3.7
   - gsl
   - numpy

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - sphinx=2.2.1
   - gsl
   - numpy
+  - rasterio

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@ xarray
 dask
 matplotlib
 shapely
+rasterio

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 numpy
+sphinx==2.2.1
 pandas
 xarray
 dask
 matplotlib
 shapely
-rasterio

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,4 @@
 numpy
-sphinx==2.2.1
 pandas
 xarray
 dask

--- a/nd/__init__.py
+++ b/nd/__init__.py
@@ -1,3 +1,4 @@
+import os
 # Strangely, h5netcdf must be imported at this point
 # for the h5netcdf backend to work properly on Travis (and Ubuntu)
 try:
@@ -5,11 +6,13 @@ try:
 except Exception:
     pass
 
-# Import shapely.geometry at this point to avoid the error:
-# Assertion failed: (0), function query, file AbstractSTRtree.cpp
-# which may occur if shapely is imported *after* fiona
-import shapely.geometry
-import shapely.affinity
+# Skip on mock install
+if os.environ.get('READTHEDOCS') != 'True':
+    # Import shapely.geometry at this point to avoid the error:
+    # Assertion failed: (0), function query, file AbstractSTRtree.cpp
+    # which may occur if shapely is imported *after* fiona
+    import shapely.geometry
+    import shapely.affinity
 
 from xarray import Dataset, DataArray
 from .io import open_dataset, to_netcdf

--- a/nd/algorithm.py
+++ b/nd/algorithm.py
@@ -5,7 +5,10 @@ from abc import ABC, abstractmethod, ABCMeta
 import inspect
 from types import CodeType
 from collections import OrderedDict
+import sys
 from . import utils
+
+PY_VERSION = sys.version_info
 
 
 class Algorithm(ABC):
@@ -66,23 +69,29 @@ def wrap_algorithm(algo, name=None):
     new_filename = inspect.getfile(algo)
     caller = inspect.getframeinfo(inspect.stack()[1][0])
     new_firstlineno = caller.lineno
-    new_code = CodeType(
-        code.co_argcount,
-        code.co_kwonlyargcount,
-        code.co_nlocals,
-        code.co_stacksize,
-        code.co_flags,
-        code.co_code,
-        code.co_consts,
-        code.co_names,
-        code.co_varnames,
-        new_filename,
-        code.co_name,
-        new_firstlineno,
-        code.co_lnotab,
-        code.co_freevars,
-        code.co_cellvars
-    )
+    if PY_VERSION >= (3, 8):
+        new_code = code.replace(
+            co_filename=new_filename,
+            co_firstlineno=new_firstlineno
+        )
+    else:
+        new_code = CodeType(
+            code.co_argcount,
+            code.co_kwonlyargcount,
+            code.co_nlocals,
+            code.co_stacksize,
+            code.co_flags,
+            code.co_code,
+            code.co_consts,
+            code.co_names,
+            code.co_varnames,
+            new_filename,
+            code.co_name,
+            new_firstlineno,
+            code.co_lnotab,
+            code.co_freevars,
+            code.co_cellvars
+        )
     _wrapper.__code__ = new_code
 
     # Override function name

--- a/nd/testing.py
+++ b/nd/testing.py
@@ -164,7 +164,12 @@ def assert_equal_data(ds1, ds2):
 
 
 def assert_equal_crs(crs1, crs2, *args, **kwargs):
+    # Perform some easy checks first.
+    # If they fail check if a transform between both CRS
+    # is approximately the identity.
     if crs1 is None and crs2 is None:
+        return
+    if crs1.to_wkt() == crs2.to_wkt():
         return
     xs = np.arange(10, dtype=np.float64)
     ys = np.arange(10, dtype=np.float64)

--- a/nd/testing.py
+++ b/nd/testing.py
@@ -329,8 +329,8 @@ def generate_test_polygons(n_polygon=20,
 
             except shapely.errors.TopologicalError:
                 continue
-
-        poly.append(polygon)
+        if not polygon.is_empty:
+            poly.append(polygon)
 
     return poly
 

--- a/nd/testing.py
+++ b/nd/testing.py
@@ -329,6 +329,7 @@ def generate_test_polygons(n_polygon=20,
 
             except shapely.errors.TopologicalError:
                 continue
+
         if not polygon.is_empty:
             poly.append(polygon)
 

--- a/nd/vector.py
+++ b/nd/vector.py
@@ -27,6 +27,9 @@ def read_file(path, clip=None):
     -------
     geopandas.GeoDataFrame
     """
+    if clip is None:
+        return gpd.read_file(path)
+
     def records(filename, geom):
         with fiona.open(filename) as source:
             for feature in source:
@@ -36,6 +39,7 @@ def read_file(path, clip=None):
                     poly = shapely.geometry.shape(feature['geometry'])
                     if poly.intersects(geom):
                         yield feature
+
     return gpd.GeoDataFrame.from_features(records(path, clip))
 
 

--- a/nd/vector.py
+++ b/nd/vector.py
@@ -36,6 +36,8 @@ def read_file(path, clip=None):
                 if geom is None:
                     yield feature
                 else:
+                    if feature['geometry'] is None:
+                        continue
                     poly = shapely.geometry.shape(feature['geometry'])
                     if poly.intersects(geom):
                         yield feature

--- a/nd/visualize.py
+++ b/nd/visualize.py
@@ -352,13 +352,11 @@ def gridlines_with_labels(ax, top=True, bottom=True, left=True,
         gridline_coords[side] = ccrs.PlateCarree().transform_points(
             ax.projection, values[0], values[1])
 
-    # cartopy < 0.18.0:
-    try:
-        lon_lim, lat_lim = gridliner._axes_domain(
-            background_patch=ax.background_patch)
-    # cartopy >= 0.18.0
-    except Exception:
-        lon_lim, lat_lim = gridliner._axes_domain()
+    # Get longitude and latitude limits
+    points = np.concatenate(list(gridline_coords.values()))
+    lon_lim = (points[:, 0].min(), points[:, 0].max())
+    lat_lim = (points[:, 1].min(), points[:, 1].max())
+
     ticklocs = {
         'x': gridliner.xlocator.tick_values(lon_lim[0], lon_lim[1]),
         'y': gridliner.ylocator.tick_values(lat_lim[0], lat_lim[1])

--- a/nd/visualize.py
+++ b/nd/visualize.py
@@ -491,6 +491,12 @@ def plot_map(ds, buffer=None, background='_default', imscale=6,
     # (centered at the polygon)
     # ----------------------------------
     map_crs = _get_orthographic_projection(ds)
+    proj4_params = map_crs.proj4_params
+    if 'a' in proj4_params:
+        # Some version of cartopy add the parameter 'a'.
+        # For some reason, the CRS cannot be parsed by rasterio with
+        # this parameter present.
+        del proj4_params['a']
 
     # Create figure
     # -------------
@@ -517,7 +523,7 @@ def plot_map(ds, buffer=None, background='_default', imscale=6,
 
     # Add polygon
     # -----------
-    geometry_map = warp.get_geometry(ds, crs=map_crs.proj4_params)
+    geometry_map = warp.get_geometry(ds, crs=proj4_params)
     ax.add_geometries([geometry_map], crs=map_crs,
                       facecolor=(1, 0, 0, 0.2), edgecolor=(0, 0, 0, 1))
 

--- a/nd/visualize.py
+++ b/nd/visualize.py
@@ -352,8 +352,13 @@ def gridlines_with_labels(ax, top=True, bottom=True, left=True,
         gridline_coords[side] = ccrs.PlateCarree().transform_points(
             ax.projection, values[0], values[1])
 
-    lon_lim, lat_lim = gridliner._axes_domain(
-        background_patch=ax.background_patch)
+    # cartopy < 0.18.0:
+    try:
+        lon_lim, lat_lim = gridliner._axes_domain(
+            background_patch=ax.background_patch)
+    # cartopy >= 0.18.0
+    except Exception:
+        lon_lim, lat_lim = gridliner._axes_domain()
     ticklocs = {
         'x': gridliner.xlocator.tick_values(lon_lim[0], lon_lim[1]),
         'y': gridliner.ylocator.tick_values(lat_lim[0], lat_lim[1])

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,10 @@ def get_gsl_lib_dir():
 
 
 change_libraries = ['gsl', 'gslcblas']
-change_library_dirs = [get_gsl_lib_dir()]
+if mock_install:
+    change_library_dirs = []
+else:
+    change_library_dirs = [get_gsl_lib_dir()]
 change_include_dirs = ['.']
 
 cmdclass = {}
@@ -84,10 +87,13 @@ if USE_CYTHON:
         extensions, compiler_directives=compiler_directives)
     cmdclass = {'build_ext': build_ext}
 
-include_dirs = [
-    numpy.get_include(),
-    get_gsl_include_dir()
-]
+if mock_install:
+    include_dirs = []
+else:
+    include_dirs = [
+        numpy.get_include(),
+        get_gsl_include_dir()
+    ]
 
 install_requires = [
     "numpy",

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ if not mock_install:
 setup(
     use_scm_version=True,
     cmdclass=cmdclass,
-    ext_modules=extensions,
+    ext_modules=extensions if not mock_install else [],
     include_dirs=include_dirs,
     install_requires=install_requires
 )


### PR DESCRIPTION
- add `.readthedocs.yml`
- update `.travis.yml`
- fix `wrap_algorithm` for Python 3.8
- fix `visualize.gridlines_with_labels` for newer version of cartopy (>= 0.18.0)
- additional mocks on RTD