### PR TITLE
Make libgsl dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ language: python
 addons:
   apt:
     packages:
-    - libhdf5-serial-dev
-    - netcdf-bin
-    - libnetcdf-dev
-    - gsl-bin
-    - libgsl0-dev
-    - libgdal1-dev
+    - &basic_deps [libhdf5-serial-dev, netcdf-bin, libnetcdf-dev]
+    - &gsl_deps [gsl-bin, libgsl0-dev, libgdal1-dev]
 before_install:
 - sudo apt-get update -q
 - nc-config --version
@@ -18,9 +14,35 @@ before_install:
 jobs:
   include:
   - python: 3.5
+    addons:
+      apt:
+        packages:
+          - *basic_deps
+          - *gsl_deps
   - python: 3.6
+    addons:
+      apt:
+        packages:
+          - *basic_deps
+          - *gsl_deps
   - python: 3.7
+    addons:
+      apt:
+        packages:
+          - *basic_deps
+          - *gsl_deps
   - python: 3.8
+    addons:
+      apt:
+        packages:
+          - *basic_deps
+          - *gsl_deps
+  - python: 3.7
+    env: NOGSL=True
+    addons:
+      apt:
+        packages:
+          - *basic_deps
 install:
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ addons:
   apt:
     packages:
     - &basic_deps [libhdf5-serial-dev, netcdf-bin, libnetcdf-dev]
-    - &gsl_deps [gsl-bin, libgsl0-dev, libgdal1-dev]
+    - &gsl_deps [gsl-bin, libgsl0-dev]
+    - &gdal_deps [libgdal1-dev]
 before_install:
 - sudo apt-get update -q
 - nc-config --version
@@ -18,24 +19,28 @@ jobs:
       apt:
         packages:
           - *basic_deps
+          - *gdal_deps
           - *gsl_deps
   - python: 3.6
     addons:
       apt:
         packages:
           - *basic_deps
+          - *gdal_deps
           - *gsl_deps
   - python: 3.7
     addons:
       apt:
         packages:
           - *basic_deps
+          - *gdal_deps
           - *gsl_deps
   - python: 3.8
     addons:
       apt:
         packages:
           - *basic_deps
+          - *gdal_deps
           - *gsl_deps
   - python: 3.7
     env: NOGSL=True
@@ -43,6 +48,7 @@ jobs:
       apt:
         packages:
           - *basic_deps
+          - *gdal_deps
 install:
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Read the [Documentation](https://nd.readthedocs.io/en/latest/) for detailed user
 pip install nd
 ```
 
-Note that ``nd`` requires the ``libgsl-dev`` C library to be installed.
+Note that the following algorithms require the ``libgsl-dev`` C library to be installed:
+
+- ``nd.change.OmnibusTest``
 
 
 ## What does this library add?

--- a/examples/tutorial_ghrsst.html
+++ b/examples/tutorial_ghrsst.html
@@ -1,0 +1,13498 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" />
+
+<title>tutorial_ghrsst</title>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
+
+
+<style type="text/css">
+    /*!
+*
+* Twitter Bootstrap
+*
+*/
+/*!
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+html {
+  font-family: sans-serif;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+}
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  vertical-align: baseline;
+}
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+[hidden],
+template {
+  display: none;
+}
+a {
+  background-color: transparent;
+}
+a:active,
+a:hover {
+  outline: 0;
+}
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+b,
+strong {
+  font-weight: bold;
+}
+dfn {
+  font-style: italic;
+}
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+mark {
+  background: #ff0;
+  color: #000;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+img {
+  border: 0;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+figure {
+  margin: 1em 40px;
+}
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+pre {
+  overflow: auto;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+  margin: 0;
+}
+button {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer;
+}
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+input {
+  line-height: normal;
+}
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+input[type="search"] {
+  -webkit-appearance: textfield;
+  box-sizing: content-box;
+}
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+legend {
+  border: 0;
+  padding: 0;
+}
+textarea {
+  overflow: auto;
+}
+optgroup {
+  font-weight: bold;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td,
+th {
+  padding: 0;
+}
+/*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
+@media print {
+  *,
+  *:before,
+  *:after {
+    background: transparent !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+  a[href^="#"]:after,
+  a[href^="javascript:"]:after {
+    content: "";
+  }
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+  thead {
+    display: table-header-group;
+  }
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+  img {
+    max-width: 100% !important;
+  }
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+  .navbar {
+    display: none;
+  }
+  .btn > .caret,
+  .dropup > .btn > .caret {
+    border-top-color: #000 !important;
+  }
+  .label {
+    border: 1px solid #000;
+  }
+  .table {
+    border-collapse: collapse !important;
+  }
+  .table td,
+  .table th {
+    background-color: #fff !important;
+  }
+  .table-bordered th,
+  .table-bordered td {
+    border: 1px solid #ddd !important;
+  }
+}
+@font-face {
+  font-family: 'Glyphicons Halflings';
+  src: url('../components/bootstrap/fonts/glyphicons-halflings-regular.eot');
+  src: url('../components/bootstrap/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.woff2') format('woff2'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.woff') format('woff'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../components/bootstrap/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+}
+.glyphicon {
+  position: relative;
+  top: 1px;
+  display: inline-block;
+  font-family: 'Glyphicons Halflings';
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.glyphicon-asterisk:before {
+  content: "\002a";
+}
+.glyphicon-plus:before {
+  content: "\002b";
+}
+.glyphicon-euro:before,
+.glyphicon-eur:before {
+  content: "\20ac";
+}
+.glyphicon-minus:before {
+  content: "\2212";
+}
+.glyphicon-cloud:before {
+  content: "\2601";
+}
+.glyphicon-envelope:before {
+  content: "\2709";
+}
+.glyphicon-pencil:before {
+  content: "\270f";
+}
+.glyphicon-glass:before {
+  content: "\e001";
+}
+.glyphicon-music:before {
+  content: "\e002";
+}
+.glyphicon-search:before {
+  content: "\e003";
+}
+.glyphicon-heart:before {
+  content: "\e005";
+}
+.glyphicon-star:before {
+  content: "\e006";
+}
+.glyphicon-star-empty:before {
+  content: "\e007";
+}
+.glyphicon-user:before {
+  content: "\e008";
+}
+.glyphicon-film:before {
+  content: "\e009";
+}
+.glyphicon-th-large:before {
+  content: "\e010";
+}
+.glyphicon-th:before {
+  content: "\e011";
+}
+.glyphicon-th-list:before {
+  content: "\e012";
+}
+.glyphicon-ok:before {
+  content: "\e013";
+}
+.glyphicon-remove:before {
+  content: "\e014";
+}
+.glyphicon-zoom-in:before {
+  content: "\e015";
+}
+.glyphicon-zoom-out:before {
+  content: "\e016";
+}
+.glyphicon-off:before {
+  content: "\e017";
+}
+.glyphicon-signal:before {
+  content: "\e018";
+}
+.glyphicon-cog:before {
+  content: "\e019";
+}
+.glyphicon-trash:before {
+  content: "\e020";
+}
+.glyphicon-home:before {
+  content: "\e021";
+}
+.glyphicon-file:before {
+  content: "\e022";
+}
+.glyphicon-time:before {
+  content: "\e023";
+}
+.glyphicon-road:before {
+  content: "\e024";
+}
+.glyphicon-download-alt:before {
+  content: "\e025";
+}
+.glyphicon-download:before {
+  content: "\e026";
+}
+.glyphicon-upload:before {
+  content: "\e027";
+}
+.glyphicon-inbox:before {
+  content: "\e028";
+}
+.glyphicon-play-circle:before {
+  content: "\e029";
+}
+.glyphicon-repeat:before {
+  content: "\e030";
+}
+.glyphicon-refresh:before {
+  content: "\e031";
+}
+.glyphicon-list-alt:before {
+  content: "\e032";
+}
+.glyphicon-lock:before {
+  content: "\e033";
+}
+.glyphicon-flag:before {
+  content: "\e034";
+}
+.glyphicon-headphones:before {
+  content: "\e035";
+}
+.glyphicon-volume-off:before {
+  content: "\e036";
+}
+.glyphicon-volume-down:before {
+  content: "\e037";
+}
+.glyphicon-volume-up:before {
+  content: "\e038";
+}
+.glyphicon-qrcode:before {
+  content: "\e039";
+}
+.glyphicon-barcode:before {
+  content: "\e040";
+}
+.glyphicon-tag:before {
+  content: "\e041";
+}
+.glyphicon-tags:before {
+  content: "\e042";
+}
+.glyphicon-book:before {
+  content: "\e043";
+}
+.glyphicon-bookmark:before {
+  content: "\e044";
+}
+.glyphicon-print:before {
+  content: "\e045";
+}
+.glyphicon-camera:before {
+  content: "\e046";
+}
+.glyphicon-font:before {
+  content: "\e047";
+}
+.glyphicon-bold:before {
+  content: "\e048";
+}
+.glyphicon-italic:before {
+  content: "\e049";
+}
+.glyphicon-text-height:before {
+  content: "\e050";
+}
+.glyphicon-text-width:before {
+  content: "\e051";
+}
+.glyphicon-align-left:before {
+  content: "\e052";
+}
+.glyphicon-align-center:before {
+  content: "\e053";
+}
+.glyphicon-align-right:before {
+  content: "\e054";
+}
+.glyphicon-align-justify:before {
+  content: "\e055";
+}
+.glyphicon-list:before {
+  content: "\e056";
+}
+.glyphicon-indent-left:before {
+  content: "\e057";
+}
+.glyphicon-indent-right:before {
+  content: "\e058";
+}
+.glyphicon-facetime-video:before {
+  content: "\e059";
+}
+.glyphicon-picture:before {
+  content: "\e060";
+}
+.glyphicon-map-marker:before {
+  content: "\e062";
+}
+.glyphicon-adjust:before {
+  content: "\e063";
+}
+.glyphicon-tint:before {
+  content: "\e064";
+}
+.glyphicon-edit:before {
+  content: "\e065";
+}
+.glyphicon-share:before {
+  content: "\e066";
+}
+.glyphicon-check:before {
+  content: "\e067";
+}
+.glyphicon-move:before {
+  content: "\e068";
+}
+.glyphicon-step-backward:before {
+  content: "\e069";
+}
+.glyphicon-fast-backward:before {
+  content: "\e070";
+}
+.glyphicon-backward:before {
+  content: "\e071";
+}
+.glyphicon-play:before {
+  content: "\e072";
+}
+.glyphicon-pause:before {
+  content: "\e073";
+}
+.glyphicon-stop:before {
+  content: "\e074";
+}
+.glyphicon-forward:before {
+  content: "\e075";
+}
+.glyphicon-fast-forward:before {
+  content: "\e076";
+}
+.glyphicon-step-forward:before {
+  content: "\e077";
+}
+.glyphicon-eject:before {
+  content: "\e078";
+}
+.glyphicon-chevron-left:before {
+  content: "\e079";
+}
+.glyphicon-chevron-right:before {
+  content: "\e080";
+}
+.glyphicon-plus-sign:before {
+  content: "\e081";
+}
+.glyphicon-minus-sign:before {
+  content: "\e082";
+}
+.glyphicon-remove-sign:before {
+  content: "\e083";
+}
+.glyphicon-ok-sign:before {
+  content: "\e084";
+}
+.glyphicon-question-sign:before {
+  content: "\e085";
+}
+.glyphicon-info-sign:before {
+  content: "\e086";
+}
+.glyphicon-screenshot:before {
+  content: "\e087";
+}
+.glyphicon-remove-circle:before {
+  content: "\e088";
+}
+.glyphicon-ok-circle:before {
+  content: "\e089";
+}
+.glyphicon-ban-circle:before {
+  content: "\e090";
+}
+.glyphicon-arrow-left:before {
+  content: "\e091";
+}
+.glyphicon-arrow-right:before {
+  content: "\e092";
+}
+.glyphicon-arrow-up:before {
+  content: "\e093";
+}
+.glyphicon-arrow-down:before {
+  content: "\e094";
+}
+.glyphicon-share-alt:before {
+  content: "\e095";
+}
+.glyphicon-resize-full:before {
+  content: "\e096";
+}
+.glyphicon-resize-small:before {
+  content: "\e097";
+}
+.glyphicon-exclamation-sign:before {
+  content: "\e101";
+}
+.glyphicon-gift:before {
+  content: "\e102";
+}
+.glyphicon-leaf:before {
+  content: "\e103";
+}
+.glyphicon-fire:before {
+  content: "\e104";
+}
+.glyphicon-eye-open:before {
+  content: "\e105";
+}
+.glyphicon-eye-close:before {
+  content: "\e106";
+}
+.glyphicon-warning-sign:before {
+  content: "\e107";
+}
+.glyphicon-plane:before {
+  content: "\e108";
+}
+.glyphicon-calendar:before {
+  content: "\e109";
+}
+.glyphicon-random:before {
+  content: "\e110";
+}
+.glyphicon-comment:before {
+  content: "\e111";
+}
+.glyphicon-magnet:before {
+  content: "\e112";
+}
+.glyphicon-chevron-up:before {
+  content: "\e113";
+}
+.glyphicon-chevron-down:before {
+  content: "\e114";
+}
+.glyphicon-retweet:before {
+  content: "\e115";
+}
+.glyphicon-shopping-cart:before {
+  content: "\e116";
+}
+.glyphicon-folder-close:before {
+  content: "\e117";
+}
+.glyphicon-folder-open:before {
+  content: "\e118";
+}
+.glyphicon-resize-vertical:before {
+  content: "\e119";
+}
+.glyphicon-resize-horizontal:before {
+  content: "\e120";
+}
+.glyphicon-hdd:before {
+  content: "\e121";
+}
+.glyphicon-bullhorn:before {
+  content: "\e122";
+}
+.glyphicon-bell:before {
+  content: "\e123";
+}
+.glyphicon-certificate:before {
+  content: "\e124";
+}
+.glyphicon-thumbs-up:before {
+  content: "\e125";
+}
+.glyphicon-thumbs-down:before {
+  content: "\e126";
+}
+.glyphicon-hand-right:before {
+  content: "\e127";
+}
+.glyphicon-hand-left:before {
+  content: "\e128";
+}
+.glyphicon-hand-up:before {
+  content: "\e129";
+}
+.glyphicon-hand-down:before {
+  content: "\e130";
+}
+.glyphicon-circle-arrow-right:before {
+  content: "\e131";
+}
+.glyphicon-circle-arrow-left:before {
+  content: "\e132";
+}
+.glyphicon-circle-arrow-up:before {
+  content: "\e133";
+}
+.glyphicon-circle-arrow-down:before {
+  content: "\e134";
+}
+.glyphicon-globe:before {
+  content: "\e135";
+}
+.glyphicon-wrench:before {
+  content: "\e136";
+}
+.glyphicon-tasks:before {
+  content: "\e137";
+}
+.glyphicon-filter:before {
+  content: "\e138";
+}
+.glyphicon-briefcase:before {
+  content: "\e139";
+}
+.glyphicon-fullscreen:before {
+  content: "\e140";
+}
+.glyphicon-dashboard:before {
+  content: "\e141";
+}
+.glyphicon-paperclip:before {
+  content: "\e142";
+}
+.glyphicon-heart-empty:before {
+  content: "\e143";
+}
+.glyphicon-link:before {
+  content: "\e144";
+}
+.glyphicon-phone:before {
+  content: "\e145";
+}
+.glyphicon-pushpin:before {
+  content: "\e146";
+}
+.glyphicon-usd:before {
+  content: "\e148";
+}
+.glyphicon-gbp:before {
+  content: "\e149";
+}
+.glyphicon-sort:before {
+  content: "\e150";
+}
+.glyphicon-sort-by-alphabet:before {
+  content: "\e151";
+}
+.glyphicon-sort-by-alphabet-alt:before {
+  content: "\e152";
+}
+.glyphicon-sort-by-order:before {
+  content: "\e153";
+}
+.glyphicon-sort-by-order-alt:before {
+  content: "\e154";
+}
+.glyphicon-sort-by-attributes:before {
+  content: "\e155";
+}
+.glyphicon-sort-by-attributes-alt:before {
+  content: "\e156";
+}
+.glyphicon-unchecked:before {
+  content: "\e157";
+}
+.glyphicon-expand:before {
+  content: "\e158";
+}
+.glyphicon-collapse-down:before {
+  content: "\e159";
+}
+.glyphicon-collapse-up:before {
+  content: "\e160";
+}
+.glyphicon-log-in:before {
+  content: "\e161";
+}
+.glyphicon-flash:before {
+  content: "\e162";
+}
+.glyphicon-log-out:before {
+  content: "\e163";
+}
+.glyphicon-new-window:before {
+  content: "\e164";
+}
+.glyphicon-record:before {
+  content: "\e165";
+}
+.glyphicon-save:before {
+  content: "\e166";
+}
+.glyphicon-open:before {
+  content: "\e167";
+}
+.glyphicon-saved:before {
+  content: "\e168";
+}
+.glyphicon-import:before {
+  content: "\e169";
+}
+.glyphicon-export:before {
+  content: "\e170";
+}
+.glyphicon-send:before {
+  content: "\e171";
+}
+.glyphicon-floppy-disk:before {
+  content: "\e172";
+}
+.glyphicon-floppy-saved:before {
+  content: "\e173";
+}
+.glyphicon-floppy-remove:before {
+  content: "\e174";
+}
+.glyphicon-floppy-save:before {
+  content: "\e175";
+}
+.glyphicon-floppy-open:before {
+  content: "\e176";
+}
+.glyphicon-credit-card:before {
+  content: "\e177";
+}
+.glyphicon-transfer:before {
+  content: "\e178";
+}
+.glyphicon-cutlery:before {
+  content: "\e179";
+}
+.glyphicon-header:before {
+  content: "\e180";
+}
+.glyphicon-compressed:before {
+  content: "\e181";
+}
+.glyphicon-earphone:before {
+  content: "\e182";
+}
+.glyphicon-phone-alt:before {
+  content: "\e183";
+}
+.glyphicon-tower:before {
+  content: "\e184";
+}
+.glyphicon-stats:before {
+  content: "\e185";
+}
+.glyphicon-sd-video:before {
+  content: "\e186";
+}
+.glyphicon-hd-video:before {
+  content: "\e187";
+}
+.glyphicon-subtitles:before {
+  content: "\e188";
+}
+.glyphicon-sound-stereo:before {
+  content: "\e189";
+}
+.glyphicon-sound-dolby:before {
+  content: "\e190";
+}
+.glyphicon-sound-5-1:before {
+  content: "\e191";
+}
+.glyphicon-sound-6-1:before {
+  content: "\e192";
+}
+.glyphicon-sound-7-1:before {
+  content: "\e193";
+}
+.glyphicon-copyright-mark:before {
+  content: "\e194";
+}
+.glyphicon-registration-mark:before {
+  content: "\e195";
+}
+.glyphicon-cloud-download:before {
+  content: "\e197";
+}
+.glyphicon-cloud-upload:before {
+  content: "\e198";
+}
+.glyphicon-tree-conifer:before {
+  content: "\e199";
+}
+.glyphicon-tree-deciduous:before {
+  content: "\e200";
+}
+.glyphicon-cd:before {
+  content: "\e201";
+}
+.glyphicon-save-file:before {
+  content: "\e202";
+}
+.glyphicon-open-file:before {
+  content: "\e203";
+}
+.glyphicon-level-up:before {
+  content: "\e204";
+}
+.glyphicon-copy:before {
+  content: "\e205";
+}
+.glyphicon-paste:before {
+  content: "\e206";
+}
+.glyphicon-alert:before {
+  content: "\e209";
+}
+.glyphicon-equalizer:before {
+  content: "\e210";
+}
+.glyphicon-king:before {
+  content: "\e211";
+}
+.glyphicon-queen:before {
+  content: "\e212";
+}
+.glyphicon-pawn:before {
+  content: "\e213";
+}
+.glyphicon-bishop:before {
+  content: "\e214";
+}
+.glyphicon-knight:before {
+  content: "\e215";
+}
+.glyphicon-baby-formula:before {
+  content: "\e216";
+}
+.glyphicon-tent:before {
+  content: "\26fa";
+}
+.glyphicon-blackboard:before {
+  content: "\e218";
+}
+.glyphicon-bed:before {
+  content: "\e219";
+}
+.glyphicon-apple:before {
+  content: "\f8ff";
+}
+.glyphicon-erase:before {
+  content: "\e221";
+}
+.glyphicon-hourglass:before {
+  content: "\231b";
+}
+.glyphicon-lamp:before {
+  content: "\e223";
+}
+.glyphicon-duplicate:before {
+  content: "\e224";
+}
+.glyphicon-piggy-bank:before {
+  content: "\e225";
+}
+.glyphicon-scissors:before {
+  content: "\e226";
+}
+.glyphicon-bitcoin:before {
+  content: "\e227";
+}
+.glyphicon-btc:before {
+  content: "\e227";
+}
+.glyphicon-xbt:before {
+  content: "\e227";
+}
+.glyphicon-yen:before {
+  content: "\00a5";
+}
+.glyphicon-jpy:before {
+  content: "\00a5";
+}
+.glyphicon-ruble:before {
+  content: "\20bd";
+}
+.glyphicon-rub:before {
+  content: "\20bd";
+}
+.glyphicon-scale:before {
+  content: "\e230";
+}
+.glyphicon-ice-lolly:before {
+  content: "\e231";
+}
+.glyphicon-ice-lolly-tasted:before {
+  content: "\e232";
+}
+.glyphicon-education:before {
+  content: "\e233";
+}
+.glyphicon-option-horizontal:before {
+  content: "\e234";
+}
+.glyphicon-option-vertical:before {
+  content: "\e235";
+}
+.glyphicon-menu-hamburger:before {
+  content: "\e236";
+}
+.glyphicon-modal-window:before {
+  content: "\e237";
+}
+.glyphicon-oil:before {
+  content: "\e238";
+}
+.glyphicon-grain:before {
+  content: "\e239";
+}
+.glyphicon-sunglasses:before {
+  content: "\e240";
+}
+.glyphicon-text-size:before {
+  content: "\e241";
+}
+.glyphicon-text-color:before {
+  content: "\e242";
+}
+.glyphicon-text-background:before {
+  content: "\e243";
+}
+.glyphicon-object-align-top:before {
+  content: "\e244";
+}
+.glyphicon-object-align-bottom:before {
+  content: "\e245";
+}
+.glyphicon-object-align-horizontal:before {
+  content: "\e246";
+}
+.glyphicon-object-align-left:before {
+  content: "\e247";
+}
+.glyphicon-object-align-vertical:before {
+  content: "\e248";
+}
+.glyphicon-object-align-right:before {
+  content: "\e249";
+}
+.glyphicon-triangle-right:before {
+  content: "\e250";
+}
+.glyphicon-triangle-left:before {
+  content: "\e251";
+}
+.glyphicon-triangle-bottom:before {
+  content: "\e252";
+}
+.glyphicon-triangle-top:before {
+  content: "\e253";
+}
+.glyphicon-console:before {
+  content: "\e254";
+}
+.glyphicon-superscript:before {
+  content: "\e255";
+}
+.glyphicon-subscript:before {
+  content: "\e256";
+}
+.glyphicon-menu-left:before {
+  content: "\e257";
+}
+.glyphicon-menu-right:before {
+  content: "\e258";
+}
+.glyphicon-menu-down:before {
+  content: "\e259";
+}
+.glyphicon-menu-up:before {
+  content: "\e260";
+}
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+*:before,
+*:after {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html {
+  font-size: 10px;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #000;
+  background-color: #fff;
+}
+input,
+button,
+select,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+a {
+  color: #337ab7;
+  text-decoration: none;
+}
+a:hover,
+a:focus {
+  color: #23527c;
+  text-decoration: underline;
+}
+a:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+figure {
+  margin: 0;
+}
+img {
+  vertical-align: middle;
+}
+.img-responsive,
+.thumbnail > img,
+.thumbnail a > img,
+.carousel-inner > .item > img,
+.carousel-inner > .item > a > img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+.img-rounded {
+  border-radius: 3px;
+}
+.img-thumbnail {
+  padding: 4px;
+  line-height: 1.42857143;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  -webkit-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+}
+.img-circle {
+  border-radius: 50%;
+}
+hr {
+  margin-top: 18px;
+  margin-bottom: 18px;
+  border: 0;
+  border-top: 1px solid #eeeeee;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+[role="button"] {
+  cursor: pointer;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1.1;
+  color: inherit;
+}
+h1 small,
+h2 small,
+h3 small,
+h4 small,
+h5 small,
+h6 small,
+.h1 small,
+.h2 small,
+.h3 small,
+.h4 small,
+.h5 small,
+.h6 small,
+h1 .small,
+h2 .small,
+h3 .small,
+h4 .small,
+h5 .small,
+h6 .small,
+.h1 .small,
+.h2 .small,
+.h3 .small,
+.h4 .small,
+.h5 .small,
+.h6 .small {
+  font-weight: normal;
+  line-height: 1;
+  color: #777777;
+}
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3 {
+  margin-top: 18px;
+  margin-bottom: 9px;
+}
+h1 small,
+.h1 small,
+h2 small,
+.h2 small,
+h3 small,
+.h3 small,
+h1 .small,
+.h1 .small,
+h2 .small,
+.h2 .small,
+h3 .small,
+.h3 .small {
+  font-size: 65%;
+}
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
+  margin-top: 9px;
+  margin-bottom: 9px;
+}
+h4 small,
+.h4 small,
+h5 small,
+.h5 small,
+h6 small,
+.h6 small,
+h4 .small,
+.h4 .small,
+h5 .small,
+.h5 .small,
+h6 .small,
+.h6 .small {
+  font-size: 75%;
+}
+h1,
+.h1 {
+  font-size: 33px;
+}
+h2,
+.h2 {
+  font-size: 27px;
+}
+h3,
+.h3 {
+  font-size: 23px;
+}
+h4,
+.h4 {
+  font-size: 17px;
+}
+h5,
+.h5 {
+  font-size: 13px;
+}
+h6,
+.h6 {
+  font-size: 12px;
+}
+p {
+  margin: 0 0 9px;
+}
+.lead {
+  margin-bottom: 18px;
+  font-size: 14px;
+  font-weight: 300;
+  line-height: 1.4;
+}
+@media (min-width: 768px) {
+  .lead {
+    font-size: 19.5px;
+  }
+}
+small,
+.small {
+  font-size: 92%;
+}
+mark,
+.mark {
+  background-color: #fcf8e3;
+  padding: .2em;
+}
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
+.text-center {
+  text-align: center;
+}
+.text-justify {
+  text-align: justify;
+}
+.text-nowrap {
+  white-space: nowrap;
+}
+.text-lowercase {
+  text-transform: lowercase;
+}
+.text-uppercase {
+  text-transform: uppercase;
+}
+.text-capitalize {
+  text-transform: capitalize;
+}
+.text-muted {
+  color: #777777;
+}
+.text-primary {
+  color: #337ab7;
+}
+a.text-primary:hover,
+a.text-primary:focus {
+  color: #286090;
+}
+.text-success {
+  color: #3c763d;
+}
+a.text-success:hover,
+a.text-success:focus {
+  color: #2b542c;
+}
+.text-info {
+  color: #31708f;
+}
+a.text-info:hover,
+a.text-info:focus {
+  color: #245269;
+}
+.text-warning {
+  color: #8a6d3b;
+}
+a.text-warning:hover,
+a.text-warning:focus {
+  color: #66512c;
+}
+.text-danger {
+  color: #a94442;
+}
+a.text-danger:hover,
+a.text-danger:focus {
+  color: #843534;
+}
+.bg-primary {
+  color: #fff;
+  background-color: #337ab7;
+}
+a.bg-primary:hover,
+a.bg-primary:focus {
+  background-color: #286090;
+}
+.bg-success {
+  background-color: #dff0d8;
+}
+a.bg-success:hover,
+a.bg-success:focus {
+  background-color: #c1e2b3;
+}
+.bg-info {
+  background-color: #d9edf7;
+}
+a.bg-info:hover,
+a.bg-info:focus {
+  background-color: #afd9ee;
+}
+.bg-warning {
+  background-color: #fcf8e3;
+}
+a.bg-warning:hover,
+a.bg-warning:focus {
+  background-color: #f7ecb5;
+}
+.bg-danger {
+  background-color: #f2dede;
+}
+a.bg-danger:hover,
+a.bg-danger:focus {
+  background-color: #e4b9b9;
+}
+.page-header {
+  padding-bottom: 8px;
+  margin: 36px 0 18px;
+  border-bottom: 1px solid #eeeeee;
+}
+ul,
+ol {
+  margin-top: 0;
+  margin-bottom: 9px;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-bottom: 0;
+}
+.list-unstyled {
+  padding-left: 0;
+  list-style: none;
+}
+.list-inline {
+  padding-left: 0;
+  list-style: none;
+  margin-left: -5px;
+}
+.list-inline > li {
+  display: inline-block;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+dl {
+  margin-top: 0;
+  margin-bottom: 18px;
+}
+dt,
+dd {
+  line-height: 1.42857143;
+}
+dt {
+  font-weight: bold;
+}
+dd {
+  margin-left: 0;
+}
+@media (min-width: 541px) {
+  .dl-horizontal dt {
+    float: left;
+    width: 160px;
+    clear: left;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .dl-horizontal dd {
+    margin-left: 180px;
+  }
+}
+abbr[title],
+abbr[data-original-title] {
+  cursor: help;
+  border-bottom: 1px dotted #777777;
+}
+.initialism {
+  font-size: 90%;
+  text-transform: uppercase;
+}
+blockquote {
+  padding: 9px 18px;
+  margin: 0 0 18px;
+  font-size: inherit;
+  border-left: 5px solid #eeeeee;
+}
+blockquote p:last-child,
+blockquote ul:last-child,
+blockquote ol:last-child {
+  margin-bottom: 0;
+}
+blockquote footer,
+blockquote small,
+blockquote .small {
+  display: block;
+  font-size: 80%;
+  line-height: 1.42857143;
+  color: #777777;
+}
+blockquote footer:before,
+blockquote small:before,
+blockquote .small:before {
+  content: '\2014 \00A0';
+}
+.blockquote-reverse,
+blockquote.pull-right {
+  padding-right: 15px;
+  padding-left: 0;
+  border-right: 5px solid #eeeeee;
+  border-left: 0;
+  text-align: right;
+}
+.blockquote-reverse footer:before,
+blockquote.pull-right footer:before,
+.blockquote-reverse small:before,
+blockquote.pull-right small:before,
+.blockquote-reverse .small:before,
+blockquote.pull-right .small:before {
+  content: '';
+}
+.blockquote-reverse footer:after,
+blockquote.pull-right footer:after,
+.blockquote-reverse small:after,
+blockquote.pull-right small:after,
+.blockquote-reverse .small:after,
+blockquote.pull-right .small:after {
+  content: '\00A0 \2014';
+}
+address {
+  margin-bottom: 18px;
+  font-style: normal;
+  line-height: 1.42857143;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace;
+}
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 2px;
+}
+kbd {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #888;
+  background-color: transparent;
+  border-radius: 1px;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: bold;
+  box-shadow: none;
+}
+pre {
+  display: block;
+  padding: 8.5px;
+  margin: 0 0 9px;
+  font-size: 12px;
+  line-height: 1.42857143;
+  word-break: break-all;
+  word-wrap: break-word;
+  color: #333333;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+}
+pre code {
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border-radius: 0;
+}
+.pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll;
+}
+.container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 0px;
+  padding-right: 0px;
+}
+@media (min-width: 768px) {
+  .container {
+    width: 768px;
+  }
+}
+@media (min-width: 992px) {
+  .container {
+    width: 940px;
+  }
+}
+@media (min-width: 1200px) {
+  .container {
+    width: 1140px;
+  }
+}
+.container-fluid {
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 0px;
+  padding-right: 0px;
+}
+.row {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
+  position: relative;
+  min-height: 1px;
+  padding-left: 0px;
+  padding-right: 0px;
+}
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
+  float: left;
+}
+.col-xs-12 {
+  width: 100%;
+}
+.col-xs-11 {
+  width: 91.66666667%;
+}
+.col-xs-10 {
+  width: 83.33333333%;
+}
+.col-xs-9 {
+  width: 75%;
+}
+.col-xs-8 {
+  width: 66.66666667%;
+}
+.col-xs-7 {
+  width: 58.33333333%;
+}
+.col-xs-6 {
+  width: 50%;
+}
+.col-xs-5 {
+  width: 41.66666667%;
+}
+.col-xs-4 {
+  width: 33.33333333%;
+}
+.col-xs-3 {
+  width: 25%;
+}
+.col-xs-2 {
+  width: 16.66666667%;
+}
+.col-xs-1 {
+  width: 8.33333333%;
+}
+.col-xs-pull-12 {
+  right: 100%;
+}
+.col-xs-pull-11 {
+  right: 91.66666667%;
+}
+.col-xs-pull-10 {
+  right: 83.33333333%;
+}
+.col-xs-pull-9 {
+  right: 75%;
+}
+.col-xs-pull-8 {
+  right: 66.66666667%;
+}
+.col-xs-pull-7 {
+  right: 58.33333333%;
+}
+.col-xs-pull-6 {
+  right: 50%;
+}
+.col-xs-pull-5 {
+  right: 41.66666667%;
+}
+.col-xs-pull-4 {
+  right: 33.33333333%;
+}
+.col-xs-pull-3 {
+  right: 25%;
+}
+.col-xs-pull-2 {
+  right: 16.66666667%;
+}
+.col-xs-pull-1 {
+  right: 8.33333333%;
+}
+.col-xs-pull-0 {
+  right: auto;
+}
+.col-xs-push-12 {
+  left: 100%;
+}
+.col-xs-push-11 {
+  left: 91.66666667%;
+}
+.col-xs-push-10 {
+  left: 83.33333333%;
+}
+.col-xs-push-9 {
+  left: 75%;
+}
+.col-xs-push-8 {
+  left: 66.66666667%;
+}
+.col-xs-push-7 {
+  left: 58.33333333%;
+}
+.col-xs-push-6 {
+  left: 50%;
+}
+.col-xs-push-5 {
+  left: 41.66666667%;
+}
+.col-xs-push-4 {
+  left: 33.33333333%;
+}
+.col-xs-push-3 {
+  left: 25%;
+}
+.col-xs-push-2 {
+  left: 16.66666667%;
+}
+.col-xs-push-1 {
+  left: 8.33333333%;
+}
+.col-xs-push-0 {
+  left: auto;
+}
+.col-xs-offset-12 {
+  margin-left: 100%;
+}
+.col-xs-offset-11 {
+  margin-left: 91.66666667%;
+}
+.col-xs-offset-10 {
+  margin-left: 83.33333333%;
+}
+.col-xs-offset-9 {
+  margin-left: 75%;
+}
+.col-xs-offset-8 {
+  margin-left: 66.66666667%;
+}
+.col-xs-offset-7 {
+  margin-left: 58.33333333%;
+}
+.col-xs-offset-6 {
+  margin-left: 50%;
+}
+.col-xs-offset-5 {
+  margin-left: 41.66666667%;
+}
+.col-xs-offset-4 {
+  margin-left: 33.33333333%;
+}
+.col-xs-offset-3 {
+  margin-left: 25%;
+}
+.col-xs-offset-2 {
+  margin-left: 16.66666667%;
+}
+.col-xs-offset-1 {
+  margin-left: 8.33333333%;
+}
+.col-xs-offset-0 {
+  margin-left: 0%;
+}
+@media (min-width: 768px) {
+  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
+    float: left;
+  }
+  .col-sm-12 {
+    width: 100%;
+  }
+  .col-sm-11 {
+    width: 91.66666667%;
+  }
+  .col-sm-10 {
+    width: 83.33333333%;
+  }
+  .col-sm-9 {
+    width: 75%;
+  }
+  .col-sm-8 {
+    width: 66.66666667%;
+  }
+  .col-sm-7 {
+    width: 58.33333333%;
+  }
+  .col-sm-6 {
+    width: 50%;
+  }
+  .col-sm-5 {
+    width: 41.66666667%;
+  }
+  .col-sm-4 {
+    width: 33.33333333%;
+  }
+  .col-sm-3 {
+    width: 25%;
+  }
+  .col-sm-2 {
+    width: 16.66666667%;
+  }
+  .col-sm-1 {
+    width: 8.33333333%;
+  }
+  .col-sm-pull-12 {
+    right: 100%;
+  }
+  .col-sm-pull-11 {
+    right: 91.66666667%;
+  }
+  .col-sm-pull-10 {
+    right: 83.33333333%;
+  }
+  .col-sm-pull-9 {
+    right: 75%;
+  }
+  .col-sm-pull-8 {
+    right: 66.66666667%;
+  }
+  .col-sm-pull-7 {
+    right: 58.33333333%;
+  }
+  .col-sm-pull-6 {
+    right: 50%;
+  }
+  .col-sm-pull-5 {
+    right: 41.66666667%;
+  }
+  .col-sm-pull-4 {
+    right: 33.33333333%;
+  }
+  .col-sm-pull-3 {
+    right: 25%;
+  }
+  .col-sm-pull-2 {
+    right: 16.66666667%;
+  }
+  .col-sm-pull-1 {
+    right: 8.33333333%;
+  }
+  .col-sm-pull-0 {
+    right: auto;
+  }
+  .col-sm-push-12 {
+    left: 100%;
+  }
+  .col-sm-push-11 {
+    left: 91.66666667%;
+  }
+  .col-sm-push-10 {
+    left: 83.33333333%;
+  }
+  .col-sm-push-9 {
+    left: 75%;
+  }
+  .col-sm-push-8 {
+    left: 66.66666667%;
+  }
+  .col-sm-push-7 {
+    left: 58.33333333%;
+  }
+  .col-sm-push-6 {
+    left: 50%;
+  }
+  .col-sm-push-5 {
+    left: 41.66666667%;
+  }
+  .col-sm-push-4 {
+    left: 33.33333333%;
+  }
+  .col-sm-push-3 {
+    left: 25%;
+  }
+  .col-sm-push-2 {
+    left: 16.66666667%;
+  }
+  .col-sm-push-1 {
+    left: 8.33333333%;
+  }
+  .col-sm-push-0 {
+    left: auto;
+  }
+  .col-sm-offset-12 {
+    margin-left: 100%;
+  }
+  .col-sm-offset-11 {
+    margin-left: 91.66666667%;
+  }
+  .col-sm-offset-10 {
+    margin-left: 83.33333333%;
+  }
+  .col-sm-offset-9 {
+    margin-left: 75%;
+  }
+  .col-sm-offset-8 {
+    margin-left: 66.66666667%;
+  }
+  .col-sm-offset-7 {
+    margin-left: 58.33333333%;
+  }
+  .col-sm-offset-6 {
+    margin-left: 50%;
+  }
+  .col-sm-offset-5 {
+    margin-left: 41.66666667%;
+  }
+  .col-sm-offset-4 {
+    margin-left: 33.33333333%;
+  }
+  .col-sm-offset-3 {
+    margin-left: 25%;
+  }
+  .col-sm-offset-2 {
+    margin-left: 16.66666667%;
+  }
+  .col-sm-offset-1 {
+    margin-left: 8.33333333%;
+  }
+  .col-sm-offset-0 {
+    margin-left: 0%;
+  }
+}
+@media (min-width: 992px) {
+  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+    float: left;
+  }
+  .col-md-12 {
+    width: 100%;
+  }
+  .col-md-11 {
+    width: 91.66666667%;
+  }
+  .col-md-10 {
+    width: 83.33333333%;
+  }
+  .col-md-9 {
+    width: 75%;
+  }
+  .col-md-8 {
+    width: 66.66666667%;
+  }
+  .col-md-7 {
+    width: 58.33333333%;
+  }
+  .col-md-6 {
+    width: 50%;
+  }
+  .col-md-5 {
+    width: 41.66666667%;
+  }
+  .col-md-4 {
+    width: 33.33333333%;
+  }
+  .col-md-3 {
+    width: 25%;
+  }
+  .col-md-2 {
+    width: 16.66666667%;
+  }
+  .col-md-1 {
+    width: 8.33333333%;
+  }
+  .col-md-pull-12 {
+    right: 100%;
+  }
+  .col-md-pull-11 {
+    right: 91.66666667%;
+  }
+  .col-md-pull-10 {
+    right: 83.33333333%;
+  }
+  .col-md-pull-9 {
+    right: 75%;
+  }
+  .col-md-pull-8 {
+    right: 66.66666667%;
+  }
+  .col-md-pull-7 {
+    right: 58.33333333%;
+  }
+  .col-md-pull-6 {
+    right: 50%;
+  }
+  .col-md-pull-5 {
+    right: 41.66666667%;
+  }
+  .col-md-pull-4 {
+    right: 33.33333333%;
+  }
+  .col-md-pull-3 {
+    right: 25%;
+  }
+  .col-md-pull-2 {
+    right: 16.66666667%;
+  }
+  .col-md-pull-1 {
+    right: 8.33333333%;
+  }
+  .col-md-pull-0 {
+    right: auto;
+  }
+  .col-md-push-12 {
+    left: 100%;
+  }
+  .col-md-push-11 {
+    left: 91.66666667%;
+  }
+  .col-md-push-10 {
+    left: 83.33333333%;
+  }
+  .col-md-push-9 {
+    left: 75%;
+  }
+  .col-md-push-8 {
+    left: 66.66666667%;
+  }
+  .col-md-push-7 {
+    left: 58.33333333%;
+  }
+  .col-md-push-6 {
+    left: 50%;
+  }
+  .col-md-push-5 {
+    left: 41.66666667%;
+  }
+  .col-md-push-4 {
+    left: 33.33333333%;
+  }
+  .col-md-push-3 {
+    left: 25%;
+  }
+  .col-md-push-2 {
+    left: 16.66666667%;
+  }
+  .col-md-push-1 {
+    left: 8.33333333%;
+  }
+  .col-md-push-0 {
+    left: auto;
+  }
+  .col-md-offset-12 {
+    margin-left: 100%;
+  }
+  .col-md-offset-11 {
+    margin-left: 91.66666667%;
+  }
+  .col-md-offset-10 {
+    margin-left: 83.33333333%;
+  }
+  .col-md-offset-9 {
+    margin-left: 75%;
+  }
+  .col-md-offset-8 {
+    margin-left: 66.66666667%;
+  }
+  .col-md-offset-7 {
+    margin-left: 58.33333333%;
+  }
+  .col-md-offset-6 {
+    margin-left: 50%;
+  }
+  .col-md-offset-5 {
+    margin-left: 41.66666667%;
+  }
+  .col-md-offset-4 {
+    margin-left: 33.33333333%;
+  }
+  .col-md-offset-3 {
+    margin-left: 25%;
+  }
+  .col-md-offset-2 {
+    margin-left: 16.66666667%;
+  }
+  .col-md-offset-1 {
+    margin-left: 8.33333333%;
+  }
+  .col-md-offset-0 {
+    margin-left: 0%;
+  }
+}
+@media (min-width: 1200px) {
+  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
+    float: left;
+  }
+  .col-lg-12 {
+    width: 100%;
+  }
+  .col-lg-11 {
+    width: 91.66666667%;
+  }
+  .col-lg-10 {
+    width: 83.33333333%;
+  }
+  .col-lg-9 {
+    width: 75%;
+  }
+  .col-lg-8 {
+    width: 66.66666667%;
+  }
+  .col-lg-7 {
+    width: 58.33333333%;
+  }
+  .col-lg-6 {
+    width: 50%;
+  }
+  .col-lg-5 {
+    width: 41.66666667%;
+  }
+  .col-lg-4 {
+    width: 33.33333333%;
+  }
+  .col-lg-3 {
+    width: 25%;
+  }
+  .col-lg-2 {
+    width: 16.66666667%;
+  }
+  .col-lg-1 {
+    width: 8.33333333%;
+  }
+  .col-lg-pull-12 {
+    right: 100%;
+  }
+  .col-lg-pull-11 {
+    right: 91.66666667%;
+  }
+  .col-lg-pull-10 {
+    right: 83.33333333%;
+  }
+  .col-lg-pull-9 {
+    right: 75%;
+  }
+  .col-lg-pull-8 {
+    right: 66.66666667%;
+  }
+  .col-lg-pull-7 {
+    right: 58.33333333%;
+  }
+  .col-lg-pull-6 {
+    right: 50%;
+  }
+  .col-lg-pull-5 {
+    right: 41.66666667%;
+  }
+  .col-lg-pull-4 {
+    right: 33.33333333%;
+  }
+  .col-lg-pull-3 {
+    right: 25%;
+  }
+  .col-lg-pull-2 {
+    right: 16.66666667%;
+  }
+  .col-lg-pull-1 {
+    right: 8.33333333%;
+  }
+  .col-lg-pull-0 {
+    right: auto;
+  }
+  .col-lg-push-12 {
+    left: 100%;
+  }
+  .col-lg-push-11 {
+    left: 91.66666667%;
+  }
+  .col-lg-push-10 {
+    left: 83.33333333%;
+  }
+  .col-lg-push-9 {
+    left: 75%;
+  }
+  .col-lg-push-8 {
+    left: 66.66666667%;
+  }
+  .col-lg-push-7 {
+    left: 58.33333333%;
+  }
+  .col-lg-push-6 {
+    left: 50%;
+  }
+  .col-lg-push-5 {
+    left: 41.66666667%;
+  }
+  .col-lg-push-4 {
+    left: 33.33333333%;
+  }
+  .col-lg-push-3 {
+    left: 25%;
+  }
+  .col-lg-push-2 {
+    left: 16.66666667%;
+  }
+  .col-lg-push-1 {
+    left: 8.33333333%;
+  }
+  .col-lg-push-0 {
+    left: auto;
+  }
+  .col-lg-offset-12 {
+    margin-left: 100%;
+  }
+  .col-lg-offset-11 {
+    margin-left: 91.66666667%;
+  }
+  .col-lg-offset-10 {
+    margin-left: 83.33333333%;
+  }
+  .col-lg-offset-9 {
+    margin-left: 75%;
+  }
+  .col-lg-offset-8 {
+    margin-left: 66.66666667%;
+  }
+  .col-lg-offset-7 {
+    margin-left: 58.33333333%;
+  }
+  .col-lg-offset-6 {
+    margin-left: 50%;
+  }
+  .col-lg-offset-5 {
+    margin-left: 41.66666667%;
+  }
+  .col-lg-offset-4 {
+    margin-left: 33.33333333%;
+  }
+  .col-lg-offset-3 {
+    margin-left: 25%;
+  }
+  .col-lg-offset-2 {
+    margin-left: 16.66666667%;
+  }
+  .col-lg-offset-1 {
+    margin-left: 8.33333333%;
+  }
+  .col-lg-offset-0 {
+    margin-left: 0%;
+  }
+}
+table {
+  background-color: transparent;
+}
+caption {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  color: #777777;
+  text-align: left;
+}
+th {
+  text-align: left;
+}
+.table {
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 18px;
+}
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  padding: 8px;
+  line-height: 1.42857143;
+  vertical-align: top;
+  border-top: 1px solid #ddd;
+}
+.table > thead > tr > th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #ddd;
+}
+.table > caption + thead > tr:first-child > th,
+.table > colgroup + thead > tr:first-child > th,
+.table > thead:first-child > tr:first-child > th,
+.table > caption + thead > tr:first-child > td,
+.table > colgroup + thead > tr:first-child > td,
+.table > thead:first-child > tr:first-child > td {
+  border-top: 0;
+}
+.table > tbody + tbody {
+  border-top: 2px solid #ddd;
+}
+.table .table {
+  background-color: #fff;
+}
+.table-condensed > thead > tr > th,
+.table-condensed > tbody > tr > th,
+.table-condensed > tfoot > tr > th,
+.table-condensed > thead > tr > td,
+.table-condensed > tbody > tr > td,
+.table-condensed > tfoot > tr > td {
+  padding: 5px;
+}
+.table-bordered {
+  border: 1px solid #ddd;
+}
+.table-bordered > thead > tr > th,
+.table-bordered > tbody > tr > th,
+.table-bordered > tfoot > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > td {
+  border: 1px solid #ddd;
+}
+.table-bordered > thead > tr > th,
+.table-bordered > thead > tr > td {
+  border-bottom-width: 2px;
+}
+.table-striped > tbody > tr:nth-of-type(odd) {
+  background-color: #f9f9f9;
+}
+.table-hover > tbody > tr:hover {
+  background-color: #f5f5f5;
+}
+table col[class*="col-"] {
+  position: static;
+  float: none;
+  display: table-column;
+}
+table td[class*="col-"],
+table th[class*="col-"] {
+  position: static;
+  float: none;
+  display: table-cell;
+}
+.table > thead > tr > td.active,
+.table > tbody > tr > td.active,
+.table > tfoot > tr > td.active,
+.table > thead > tr > th.active,
+.table > tbody > tr > th.active,
+.table > tfoot > tr > th.active,
+.table > thead > tr.active > td,
+.table > tbody > tr.active > td,
+.table > tfoot > tr.active > td,
+.table > thead > tr.active > th,
+.table > tbody > tr.active > th,
+.table > tfoot > tr.active > th {
+  background-color: #f5f5f5;
+}
+.table-hover > tbody > tr > td.active:hover,
+.table-hover > tbody > tr > th.active:hover,
+.table-hover > tbody > tr.active:hover > td,
+.table-hover > tbody > tr:hover > .active,
+.table-hover > tbody > tr.active:hover > th {
+  background-color: #e8e8e8;
+}
+.table > thead > tr > td.success,
+.table > tbody > tr > td.success,
+.table > tfoot > tr > td.success,
+.table > thead > tr > th.success,
+.table > tbody > tr > th.success,
+.table > tfoot > tr > th.success,
+.table > thead > tr.success > td,
+.table > tbody > tr.success > td,
+.table > tfoot > tr.success > td,
+.table > thead > tr.success > th,
+.table > tbody > tr.success > th,
+.table > tfoot > tr.success > th {
+  background-color: #dff0d8;
+}
+.table-hover > tbody > tr > td.success:hover,
+.table-hover > tbody > tr > th.success:hover,
+.table-hover > tbody > tr.success:hover > td,
+.table-hover > tbody > tr:hover > .success,
+.table-hover > tbody > tr.success:hover > th {
+  background-color: #d0e9c6;
+}
+.table > thead > tr > td.info,
+.table > tbody > tr > td.info,
+.table > tfoot > tr > td.info,
+.table > thead > tr > th.info,
+.table > tbody > tr > th.info,
+.table > tfoot > tr > th.info,
+.table > thead > tr.info > td,
+.table > tbody > tr.info > td,
+.table > tfoot > tr.info > td,
+.table > thead > tr.info > th,
+.table > tbody > tr.info > th,
+.table > tfoot > tr.info > th {
+  background-color: #d9edf7;
+}
+.table-hover > tbody > tr > td.info:hover,
+.table-hover > tbody > tr > th.info:hover,
+.table-hover > tbody > tr.info:hover > td,
+.table-hover > tbody > tr:hover > .info,
+.table-hover > tbody > tr.info:hover > th {
+  background-color: #c4e3f3;
+}
+.table > thead > tr > td.warning,
+.table > tbody > tr > td.warning,
+.table > tfoot > tr > td.warning,
+.table > thead > tr > th.warning,
+.table > tbody > tr > th.warning,
+.table > tfoot > tr > th.warning,
+.table > thead > tr.warning > td,
+.table > tbody > tr.warning > td,
+.table > tfoot > tr.warning > td,
+.table > thead > tr.warning > th,
+.table > tbody > tr.warning > th,
+.table > tfoot > tr.warning > th {
+  background-color: #fcf8e3;
+}
+.table-hover > tbody > tr > td.warning:hover,
+.table-hover > tbody > tr > th.warning:hover,
+.table-hover > tbody > tr.warning:hover > td,
+.table-hover > tbody > tr:hover > .warning,
+.table-hover > tbody > tr.warning:hover > th {
+  background-color: #faf2cc;
+}
+.table > thead > tr > td.danger,
+.table > tbody > tr > td.danger,
+.table > tfoot > tr > td.danger,
+.table > thead > tr > th.danger,
+.table > tbody > tr > th.danger,
+.table > tfoot > tr > th.danger,
+.table > thead > tr.danger > td,
+.table > tbody > tr.danger > td,
+.table > tfoot > tr.danger > td,
+.table > thead > tr.danger > th,
+.table > tbody > tr.danger > th,
+.table > tfoot > tr.danger > th {
+  background-color: #f2dede;
+}
+.table-hover > tbody > tr > td.danger:hover,
+.table-hover > tbody > tr > th.danger:hover,
+.table-hover > tbody > tr.danger:hover > td,
+.table-hover > tbody > tr:hover > .danger,
+.table-hover > tbody > tr.danger:hover > th {
+  background-color: #ebcccc;
+}
+.table-responsive {
+  overflow-x: auto;
+  min-height: 0.01%;
+}
+@media screen and (max-width: 767px) {
+  .table-responsive {
+    width: 100%;
+    margin-bottom: 13.5px;
+    overflow-y: hidden;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    border: 1px solid #ddd;
+  }
+  .table-responsive > .table {
+    margin-bottom: 0;
+  }
+  .table-responsive > .table > thead > tr > th,
+  .table-responsive > .table > tbody > tr > th,
+  .table-responsive > .table > tfoot > tr > th,
+  .table-responsive > .table > thead > tr > td,
+  .table-responsive > .table > tbody > tr > td,
+  .table-responsive > .table > tfoot > tr > td {
+    white-space: nowrap;
+  }
+  .table-responsive > .table-bordered {
+    border: 0;
+  }
+  .table-responsive > .table-bordered > thead > tr > th:first-child,
+  .table-responsive > .table-bordered > tbody > tr > th:first-child,
+  .table-responsive > .table-bordered > tfoot > tr > th:first-child,
+  .table-responsive > .table-bordered > thead > tr > td:first-child,
+  .table-responsive > .table-bordered > tbody > tr > td:first-child,
+  .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+    border-left: 0;
+  }
+  .table-responsive > .table-bordered > thead > tr > th:last-child,
+  .table-responsive > .table-bordered > tbody > tr > th:last-child,
+  .table-responsive > .table-bordered > tfoot > tr > th:last-child,
+  .table-responsive > .table-bordered > thead > tr > td:last-child,
+  .table-responsive > .table-bordered > tbody > tr > td:last-child,
+  .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+    border-right: 0;
+  }
+  .table-responsive > .table-bordered > tbody > tr:last-child > th,
+  .table-responsive > .table-bordered > tfoot > tr:last-child > th,
+  .table-responsive > .table-bordered > tbody > tr:last-child > td,
+  .table-responsive > .table-bordered > tfoot > tr:last-child > td {
+    border-bottom: 0;
+  }
+}
+fieldset {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  min-width: 0;
+}
+legend {
+  display: block;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 18px;
+  font-size: 19.5px;
+  line-height: inherit;
+  color: #333333;
+  border: 0;
+  border-bottom: 1px solid #e5e5e5;
+}
+label {
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+input[type="search"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+input[type="radio"],
+input[type="checkbox"] {
+  margin: 4px 0 0;
+  margin-top: 1px \9;
+  line-height: normal;
+}
+input[type="file"] {
+  display: block;
+}
+input[type="range"] {
+  display: block;
+  width: 100%;
+}
+select[multiple],
+select[size] {
+  height: auto;
+}
+input[type="file"]:focus,
+input[type="radio"]:focus,
+input[type="checkbox"]:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+output {
+  display: block;
+  padding-top: 7px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #555555;
+}
+.form-control {
+  display: block;
+  width: 100%;
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #555555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+}
+.form-control:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.form-control::-moz-placeholder {
+  color: #999;
+  opacity: 1;
+}
+.form-control:-ms-input-placeholder {
+  color: #999;
+}
+.form-control::-webkit-input-placeholder {
+  color: #999;
+}
+.form-control::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+.form-control[disabled],
+.form-control[readonly],
+fieldset[disabled] .form-control {
+  background-color: #eeeeee;
+  opacity: 1;
+}
+.form-control[disabled],
+fieldset[disabled] .form-control {
+  cursor: not-allowed;
+}
+textarea.form-control {
+  height: auto;
+}
+input[type="search"] {
+  -webkit-appearance: none;
+}
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input[type="date"].form-control,
+  input[type="time"].form-control,
+  input[type="datetime-local"].form-control,
+  input[type="month"].form-control {
+    line-height: 32px;
+  }
+  input[type="date"].input-sm,
+  input[type="time"].input-sm,
+  input[type="datetime-local"].input-sm,
+  input[type="month"].input-sm,
+  .input-group-sm input[type="date"],
+  .input-group-sm input[type="time"],
+  .input-group-sm input[type="datetime-local"],
+  .input-group-sm input[type="month"] {
+    line-height: 30px;
+  }
+  input[type="date"].input-lg,
+  input[type="time"].input-lg,
+  input[type="datetime-local"].input-lg,
+  input[type="month"].input-lg,
+  .input-group-lg input[type="date"],
+  .input-group-lg input[type="time"],
+  .input-group-lg input[type="datetime-local"],
+  .input-group-lg input[type="month"] {
+    line-height: 45px;
+  }
+}
+.form-group {
+  margin-bottom: 15px;
+}
+.radio,
+.checkbox {
+  position: relative;
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.radio label,
+.checkbox label {
+  min-height: 18px;
+  padding-left: 20px;
+  margin-bottom: 0;
+  font-weight: normal;
+  cursor: pointer;
+}
+.radio input[type="radio"],
+.radio-inline input[type="radio"],
+.checkbox input[type="checkbox"],
+.checkbox-inline input[type="checkbox"] {
+  position: absolute;
+  margin-left: -20px;
+  margin-top: 4px \9;
+}
+.radio + .radio,
+.checkbox + .checkbox {
+  margin-top: -5px;
+}
+.radio-inline,
+.checkbox-inline {
+  position: relative;
+  display: inline-block;
+  padding-left: 20px;
+  margin-bottom: 0;
+  vertical-align: middle;
+  font-weight: normal;
+  cursor: pointer;
+}
+.radio-inline + .radio-inline,
+.checkbox-inline + .checkbox-inline {
+  margin-top: 0;
+  margin-left: 10px;
+}
+input[type="radio"][disabled],
+input[type="checkbox"][disabled],
+input[type="radio"].disabled,
+input[type="checkbox"].disabled,
+fieldset[disabled] input[type="radio"],
+fieldset[disabled] input[type="checkbox"] {
+  cursor: not-allowed;
+}
+.radio-inline.disabled,
+.checkbox-inline.disabled,
+fieldset[disabled] .radio-inline,
+fieldset[disabled] .checkbox-inline {
+  cursor: not-allowed;
+}
+.radio.disabled label,
+.checkbox.disabled label,
+fieldset[disabled] .radio label,
+fieldset[disabled] .checkbox label {
+  cursor: not-allowed;
+}
+.form-control-static {
+  padding-top: 7px;
+  padding-bottom: 7px;
+  margin-bottom: 0;
+  min-height: 31px;
+}
+.form-control-static.input-lg,
+.form-control-static.input-sm {
+  padding-left: 0;
+  padding-right: 0;
+}
+.input-sm {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+select.input-sm {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.input-sm,
+select[multiple].input-sm {
+  height: auto;
+}
+.form-group-sm .form-control {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+.form-group-sm select.form-control {
+  height: 30px;
+  line-height: 30px;
+}
+.form-group-sm textarea.form-control,
+.form-group-sm select[multiple].form-control {
+  height: auto;
+}
+.form-group-sm .form-control-static {
+  height: 30px;
+  min-height: 30px;
+  padding: 6px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.input-lg {
+  height: 45px;
+  padding: 10px 16px;
+  font-size: 17px;
+  line-height: 1.3333333;
+  border-radius: 3px;
+}
+select.input-lg {
+  height: 45px;
+  line-height: 45px;
+}
+textarea.input-lg,
+select[multiple].input-lg {
+  height: auto;
+}
+.form-group-lg .form-control {
+  height: 45px;
+  padding: 10px 16px;
+  font-size: 17px;
+  line-height: 1.3333333;
+  border-radius: 3px;
+}
+.form-group-lg select.form-control {
+  height: 45px;
+  line-height: 45px;
+}
+.form-group-lg textarea.form-control,
+.form-group-lg select[multiple].form-control {
+  height: auto;
+}
+.form-group-lg .form-control-static {
+  height: 45px;
+  min-height: 35px;
+  padding: 11px 16px;
+  font-size: 17px;
+  line-height: 1.3333333;
+}
+.has-feedback {
+  position: relative;
+}
+.has-feedback .form-control {
+  padding-right: 40px;
+}
+.form-control-feedback {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  display: block;
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  text-align: center;
+  pointer-events: none;
+}
+.input-lg + .form-control-feedback,
+.input-group-lg + .form-control-feedback,
+.form-group-lg .form-control + .form-control-feedback {
+  width: 45px;
+  height: 45px;
+  line-height: 45px;
+}
+.input-sm + .form-control-feedback,
+.input-group-sm + .form-control-feedback,
+.form-group-sm .form-control + .form-control-feedback {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+}
+.has-success .help-block,
+.has-success .control-label,
+.has-success .radio,
+.has-success .checkbox,
+.has-success .radio-inline,
+.has-success .checkbox-inline,
+.has-success.radio label,
+.has-success.checkbox label,
+.has-success.radio-inline label,
+.has-success.checkbox-inline label {
+  color: #3c763d;
+}
+.has-success .form-control {
+  border-color: #3c763d;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-success .form-control:focus {
+  border-color: #2b542c;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+}
+.has-success .input-group-addon {
+  color: #3c763d;
+  border-color: #3c763d;
+  background-color: #dff0d8;
+}
+.has-success .form-control-feedback {
+  color: #3c763d;
+}
+.has-warning .help-block,
+.has-warning .control-label,
+.has-warning .radio,
+.has-warning .checkbox,
+.has-warning .radio-inline,
+.has-warning .checkbox-inline,
+.has-warning.radio label,
+.has-warning.checkbox label,
+.has-warning.radio-inline label,
+.has-warning.checkbox-inline label {
+  color: #8a6d3b;
+}
+.has-warning .form-control {
+  border-color: #8a6d3b;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-warning .form-control:focus {
+  border-color: #66512c;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+}
+.has-warning .input-group-addon {
+  color: #8a6d3b;
+  border-color: #8a6d3b;
+  background-color: #fcf8e3;
+}
+.has-warning .form-control-feedback {
+  color: #8a6d3b;
+}
+.has-error .help-block,
+.has-error .control-label,
+.has-error .radio,
+.has-error .checkbox,
+.has-error .radio-inline,
+.has-error .checkbox-inline,
+.has-error.radio label,
+.has-error.checkbox label,
+.has-error.radio-inline label,
+.has-error.checkbox-inline label {
+  color: #a94442;
+}
+.has-error .form-control {
+  border-color: #a94442;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-error .form-control:focus {
+  border-color: #843534;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}
+.has-error .input-group-addon {
+  color: #a94442;
+  border-color: #a94442;
+  background-color: #f2dede;
+}
+.has-error .form-control-feedback {
+  color: #a94442;
+}
+.has-feedback label ~ .form-control-feedback {
+  top: 23px;
+}
+.has-feedback label.sr-only ~ .form-control-feedback {
+  top: 0;
+}
+.help-block {
+  display: block;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  color: #404040;
+}
+@media (min-width: 768px) {
+  .form-inline .form-group {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .form-inline .form-control {
+    display: inline-block;
+    width: auto;
+    vertical-align: middle;
+  }
+  .form-inline .form-control-static {
+    display: inline-block;
+  }
+  .form-inline .input-group {
+    display: inline-table;
+    vertical-align: middle;
+  }
+  .form-inline .input-group .input-group-addon,
+  .form-inline .input-group .input-group-btn,
+  .form-inline .input-group .form-control {
+    width: auto;
+  }
+  .form-inline .input-group > .form-control {
+    width: 100%;
+  }
+  .form-inline .control-label {
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .form-inline .radio,
+  .form-inline .checkbox {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .form-inline .radio label,
+  .form-inline .checkbox label {
+    padding-left: 0;
+  }
+  .form-inline .radio input[type="radio"],
+  .form-inline .checkbox input[type="checkbox"] {
+    position: relative;
+    margin-left: 0;
+  }
+  .form-inline .has-feedback .form-control-feedback {
+    top: 0;
+  }
+}
+.form-horizontal .radio,
+.form-horizontal .checkbox,
+.form-horizontal .radio-inline,
+.form-horizontal .checkbox-inline {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 7px;
+}
+.form-horizontal .radio,
+.form-horizontal .checkbox {
+  min-height: 25px;
+}
+.form-horizontal .form-group {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+@media (min-width: 768px) {
+  .form-horizontal .control-label {
+    text-align: right;
+    margin-bottom: 0;
+    padding-top: 7px;
+  }
+}
+.form-horizontal .has-feedback .form-control-feedback {
+  right: 0px;
+}
+@media (min-width: 768px) {
+  .form-horizontal .form-group-lg .control-label {
+    padding-top: 11px;
+    font-size: 17px;
+  }
+}
+@media (min-width: 768px) {
+  .form-horizontal .form-group-sm .control-label {
+    padding-top: 6px;
+    font-size: 12px;
+  }
+}
+.btn {
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: normal;
+  text-align: center;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  border-radius: 2px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.btn:focus,
+.btn:active:focus,
+.btn.active:focus,
+.btn.focus,
+.btn:active.focus,
+.btn.active.focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+.btn:hover,
+.btn:focus,
+.btn.focus {
+  color: #333;
+  text-decoration: none;
+}
+.btn:active,
+.btn.active {
+  outline: 0;
+  background-image: none;
+  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+.btn.disabled,
+.btn[disabled],
+fieldset[disabled] .btn {
+  cursor: not-allowed;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+a.btn.disabled,
+fieldset[disabled] a.btn {
+  pointer-events: none;
+}
+.btn-default {
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+.btn-default:focus,
+.btn-default.focus {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #8c8c8c;
+}
+.btn-default:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+.btn-default:active,
+.btn-default.active,
+.open > .dropdown-toggle.btn-default {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+.btn-default:active:hover,
+.btn-default.active:hover,
+.open > .dropdown-toggle.btn-default:hover,
+.btn-default:active:focus,
+.btn-default.active:focus,
+.open > .dropdown-toggle.btn-default:focus,
+.btn-default:active.focus,
+.btn-default.active.focus,
+.open > .dropdown-toggle.btn-default.focus {
+  color: #333;
+  background-color: #d4d4d4;
+  border-color: #8c8c8c;
+}
+.btn-default:active,
+.btn-default.active,
+.open > .dropdown-toggle.btn-default {
+  background-image: none;
+}
+.btn-default.disabled:hover,
+.btn-default[disabled]:hover,
+fieldset[disabled] .btn-default:hover,
+.btn-default.disabled:focus,
+.btn-default[disabled]:focus,
+fieldset[disabled] .btn-default:focus,
+.btn-default.disabled.focus,
+.btn-default[disabled].focus,
+fieldset[disabled] .btn-default.focus {
+  background-color: #fff;
+  border-color: #ccc;
+}
+.btn-default .badge {
+  color: #fff;
+  background-color: #333;
+}
+.btn-primary {
+  color: #fff;
+  background-color: #337ab7;
+  border-color: #2e6da4;
+}
+.btn-primary:focus,
+.btn-primary.focus {
+  color: #fff;
+  background-color: #286090;
+  border-color: #122b40;
+}
+.btn-primary:hover {
+  color: #fff;
+  background-color: #286090;
+  border-color: #204d74;
+}
+.btn-primary:active,
+.btn-primary.active,
+.open > .dropdown-toggle.btn-primary {
+  color: #fff;
+  background-color: #286090;
+  border-color: #204d74;
+}
+.btn-primary:active:hover,
+.btn-primary.active:hover,
+.open > .dropdown-toggle.btn-primary:hover,
+.btn-primary:active:focus,
+.btn-primary.active:focus,
+.open > .dropdown-toggle.btn-primary:focus,
+.btn-primary:active.focus,
+.btn-primary.active.focus,
+.open > .dropdown-toggle.btn-primary.focus {
+  color: #fff;
+  background-color: #204d74;
+  border-color: #122b40;
+}
+.btn-primary:active,
+.btn-primary.active,
+.open > .dropdown-toggle.btn-primary {
+  background-image: none;
+}
+.btn-primary.disabled:hover,
+.btn-primary[disabled]:hover,
+fieldset[disabled] .btn-primary:hover,
+.btn-primary.disabled:focus,
+.btn-primary[disabled]:focus,
+fieldset[disabled] .btn-primary:focus,
+.btn-primary.disabled.focus,
+.btn-primary[disabled].focus,
+fieldset[disabled] .btn-primary.focus {
+  background-color: #337ab7;
+  border-color: #2e6da4;
+}
+.btn-primary .badge {
+  color: #337ab7;
+  background-color: #fff;
+}
+.btn-success {
+  color: #fff;
+  background-color: #5cb85c;
+  border-color: #4cae4c;
+}
+.btn-success:focus,
+.btn-success.focus {
+  color: #fff;
+  background-color: #449d44;
+  border-color: #255625;
+}
+.btn-success:hover {
+  color: #fff;
+  background-color: #449d44;
+  border-color: #398439;
+}
+.btn-success:active,
+.btn-success.active,
+.open > .dropdown-toggle.btn-success {
+  color: #fff;
+  background-color: #449d44;
+  border-color: #398439;
+}
+.btn-success:active:hover,
+.btn-success.active:hover,
+.open > .dropdown-toggle.btn-success:hover,
+.btn-success:active:focus,
+.btn-success.active:focus,
+.open > .dropdown-toggle.btn-success:focus,
+.btn-success:active.focus,
+.btn-success.active.focus,
+.open > .dropdown-toggle.btn-success.focus {
+  color: #fff;
+  background-color: #398439;
+  border-color: #255625;
+}
+.btn-success:active,
+.btn-success.active,
+.open > .dropdown-toggle.btn-success {
+  background-image: none;
+}
+.btn-success.disabled:hover,
+.btn-success[disabled]:hover,
+fieldset[disabled] .btn-success:hover,
+.btn-success.disabled:focus,
+.btn-success[disabled]:focus,
+fieldset[disabled] .btn-success:focus,
+.btn-success.disabled.focus,
+.btn-success[disabled].focus,
+fieldset[disabled] .btn-success.focus {
+  background-color: #5cb85c;
+  border-color: #4cae4c;
+}
+.btn-success .badge {
+  color: #5cb85c;
+  background-color: #fff;
+}
+.btn-info {
+  color: #fff;
+  background-color: #5bc0de;
+  border-color: #46b8da;
+}
+.btn-info:focus,
+.btn-info.focus {
+  color: #fff;
+  background-color: #31b0d5;
+  border-color: #1b6d85;
+}
+.btn-info:hover {
+  color: #fff;
+  background-color: #31b0d5;
+  border-color: #269abc;
+}
+.btn-info:active,
+.btn-info.active,
+.open > .dropdown-toggle.btn-info {
+  color: #fff;
+  background-color: #31b0d5;
+  border-color: #269abc;
+}
+.btn-info:active:hover,
+.btn-info.active:hover,
+.open > .dropdown-toggle.btn-info:hover,
+.btn-info:active:focus,
+.btn-info.active:focus,
+.open > .dropdown-toggle.btn-info:focus,
+.btn-info:active.focus,
+.btn-info.active.focus,
+.open > .dropdown-toggle.btn-info.focus {
+  color: #fff;
+  background-color: #269abc;
+  border-color: #1b6d85;
+}
+.btn-info:active,
+.btn-info.active,
+.open > .dropdown-toggle.btn-info {
+  background-image: none;
+}
+.btn-info.disabled:hover,
+.btn-info[disabled]:hover,
+fieldset[disabled] .btn-info:hover,
+.btn-info.disabled:focus,
+.btn-info[disabled]:focus,
+fieldset[disabled] .btn-info:focus,
+.btn-info.disabled.focus,
+.btn-info[disabled].focus,
+fieldset[disabled] .btn-info.focus {
+  background-color: #5bc0de;
+  border-color: #46b8da;
+}
+.btn-info .badge {
+  color: #5bc0de;
+  background-color: #fff;
+}
+.btn-warning {
+  color: #fff;
+  background-color: #f0ad4e;
+  border-color: #eea236;
+}
+.btn-warning:focus,
+.btn-warning.focus {
+  color: #fff;
+  background-color: #ec971f;
+  border-color: #985f0d;
+}
+.btn-warning:hover {
+  color: #fff;
+  background-color: #ec971f;
+  border-color: #d58512;
+}
+.btn-warning:active,
+.btn-warning.active,
+.open > .dropdown-toggle.btn-warning {
+  color: #fff;
+  background-color: #ec971f;
+  border-color: #d58512;
+}
+.btn-warning:active:hover,
+.btn-warning.active:hover,
+.open > .dropdown-toggle.btn-warning:hover,
+.btn-warning:active:focus,
+.btn-warning.active:focus,
+.open > .dropdown-toggle.btn-warning:focus,
+.btn-warning:active.focus,
+.btn-warning.active.focus,
+.open > .dropdown-toggle.btn-warning.focus {
+  color: #fff;
+  background-color: #d58512;
+  border-color: #985f0d;
+}
+.btn-warning:active,
+.btn-warning.active,
+.open > .dropdown-toggle.btn-warning {
+  background-image: none;
+}
+.btn-warning.disabled:hover,
+.btn-warning[disabled]:hover,
+fieldset[disabled] .btn-warning:hover,
+.btn-warning.disabled:focus,
+.btn-warning[disabled]:focus,
+fieldset[disabled] .btn-warning:focus,
+.btn-warning.disabled.focus,
+.btn-warning[disabled].focus,
+fieldset[disabled] .btn-warning.focus {
+  background-color: #f0ad4e;
+  border-color: #eea236;
+}
+.btn-warning .badge {
+  color: #f0ad4e;
+  background-color: #fff;
+}
+.btn-danger {
+  color: #fff;
+  background-color: #d9534f;
+  border-color: #d43f3a;
+}
+.btn-danger:focus,
+.btn-danger.focus {
+  color: #fff;
+  background-color: #c9302c;
+  border-color: #761c19;
+}
+.btn-danger:hover {
+  color: #fff;
+  background-color: #c9302c;
+  border-color: #ac2925;
+}
+.btn-danger:active,
+.btn-danger.active,
+.open > .dropdown-toggle.btn-danger {
+  color: #fff;
+  background-color: #c9302c;
+  border-color: #ac2925;
+}
+.btn-danger:active:hover,
+.btn-danger.active:hover,
+.open > .dropdown-toggle.btn-danger:hover,
+.btn-danger:active:focus,
+.btn-danger.active:focus,
+.open > .dropdown-toggle.btn-danger:focus,
+.btn-danger:active.focus,
+.btn-danger.active.focus,
+.open > .dropdown-toggle.btn-danger.focus {
+  color: #fff;
+  background-color: #ac2925;
+  border-color: #761c19;
+}
+.btn-danger:active,
+.btn-danger.active,
+.open > .dropdown-toggle.btn-danger {
+  background-image: none;
+}
+.btn-danger.disabled:hover,
+.btn-danger[disabled]:hover,
+fieldset[disabled] .btn-danger:hover,
+.btn-danger.disabled:focus,
+.btn-danger[disabled]:focus,
+fieldset[disabled] .btn-danger:focus,
+.btn-danger.disabled.focus,
+.btn-danger[disabled].focus,
+fieldset[disabled] .btn-danger.focus {
+  background-color: #d9534f;
+  border-color: #d43f3a;
+}
+.btn-danger .badge {
+  color: #d9534f;
+  background-color: #fff;
+}
+.btn-link {
+  color: #337ab7;
+  font-weight: normal;
+  border-radius: 0;
+}
+.btn-link,
+.btn-link:active,
+.btn-link.active,
+.btn-link[disabled],
+fieldset[disabled] .btn-link {
+  background-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.btn-link,
+.btn-link:hover,
+.btn-link:focus,
+.btn-link:active {
+  border-color: transparent;
+}
+.btn-link:hover,
+.btn-link:focus {
+  color: #23527c;
+  text-decoration: underline;
+  background-color: transparent;
+}
+.btn-link[disabled]:hover,
+fieldset[disabled] .btn-link:hover,
+.btn-link[disabled]:focus,
+fieldset[disabled] .btn-link:focus {
+  color: #777777;
+  text-decoration: none;
+}
+.btn-lg,
+.btn-group-lg > .btn {
+  padding: 10px 16px;
+  font-size: 17px;
+  line-height: 1.3333333;
+  border-radius: 3px;
+}
+.btn-sm,
+.btn-group-sm > .btn {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+.btn-xs,
+.btn-group-xs > .btn {
+  padding: 1px 5px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+.btn-block {
+  display: block;
+  width: 100%;
+}
+.btn-block + .btn-block {
+  margin-top: 5px;
+}
+input[type="submit"].btn-block,
+input[type="reset"].btn-block,
+input[type="button"].btn-block {
+  width: 100%;
+}
+.fade {
+  opacity: 0;
+  -webkit-transition: opacity 0.15s linear;
+  -o-transition: opacity 0.15s linear;
+  transition: opacity 0.15s linear;
+}
+.fade.in {
+  opacity: 1;
+}
+.collapse {
+  display: none;
+}
+.collapse.in {
+  display: block;
+}
+tr.collapse.in {
+  display: table-row;
+}
+tbody.collapse.in {
+  display: table-row-group;
+}
+.collapsing {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  -webkit-transition-property: height, visibility;
+  transition-property: height, visibility;
+  -webkit-transition-duration: 0.35s;
+  transition-duration: 0.35s;
+  -webkit-transition-timing-function: ease;
+  transition-timing-function: ease;
+}
+.caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 2px;
+  vertical-align: middle;
+  border-top: 4px dashed;
+  border-top: 4px solid \9;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+}
+.dropup,
+.dropdown {
+  position: relative;
+}
+.dropdown-toggle:focus {
+  outline: 0;
+}
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  list-style: none;
+  font-size: 13px;
+  text-align: left;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 2px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  background-clip: padding-box;
+}
+.dropdown-menu.pull-right {
+  right: 0;
+  left: auto;
+}
+.dropdown-menu .divider {
+  height: 1px;
+  margin: 8px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
+}
+.dropdown-menu > li > a {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333333;
+  white-space: nowrap;
+}
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+  text-decoration: none;
+  color: #262626;
+  background-color: #f5f5f5;
+}
+.dropdown-menu > .active > a,
+.dropdown-menu > .active > a:hover,
+.dropdown-menu > .active > a:focus {
+  color: #fff;
+  text-decoration: none;
+  outline: 0;
+  background-color: #337ab7;
+}
+.dropdown-menu > .disabled > a,
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  color: #777777;
+}
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  text-decoration: none;
+  background-color: transparent;
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  cursor: not-allowed;
+}
+.open > .dropdown-menu {
+  display: block;
+}
+.open > a {
+  outline: 0;
+}
+.dropdown-menu-right {
+  left: auto;
+  right: 0;
+}
+.dropdown-menu-left {
+  left: 0;
+  right: auto;
+}
+.dropdown-header {
+  display: block;
+  padding: 3px 20px;
+  font-size: 12px;
+  line-height: 1.42857143;
+  color: #777777;
+  white-space: nowrap;
+}
+.dropdown-backdrop {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  z-index: 990;
+}
+.pull-right > .dropdown-menu {
+  right: 0;
+  left: auto;
+}
+.dropup .caret,
+.navbar-fixed-bottom .dropdown .caret {
+  border-top: 0;
+  border-bottom: 4px dashed;
+  border-bottom: 4px solid \9;
+  content: "";
+}
+.dropup .dropdown-menu,
+.navbar-fixed-bottom .dropdown .dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-bottom: 2px;
+}
+@media (min-width: 541px) {
+  .navbar-right .dropdown-menu {
+    left: auto;
+    right: 0;
+  }
+  .navbar-right .dropdown-menu-left {
+    left: 0;
+    right: auto;
+  }
+}
+.btn-group,
+.btn-group-vertical {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+}
+.btn-group > .btn,
+.btn-group-vertical > .btn {
+  position: relative;
+  float: left;
+}
+.btn-group > .btn:hover,
+.btn-group-vertical > .btn:hover,
+.btn-group > .btn:focus,
+.btn-group-vertical > .btn:focus,
+.btn-group > .btn:active,
+.btn-group-vertical > .btn:active,
+.btn-group > .btn.active,
+.btn-group-vertical > .btn.active {
+  z-index: 2;
+}
+.btn-group .btn + .btn,
+.btn-group .btn + .btn-group,
+.btn-group .btn-group + .btn,
+.btn-group .btn-group + .btn-group {
+  margin-left: -1px;
+}
+.btn-toolbar {
+  margin-left: -5px;
+}
+.btn-toolbar .btn,
+.btn-toolbar .btn-group,
+.btn-toolbar .input-group {
+  float: left;
+}
+.btn-toolbar > .btn,
+.btn-toolbar > .btn-group,
+.btn-toolbar > .input-group {
+  margin-left: 5px;
+}
+.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
+  border-radius: 0;
+}
+.btn-group > .btn:first-child {
+  margin-left: 0;
+}
+.btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.btn-group > .btn:last-child:not(:first-child),
+.btn-group > .dropdown-toggle:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.btn-group > .btn-group {
+  float: left;
+}
+.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
+  border-radius: 0;
+}
+.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child,
+.btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.btn-group .dropdown-toggle:active,
+.btn-group.open .dropdown-toggle {
+  outline: 0;
+}
+.btn-group > .btn + .dropdown-toggle {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.btn-group > .btn-lg + .dropdown-toggle {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.btn-group.open .dropdown-toggle {
+  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+.btn-group.open .dropdown-toggle.btn-link {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.btn .caret {
+  margin-left: 0;
+}
+.btn-lg .caret {
+  border-width: 5px 5px 0;
+  border-bottom-width: 0;
+}
+.dropup .btn-lg .caret {
+  border-width: 0 5px 5px;
+}
+.btn-group-vertical > .btn,
+.btn-group-vertical > .btn-group,
+.btn-group-vertical > .btn-group > .btn {
+  display: block;
+  float: none;
+  width: 100%;
+  max-width: 100%;
+}
+.btn-group-vertical > .btn-group > .btn {
+  float: none;
+}
+.btn-group-vertical > .btn + .btn,
+.btn-group-vertical > .btn + .btn-group,
+.btn-group-vertical > .btn-group + .btn,
+.btn-group-vertical > .btn-group + .btn-group {
+  margin-top: -1px;
+  margin-left: 0;
+}
+.btn-group-vertical > .btn:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+.btn-group-vertical > .btn:first-child:not(:last-child) {
+  border-top-right-radius: 2px;
+  border-top-left-radius: 2px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.btn-group-vertical > .btn:last-child:not(:first-child) {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
+  border-radius: 0;
+}
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child,
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.btn-group-justified {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+}
+.btn-group-justified > .btn,
+.btn-group-justified > .btn-group {
+  float: none;
+  display: table-cell;
+  width: 1%;
+}
+.btn-group-justified > .btn-group .btn {
+  width: 100%;
+}
+.btn-group-justified > .btn-group .dropdown-menu {
+  left: auto;
+}
+[data-toggle="buttons"] > .btn input[type="radio"],
+[data-toggle="buttons"] > .btn-group > .btn input[type="radio"],
+[data-toggle="buttons"] > .btn input[type="checkbox"],
+[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"] {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+  pointer-events: none;
+}
+.input-group {
+  position: relative;
+  display: table;
+  border-collapse: separate;
+}
+.input-group[class*="col-"] {
+  float: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+.input-group .form-control {
+  position: relative;
+  z-index: 2;
+  float: left;
+  width: 100%;
+  margin-bottom: 0;
+}
+.input-group .form-control:focus {
+  z-index: 3;
+}
+.input-group-lg > .form-control,
+.input-group-lg > .input-group-addon,
+.input-group-lg > .input-group-btn > .btn {
+  height: 45px;
+  padding: 10px 16px;
+  font-size: 17px;
+  line-height: 1.3333333;
+  border-radius: 3px;
+}
+select.input-group-lg > .form-control,
+select.input-group-lg > .input-group-addon,
+select.input-group-lg > .input-group-btn > .btn {
+  height: 45px;
+  line-height: 45px;
+}
+textarea.input-group-lg > .form-control,
+textarea.input-group-lg > .input-group-addon,
+textarea.input-group-lg > .input-group-btn > .btn,
+select[multiple].input-group-lg > .form-control,
+select[multiple].input-group-lg > .input-group-addon,
+select[multiple].input-group-lg > .input-group-btn > .btn {
+  height: auto;
+}
+.input-group-sm > .form-control,
+.input-group-sm > .input-group-addon,
+.input-group-sm > .input-group-btn > .btn {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+}
+select.input-group-sm > .form-control,
+select.input-group-sm > .input-group-addon,
+select.input-group-sm > .input-group-btn > .btn {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.input-group-sm > .form-control,
+textarea.input-group-sm > .input-group-addon,
+textarea.input-group-sm > .input-group-btn > .btn,
+select[multiple].input-group-sm > .form-control,
+select[multiple].input-group-sm > .input-group-addon,
+select[multiple].input-group-sm > .input-group-btn > .btn {
+  height: auto;
+}
+.input-group-addon,
+.input-group-btn,
+.input-group .form-control {
+  display: table-cell;
+}
+.input-group-addon:not(:first-child):not(:last-child),
+.input-group-btn:not(:first-child):not(:last-child),
+.input-group .form-control:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+.input-group-addon,
+.input-group-btn {
+  width: 1%;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.input-group-addon {
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 1;
+  color: #555555;
+  text-align: center;
+  background-color: #eeeeee;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+}
+.input-group-addon.input-sm {
+  padding: 5px 10px;
+  font-size: 12px;
+  border-radius: 1px;
+}
+.input-group-addon.input-lg {
+  padding: 10px 16px;
+  font-size: 17px;
+  border-radius: 3px;
+}
+.input-group-addon input[type="radio"],
+.input-group-addon input[type="checkbox"] {
+  margin-top: 0;
+}
+.input-group .form-control:first-child,
+.input-group-addon:first-child,
+.input-group-btn:first-child > .btn,
+.input-group-btn:first-child > .btn-group > .btn,
+.input-group-btn:first-child > .dropdown-toggle,
+.input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
+.input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.input-group-addon:first-child {
+  border-right: 0;
+}
+.input-group .form-control:last-child,
+.input-group-addon:last-child,
+.input-group-btn:last-child > .btn,
+.input-group-btn:last-child > .btn-group > .btn,
+.input-group-btn:last-child > .dropdown-toggle,
+.input-group-btn:first-child > .btn:not(:first-child),
+.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.input-group-addon:last-child {
+  border-left: 0;
+}
+.input-group-btn {
+  position: relative;
+  font-size: 0;
+  white-space: nowrap;
+}
+.input-group-btn > .btn {
+  position: relative;
+}
+.input-group-btn > .btn + .btn {
+  margin-left: -1px;
+}
+.input-group-btn > .btn:hover,
+.input-group-btn > .btn:focus,
+.input-group-btn > .btn:active {
+  z-index: 2;
+}
+.input-group-btn:first-child > .btn,
+.input-group-btn:first-child > .btn-group {
+  margin-right: -1px;
+}
+.input-group-btn:last-child > .btn,
+.input-group-btn:last-child > .btn-group {
+  z-index: 2;
+  margin-left: -1px;
+}
+.nav {
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style: none;
+}
+.nav > li {
+  position: relative;
+  display: block;
+}
+.nav > li > a {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+}
+.nav > li > a:hover,
+.nav > li > a:focus {
+  text-decoration: none;
+  background-color: #eeeeee;
+}
+.nav > li.disabled > a {
+  color: #777777;
+}
+.nav > li.disabled > a:hover,
+.nav > li.disabled > a:focus {
+  color: #777777;
+  text-decoration: none;
+  background-color: transparent;
+  cursor: not-allowed;
+}
+.nav .open > a,
+.nav .open > a:hover,
+.nav .open > a:focus {
+  background-color: #eeeeee;
+  border-color: #337ab7;
+}
+.nav .nav-divider {
+  height: 1px;
+  margin: 8px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
+}
+.nav > li > a > img {
+  max-width: none;
+}
+.nav-tabs {
+  border-bottom: 1px solid #ddd;
+}
+.nav-tabs > li {
+  float: left;
+  margin-bottom: -1px;
+}
+.nav-tabs > li > a {
+  margin-right: 2px;
+  line-height: 1.42857143;
+  border: 1px solid transparent;
+  border-radius: 2px 2px 0 0;
+}
+.nav-tabs > li > a:hover {
+  border-color: #eeeeee #eeeeee #ddd;
+}
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
+  color: #555555;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-bottom-color: transparent;
+  cursor: default;
+}
+.nav-tabs.nav-justified {
+  width: 100%;
+  border-bottom: 0;
+}
+.nav-tabs.nav-justified > li {
+  float: none;
+}
+.nav-tabs.nav-justified > li > a {
+  text-align: center;
+  margin-bottom: 5px;
+}
+.nav-tabs.nav-justified > .dropdown .dropdown-menu {
+  top: auto;
+  left: auto;
+}
+@media (min-width: 768px) {
+  .nav-tabs.nav-justified > li {
+    display: table-cell;
+    width: 1%;
+  }
+  .nav-tabs.nav-justified > li > a {
+    margin-bottom: 0;
+  }
+}
+.nav-tabs.nav-justified > li > a {
+  margin-right: 0;
+  border-radius: 2px;
+}
+.nav-tabs.nav-justified > .active > a,
+.nav-tabs.nav-justified > .active > a:hover,
+.nav-tabs.nav-justified > .active > a:focus {
+  border: 1px solid #ddd;
+}
+@media (min-width: 768px) {
+  .nav-tabs.nav-justified > li > a {
+    border-bottom: 1px solid #ddd;
+    border-radius: 2px 2px 0 0;
+  }
+  .nav-tabs.nav-justified > .active > a,
+  .nav-tabs.nav-justified > .active > a:hover,
+  .nav-tabs.nav-justified > .active > a:focus {
+    border-bottom-color: #fff;
+  }
+}
+.nav-pills > li {
+  float: left;
+}
+.nav-pills > li > a {
+  border-radius: 2px;
+}
+.nav-pills > li + li {
+  margin-left: 2px;
+}
+.nav-pills > li.active > a,
+.nav-pills > li.active > a:hover,
+.nav-pills > li.active > a:focus {
+  color: #fff;
+  background-color: #337ab7;
+}
+.nav-stacked > li {
+  float: none;
+}
+.nav-stacked > li + li {
+  margin-top: 2px;
+  margin-left: 0;
+}
+.nav-justified {
+  width: 100%;
+}
+.nav-justified > li {
+  float: none;
+}
+.nav-justified > li > a {
+  text-align: center;
+  margin-bottom: 5px;
+}
+.nav-justified > .dropdown .dropdown-menu {
+  top: auto;
+  left: auto;
+}
+@media (min-width: 768px) {
+  .nav-justified > li {
+    display: table-cell;
+    width: 1%;
+  }
+  .nav-justified > li > a {
+    margin-bottom: 0;
+  }
+}
+.nav-tabs-justified {
+  border-bottom: 0;
+}
+.nav-tabs-justified > li > a {
+  margin-right: 0;
+  border-radius: 2px;
+}
+.nav-tabs-justified > .active > a,
+.nav-tabs-justified > .active > a:hover,
+.nav-tabs-justified > .active > a:focus {
+  border: 1px solid #ddd;
+}
+@media (min-width: 768px) {
+  .nav-tabs-justified > li > a {
+    border-bottom: 1px solid #ddd;
+    border-radius: 2px 2px 0 0;
+  }
+  .nav-tabs-justified > .active > a,
+  .nav-tabs-justified > .active > a:hover,
+  .nav-tabs-justified > .active > a:focus {
+    border-bottom-color: #fff;
+  }
+}
+.tab-content > .tab-pane {
+  display: none;
+}
+.tab-content > .active {
+  display: block;
+}
+.nav-tabs .dropdown-menu {
+  margin-top: -1px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.navbar {
+  position: relative;
+  min-height: 30px;
+  margin-bottom: 18px;
+  border: 1px solid transparent;
+}
+@media (min-width: 541px) {
+  .navbar {
+    border-radius: 2px;
+  }
+}
+@media (min-width: 541px) {
+  .navbar-header {
+    float: left;
+  }
+}
+.navbar-collapse {
+  overflow-x: visible;
+  padding-right: 0px;
+  padding-left: 0px;
+  border-top: 1px solid transparent;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  -webkit-overflow-scrolling: touch;
+}
+.navbar-collapse.in {
+  overflow-y: auto;
+}
+@media (min-width: 541px) {
+  .navbar-collapse {
+    width: auto;
+    border-top: 0;
+    box-shadow: none;
+  }
+  .navbar-collapse.collapse {
+    display: block !important;
+    height: auto !important;
+    padding-bottom: 0;
+    overflow: visible !important;
+  }
+  .navbar-collapse.in {
+    overflow-y: visible;
+  }
+  .navbar-fixed-top .navbar-collapse,
+  .navbar-static-top .navbar-collapse,
+  .navbar-fixed-bottom .navbar-collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+.navbar-fixed-top .navbar-collapse,
+.navbar-fixed-bottom .navbar-collapse {
+  max-height: 340px;
+}
+@media (max-device-width: 540px) and (orientation: landscape) {
+  .navbar-fixed-top .navbar-collapse,
+  .navbar-fixed-bottom .navbar-collapse {
+    max-height: 200px;
+  }
+}
+.container > .navbar-header,
+.container-fluid > .navbar-header,
+.container > .navbar-collapse,
+.container-fluid > .navbar-collapse {
+  margin-right: 0px;
+  margin-left: 0px;
+}
+@media (min-width: 541px) {
+  .container > .navbar-header,
+  .container-fluid > .navbar-header,
+  .container > .navbar-collapse,
+  .container-fluid > .navbar-collapse {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+.navbar-static-top {
+  z-index: 1000;
+  border-width: 0 0 1px;
+}
+@media (min-width: 541px) {
+  .navbar-static-top {
+    border-radius: 0;
+  }
+}
+.navbar-fixed-top,
+.navbar-fixed-bottom {
+  position: fixed;
+  right: 0;
+  left: 0;
+  z-index: 1030;
+}
+@media (min-width: 541px) {
+  .navbar-fixed-top,
+  .navbar-fixed-bottom {
+    border-radius: 0;
+  }
+}
+.navbar-fixed-top {
+  top: 0;
+  border-width: 0 0 1px;
+}
+.navbar-fixed-bottom {
+  bottom: 0;
+  margin-bottom: 0;
+  border-width: 1px 0 0;
+}
+.navbar-brand {
+  float: left;
+  padding: 6px 0px;
+  font-size: 17px;
+  line-height: 18px;
+  height: 30px;
+}
+.navbar-brand:hover,
+.navbar-brand:focus {
+  text-decoration: none;
+}
+.navbar-brand > img {
+  display: block;
+}
+@media (min-width: 541px) {
+  .navbar > .container .navbar-brand,
+  .navbar > .container-fluid .navbar-brand {
+    margin-left: 0px;
+  }
+}
+.navbar-toggle {
+  position: relative;
+  float: right;
+  margin-right: 0px;
+  padding: 9px 10px;
+  margin-top: -2px;
+  margin-bottom: -2px;
+  background-color: transparent;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+}
+.navbar-toggle:focus {
+  outline: 0;
+}
+.navbar-toggle .icon-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 1px;
+}
+.navbar-toggle .icon-bar + .icon-bar {
+  margin-top: 4px;
+}
+@media (min-width: 541px) {
+  .navbar-toggle {
+    display: none;
+  }
+}
+.navbar-nav {
+  margin: 3px 0px;
+}
+.navbar-nav > li > a {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  line-height: 18px;
+}
+@media (max-width: 540px) {
+  .navbar-nav .open .dropdown-menu {
+    position: static;
+    float: none;
+    width: auto;
+    margin-top: 0;
+    background-color: transparent;
+    border: 0;
+    box-shadow: none;
+  }
+  .navbar-nav .open .dropdown-menu > li > a,
+  .navbar-nav .open .dropdown-menu .dropdown-header {
+    padding: 5px 15px 5px 25px;
+  }
+  .navbar-nav .open .dropdown-menu > li > a {
+    line-height: 18px;
+  }
+  .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-nav .open .dropdown-menu > li > a:focus {
+    background-image: none;
+  }
+}
+@media (min-width: 541px) {
+  .navbar-nav {
+    float: left;
+    margin: 0;
+  }
+  .navbar-nav > li {
+    float: left;
+  }
+  .navbar-nav > li > a {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+.navbar-form {
+  margin-left: 0px;
+  margin-right: 0px;
+  padding: 10px 0px;
+  border-top: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+@media (min-width: 768px) {
+  .navbar-form .form-group {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .navbar-form .form-control {
+    display: inline-block;
+    width: auto;
+    vertical-align: middle;
+  }
+  .navbar-form .form-control-static {
+    display: inline-block;
+  }
+  .navbar-form .input-group {
+    display: inline-table;
+    vertical-align: middle;
+  }
+  .navbar-form .input-group .input-group-addon,
+  .navbar-form .input-group .input-group-btn,
+  .navbar-form .input-group .form-control {
+    width: auto;
+  }
+  .navbar-form .input-group > .form-control {
+    width: 100%;
+  }
+  .navbar-form .control-label {
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .navbar-form .radio,
+  .navbar-form .checkbox {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .navbar-form .radio label,
+  .navbar-form .checkbox label {
+    padding-left: 0;
+  }
+  .navbar-form .radio input[type="radio"],
+  .navbar-form .checkbox input[type="checkbox"] {
+    position: relative;
+    margin-left: 0;
+  }
+  .navbar-form .has-feedback .form-control-feedback {
+    top: 0;
+  }
+}
+@media (max-width: 540px) {
+  .navbar-form .form-group {
+    margin-bottom: 5px;
+  }
+  .navbar-form .form-group:last-child {
+    margin-bottom: 0;
+  }
+}
+@media (min-width: 541px) {
+  .navbar-form {
+    width: auto;
+    border: 0;
+    margin-left: 0;
+    margin-right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+  }
+}
+.navbar-nav > li > .dropdown-menu {
+  margin-top: 0;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.navbar-fixed-bottom .navbar-nav > li > .dropdown-menu {
+  margin-bottom: 0;
+  border-top-right-radius: 2px;
+  border-top-left-radius: 2px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.navbar-btn {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+.navbar-btn.btn-sm {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+.navbar-btn.btn-xs {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+.navbar-text {
+  margin-top: 6px;
+  margin-bottom: 6px;
+}
+@media (min-width: 541px) {
+  .navbar-text {
+    float: left;
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+}
+@media (min-width: 541px) {
+  .navbar-left {
+    float: left !important;
+    float: left;
+  }
+  .navbar-right {
+    float: right !important;
+    float: right;
+    margin-right: 0px;
+  }
+  .navbar-right ~ .navbar-right {
+    margin-right: 0;
+  }
+}
+.navbar-default {
+  background-color: #f8f8f8;
+  border-color: #e7e7e7;
+}
+.navbar-default .navbar-brand {
+  color: #777;
+}
+.navbar-default .navbar-brand:hover,
+.navbar-default .navbar-brand:focus {
+  color: #5e5e5e;
+  background-color: transparent;
+}
+.navbar-default .navbar-text {
+  color: #777;
+}
+.navbar-default .navbar-nav > li > a {
+  color: #777;
+}
+.navbar-default .navbar-nav > li > a:hover,
+.navbar-default .navbar-nav > li > a:focus {
+  color: #333;
+  background-color: transparent;
+}
+.navbar-default .navbar-nav > .active > a,
+.navbar-default .navbar-nav > .active > a:hover,
+.navbar-default .navbar-nav > .active > a:focus {
+  color: #555;
+  background-color: #e7e7e7;
+}
+.navbar-default .navbar-nav > .disabled > a,
+.navbar-default .navbar-nav > .disabled > a:hover,
+.navbar-default .navbar-nav > .disabled > a:focus {
+  color: #ccc;
+  background-color: transparent;
+}
+.navbar-default .navbar-toggle {
+  border-color: #ddd;
+}
+.navbar-default .navbar-toggle:hover,
+.navbar-default .navbar-toggle:focus {
+  background-color: #ddd;
+}
+.navbar-default .navbar-toggle .icon-bar {
+  background-color: #888;
+}
+.navbar-default .navbar-collapse,
+.navbar-default .navbar-form {
+  border-color: #e7e7e7;
+}
+.navbar-default .navbar-nav > .open > a,
+.navbar-default .navbar-nav > .open > a:hover,
+.navbar-default .navbar-nav > .open > a:focus {
+  background-color: #e7e7e7;
+  color: #555;
+}
+@media (max-width: 540px) {
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+    color: #777;
+  }
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
+    color: #333;
+    background-color: transparent;
+  }
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+    color: #555;
+    background-color: #e7e7e7;
+  }
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    color: #ccc;
+    background-color: transparent;
+  }
+}
+.navbar-default .navbar-link {
+  color: #777;
+}
+.navbar-default .navbar-link:hover {
+  color: #333;
+}
+.navbar-default .btn-link {
+  color: #777;
+}
+.navbar-default .btn-link:hover,
+.navbar-default .btn-link:focus {
+  color: #333;
+}
+.navbar-default .btn-link[disabled]:hover,
+fieldset[disabled] .navbar-default .btn-link:hover,
+.navbar-default .btn-link[disabled]:focus,
+fieldset[disabled] .navbar-default .btn-link:focus {
+  color: #ccc;
+}
+.navbar-inverse {
+  background-color: #222;
+  border-color: #080808;
+}
+.navbar-inverse .navbar-brand {
+  color: #9d9d9d;
+}
+.navbar-inverse .navbar-brand:hover,
+.navbar-inverse .navbar-brand:focus {
+  color: #fff;
+  background-color: transparent;
+}
+.navbar-inverse .navbar-text {
+  color: #9d9d9d;
+}
+.navbar-inverse .navbar-nav > li > a {
+  color: #9d9d9d;
+}
+.navbar-inverse .navbar-nav > li > a:hover,
+.navbar-inverse .navbar-nav > li > a:focus {
+  color: #fff;
+  background-color: transparent;
+}
+.navbar-inverse .navbar-nav > .active > a,
+.navbar-inverse .navbar-nav > .active > a:hover,
+.navbar-inverse .navbar-nav > .active > a:focus {
+  color: #fff;
+  background-color: #080808;
+}
+.navbar-inverse .navbar-nav > .disabled > a,
+.navbar-inverse .navbar-nav > .disabled > a:hover,
+.navbar-inverse .navbar-nav > .disabled > a:focus {
+  color: #444;
+  background-color: transparent;
+}
+.navbar-inverse .navbar-toggle {
+  border-color: #333;
+}
+.navbar-inverse .navbar-toggle:hover,
+.navbar-inverse .navbar-toggle:focus {
+  background-color: #333;
+}
+.navbar-inverse .navbar-toggle .icon-bar {
+  background-color: #fff;
+}
+.navbar-inverse .navbar-collapse,
+.navbar-inverse .navbar-form {
+  border-color: #101010;
+}
+.navbar-inverse .navbar-nav > .open > a,
+.navbar-inverse .navbar-nav > .open > a:hover,
+.navbar-inverse .navbar-nav > .open > a:focus {
+  background-color: #080808;
+  color: #fff;
+}
+@media (max-width: 540px) {
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
+    border-color: #080808;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
+    background-color: #080808;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
+    color: #9d9d9d;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
+    color: #fff;
+    background-color: transparent;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
+    color: #fff;
+    background-color: #080808;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    color: #444;
+    background-color: transparent;
+  }
+}
+.navbar-inverse .navbar-link {
+  color: #9d9d9d;
+}
+.navbar-inverse .navbar-link:hover {
+  color: #fff;
+}
+.navbar-inverse .btn-link {
+  color: #9d9d9d;
+}
+.navbar-inverse .btn-link:hover,
+.navbar-inverse .btn-link:focus {
+  color: #fff;
+}
+.navbar-inverse .btn-link[disabled]:hover,
+fieldset[disabled] .navbar-inverse .btn-link:hover,
+.navbar-inverse .btn-link[disabled]:focus,
+fieldset[disabled] .navbar-inverse .btn-link:focus {
+  color: #444;
+}
+.breadcrumb {
+  padding: 8px 15px;
+  margin-bottom: 18px;
+  list-style: none;
+  background-color: #f5f5f5;
+  border-radius: 2px;
+}
+.breadcrumb > li {
+  display: inline-block;
+}
+.breadcrumb > li + li:before {
+  content: "/\00a0";
+  padding: 0 5px;
+  color: #5e5e5e;
+}
+.breadcrumb > .active {
+  color: #777777;
+}
+.pagination {
+  display: inline-block;
+  padding-left: 0;
+  margin: 18px 0;
+  border-radius: 2px;
+}
+.pagination > li {
+  display: inline;
+}
+.pagination > li > a,
+.pagination > li > span {
+  position: relative;
+  float: left;
+  padding: 6px 12px;
+  line-height: 1.42857143;
+  text-decoration: none;
+  color: #337ab7;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  margin-left: -1px;
+}
+.pagination > li:first-child > a,
+.pagination > li:first-child > span {
+  margin-left: 0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+}
+.pagination > li:last-child > a,
+.pagination > li:last-child > span {
+  border-bottom-right-radius: 2px;
+  border-top-right-radius: 2px;
+}
+.pagination > li > a:hover,
+.pagination > li > span:hover,
+.pagination > li > a:focus,
+.pagination > li > span:focus {
+  z-index: 2;
+  color: #23527c;
+  background-color: #eeeeee;
+  border-color: #ddd;
+}
+.pagination > .active > a,
+.pagination > .active > span,
+.pagination > .active > a:hover,
+.pagination > .active > span:hover,
+.pagination > .active > a:focus,
+.pagination > .active > span:focus {
+  z-index: 3;
+  color: #fff;
+  background-color: #337ab7;
+  border-color: #337ab7;
+  cursor: default;
+}
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus {
+  color: #777777;
+  background-color: #fff;
+  border-color: #ddd;
+  cursor: not-allowed;
+}
+.pagination-lg > li > a,
+.pagination-lg > li > span {
+  padding: 10px 16px;
+  font-size: 17px;
+  line-height: 1.3333333;
+}
+.pagination-lg > li:first-child > a,
+.pagination-lg > li:first-child > span {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.pagination-lg > li:last-child > a,
+.pagination-lg > li:last-child > span {
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+.pagination-sm > li > a,
+.pagination-sm > li > span {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.pagination-sm > li:first-child > a,
+.pagination-sm > li:first-child > span {
+  border-bottom-left-radius: 1px;
+  border-top-left-radius: 1px;
+}
+.pagination-sm > li:last-child > a,
+.pagination-sm > li:last-child > span {
+  border-bottom-right-radius: 1px;
+  border-top-right-radius: 1px;
+}
+.pager {
+  padding-left: 0;
+  margin: 18px 0;
+  list-style: none;
+  text-align: center;
+}
+.pager li {
+  display: inline;
+}
+.pager li > a,
+.pager li > span {
+  display: inline-block;
+  padding: 5px 14px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 15px;
+}
+.pager li > a:hover,
+.pager li > a:focus {
+  text-decoration: none;
+  background-color: #eeeeee;
+}
+.pager .next > a,
+.pager .next > span {
+  float: right;
+}
+.pager .previous > a,
+.pager .previous > span {
+  float: left;
+}
+.pager .disabled > a,
+.pager .disabled > a:hover,
+.pager .disabled > a:focus,
+.pager .disabled > span {
+  color: #777777;
+  background-color: #fff;
+  cursor: not-allowed;
+}
+.label {
+  display: inline;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  font-weight: bold;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+a.label:hover,
+a.label:focus {
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+}
+.label:empty {
+  display: none;
+}
+.btn .label {
+  position: relative;
+  top: -1px;
+}
+.label-default {
+  background-color: #777777;
+}
+.label-default[href]:hover,
+.label-default[href]:focus {
+  background-color: #5e5e5e;
+}
+.label-primary {
+  background-color: #337ab7;
+}
+.label-primary[href]:hover,
+.label-primary[href]:focus {
+  background-color: #286090;
+}
+.label-success {
+  background-color: #5cb85c;
+}
+.label-success[href]:hover,
+.label-success[href]:focus {
+  background-color: #449d44;
+}
+.label-info {
+  background-color: #5bc0de;
+}
+.label-info[href]:hover,
+.label-info[href]:focus {
+  background-color: #31b0d5;
+}
+.label-warning {
+  background-color: #f0ad4e;
+}
+.label-warning[href]:hover,
+.label-warning[href]:focus {
+  background-color: #ec971f;
+}
+.label-danger {
+  background-color: #d9534f;
+}
+.label-danger[href]:hover,
+.label-danger[href]:focus {
+  background-color: #c9302c;
+}
+.badge {
+  display: inline-block;
+  min-width: 10px;
+  padding: 3px 7px;
+  font-size: 12px;
+  font-weight: bold;
+  color: #fff;
+  line-height: 1;
+  vertical-align: middle;
+  white-space: nowrap;
+  text-align: center;
+  background-color: #777777;
+  border-radius: 10px;
+}
+.badge:empty {
+  display: none;
+}
+.btn .badge {
+  position: relative;
+  top: -1px;
+}
+.btn-xs .badge,
+.btn-group-xs > .btn .badge {
+  top: 0;
+  padding: 1px 5px;
+}
+a.badge:hover,
+a.badge:focus {
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+}
+.list-group-item.active > .badge,
+.nav-pills > .active > a > .badge {
+  color: #337ab7;
+  background-color: #fff;
+}
+.list-group-item > .badge {
+  float: right;
+}
+.list-group-item > .badge + .badge {
+  margin-right: 5px;
+}
+.nav-pills > li > a > .badge {
+  margin-left: 3px;
+}
+.jumbotron {
+  padding-top: 30px;
+  padding-bottom: 30px;
+  margin-bottom: 30px;
+  color: inherit;
+  background-color: #eeeeee;
+}
+.jumbotron h1,
+.jumbotron .h1 {
+  color: inherit;
+}
+.jumbotron p {
+  margin-bottom: 15px;
+  font-size: 20px;
+  font-weight: 200;
+}
+.jumbotron > hr {
+  border-top-color: #d5d5d5;
+}
+.container .jumbotron,
+.container-fluid .jumbotron {
+  border-radius: 3px;
+  padding-left: 0px;
+  padding-right: 0px;
+}
+.jumbotron .container {
+  max-width: 100%;
+}
+@media screen and (min-width: 768px) {
+  .jumbotron {
+    padding-top: 48px;
+    padding-bottom: 48px;
+  }
+  .container .jumbotron,
+  .container-fluid .jumbotron {
+    padding-left: 60px;
+    padding-right: 60px;
+  }
+  .jumbotron h1,
+  .jumbotron .h1 {
+    font-size: 59px;
+  }
+}
+.thumbnail {
+  display: block;
+  padding: 4px;
+  margin-bottom: 18px;
+  line-height: 1.42857143;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  -webkit-transition: border 0.2s ease-in-out;
+  -o-transition: border 0.2s ease-in-out;
+  transition: border 0.2s ease-in-out;
+}
+.thumbnail > img,
+.thumbnail a > img {
+  margin-left: auto;
+  margin-right: auto;
+}
+a.thumbnail:hover,
+a.thumbnail:focus,
+a.thumbnail.active {
+  border-color: #337ab7;
+}
+.thumbnail .caption {
+  padding: 9px;
+  color: #000;
+}
+.alert {
+  padding: 15px;
+  margin-bottom: 18px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+}
+.alert h4 {
+  margin-top: 0;
+  color: inherit;
+}
+.alert .alert-link {
+  font-weight: bold;
+}
+.alert > p,
+.alert > ul {
+  margin-bottom: 0;
+}
+.alert > p + p {
+  margin-top: 5px;
+}
+.alert-dismissable,
+.alert-dismissible {
+  padding-right: 35px;
+}
+.alert-dismissable .close,
+.alert-dismissible .close {
+  position: relative;
+  top: -2px;
+  right: -21px;
+  color: inherit;
+}
+.alert-success {
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+  color: #3c763d;
+}
+.alert-success hr {
+  border-top-color: #c9e2b3;
+}
+.alert-success .alert-link {
+  color: #2b542c;
+}
+.alert-info {
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+  color: #31708f;
+}
+.alert-info hr {
+  border-top-color: #a6e1ec;
+}
+.alert-info .alert-link {
+  color: #245269;
+}
+.alert-warning {
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  color: #8a6d3b;
+}
+.alert-warning hr {
+  border-top-color: #f7e1b5;
+}
+.alert-warning .alert-link {
+  color: #66512c;
+}
+.alert-danger {
+  background-color: #f2dede;
+  border-color: #ebccd1;
+  color: #a94442;
+}
+.alert-danger hr {
+  border-top-color: #e4b9c0;
+}
+.alert-danger .alert-link {
+  color: #843534;
+}
+@-webkit-keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+.progress {
+  overflow: hidden;
+  height: 18px;
+  margin-bottom: 18px;
+  background-color: #f5f5f5;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.progress-bar {
+  float: left;
+  width: 0%;
+  height: 100%;
+  font-size: 12px;
+  line-height: 18px;
+  color: #fff;
+  text-align: center;
+  background-color: #337ab7;
+  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  -webkit-transition: width 0.6s ease;
+  -o-transition: width 0.6s ease;
+  transition: width 0.6s ease;
+}
+.progress-striped .progress-bar,
+.progress-bar-striped {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-size: 40px 40px;
+}
+.progress.active .progress-bar,
+.progress-bar.active {
+  -webkit-animation: progress-bar-stripes 2s linear infinite;
+  -o-animation: progress-bar-stripes 2s linear infinite;
+  animation: progress-bar-stripes 2s linear infinite;
+}
+.progress-bar-success {
+  background-color: #5cb85c;
+}
+.progress-striped .progress-bar-success {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.progress-bar-info {
+  background-color: #5bc0de;
+}
+.progress-striped .progress-bar-info {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.progress-bar-warning {
+  background-color: #f0ad4e;
+}
+.progress-striped .progress-bar-warning {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.progress-bar-danger {
+  background-color: #d9534f;
+}
+.progress-striped .progress-bar-danger {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.media {
+  margin-top: 15px;
+}
+.media:first-child {
+  margin-top: 0;
+}
+.media,
+.media-body {
+  zoom: 1;
+  overflow: hidden;
+}
+.media-body {
+  width: 10000px;
+}
+.media-object {
+  display: block;
+}
+.media-object.img-thumbnail {
+  max-width: none;
+}
+.media-right,
+.media > .pull-right {
+  padding-left: 10px;
+}
+.media-left,
+.media > .pull-left {
+  padding-right: 10px;
+}
+.media-left,
+.media-right,
+.media-body {
+  display: table-cell;
+  vertical-align: top;
+}
+.media-middle {
+  vertical-align: middle;
+}
+.media-bottom {
+  vertical-align: bottom;
+}
+.media-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.media-list {
+  padding-left: 0;
+  list-style: none;
+}
+.list-group {
+  margin-bottom: 20px;
+  padding-left: 0;
+}
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+  margin-bottom: -1px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+}
+.list-group-item:first-child {
+  border-top-right-radius: 2px;
+  border-top-left-radius: 2px;
+}
+.list-group-item:last-child {
+  margin-bottom: 0;
+  border-bottom-right-radius: 2px;
+  border-bottom-left-radius: 2px;
+}
+a.list-group-item,
+button.list-group-item {
+  color: #555;
+}
+a.list-group-item .list-group-item-heading,
+button.list-group-item .list-group-item-heading {
+  color: #333;
+}
+a.list-group-item:hover,
+button.list-group-item:hover,
+a.list-group-item:focus,
+button.list-group-item:focus {
+  text-decoration: none;
+  color: #555;
+  background-color: #f5f5f5;
+}
+button.list-group-item {
+  width: 100%;
+  text-align: left;
+}
+.list-group-item.disabled,
+.list-group-item.disabled:hover,
+.list-group-item.disabled:focus {
+  background-color: #eeeeee;
+  color: #777777;
+  cursor: not-allowed;
+}
+.list-group-item.disabled .list-group-item-heading,
+.list-group-item.disabled:hover .list-group-item-heading,
+.list-group-item.disabled:focus .list-group-item-heading {
+  color: inherit;
+}
+.list-group-item.disabled .list-group-item-text,
+.list-group-item.disabled:hover .list-group-item-text,
+.list-group-item.disabled:focus .list-group-item-text {
+  color: #777777;
+}
+.list-group-item.active,
+.list-group-item.active:hover,
+.list-group-item.active:focus {
+  z-index: 2;
+  color: #fff;
+  background-color: #337ab7;
+  border-color: #337ab7;
+}
+.list-group-item.active .list-group-item-heading,
+.list-group-item.active:hover .list-group-item-heading,
+.list-group-item.active:focus .list-group-item-heading,
+.list-group-item.active .list-group-item-heading > small,
+.list-group-item.active:hover .list-group-item-heading > small,
+.list-group-item.active:focus .list-group-item-heading > small,
+.list-group-item.active .list-group-item-heading > .small,
+.list-group-item.active:hover .list-group-item-heading > .small,
+.list-group-item.active:focus .list-group-item-heading > .small {
+  color: inherit;
+}
+.list-group-item.active .list-group-item-text,
+.list-group-item.active:hover .list-group-item-text,
+.list-group-item.active:focus .list-group-item-text {
+  color: #c7ddef;
+}
+.list-group-item-success {
+  color: #3c763d;
+  background-color: #dff0d8;
+}
+a.list-group-item-success,
+button.list-group-item-success {
+  color: #3c763d;
+}
+a.list-group-item-success .list-group-item-heading,
+button.list-group-item-success .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-success:hover,
+button.list-group-item-success:hover,
+a.list-group-item-success:focus,
+button.list-group-item-success:focus {
+  color: #3c763d;
+  background-color: #d0e9c6;
+}
+a.list-group-item-success.active,
+button.list-group-item-success.active,
+a.list-group-item-success.active:hover,
+button.list-group-item-success.active:hover,
+a.list-group-item-success.active:focus,
+button.list-group-item-success.active:focus {
+  color: #fff;
+  background-color: #3c763d;
+  border-color: #3c763d;
+}
+.list-group-item-info {
+  color: #31708f;
+  background-color: #d9edf7;
+}
+a.list-group-item-info,
+button.list-group-item-info {
+  color: #31708f;
+}
+a.list-group-item-info .list-group-item-heading,
+button.list-group-item-info .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-info:hover,
+button.list-group-item-info:hover,
+a.list-group-item-info:focus,
+button.list-group-item-info:focus {
+  color: #31708f;
+  background-color: #c4e3f3;
+}
+a.list-group-item-info.active,
+button.list-group-item-info.active,
+a.list-group-item-info.active:hover,
+button.list-group-item-info.active:hover,
+a.list-group-item-info.active:focus,
+button.list-group-item-info.active:focus {
+  color: #fff;
+  background-color: #31708f;
+  border-color: #31708f;
+}
+.list-group-item-warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+}
+a.list-group-item-warning,
+button.list-group-item-warning {
+  color: #8a6d3b;
+}
+a.list-group-item-warning .list-group-item-heading,
+button.list-group-item-warning .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-warning:hover,
+button.list-group-item-warning:hover,
+a.list-group-item-warning:focus,
+button.list-group-item-warning:focus {
+  color: #8a6d3b;
+  background-color: #faf2cc;
+}
+a.list-group-item-warning.active,
+button.list-group-item-warning.active,
+a.list-group-item-warning.active:hover,
+button.list-group-item-warning.active:hover,
+a.list-group-item-warning.active:focus,
+button.list-group-item-warning.active:focus {
+  color: #fff;
+  background-color: #8a6d3b;
+  border-color: #8a6d3b;
+}
+.list-group-item-danger {
+  color: #a94442;
+  background-color: #f2dede;
+}
+a.list-group-item-danger,
+button.list-group-item-danger {
+  color: #a94442;
+}
+a.list-group-item-danger .list-group-item-heading,
+button.list-group-item-danger .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-danger:hover,
+button.list-group-item-danger:hover,
+a.list-group-item-danger:focus,
+button.list-group-item-danger:focus {
+  color: #a94442;
+  background-color: #ebcccc;
+}
+a.list-group-item-danger.active,
+button.list-group-item-danger.active,
+a.list-group-item-danger.active:hover,
+button.list-group-item-danger.active:hover,
+a.list-group-item-danger.active:focus,
+button.list-group-item-danger.active:focus {
+  color: #fff;
+  background-color: #a94442;
+  border-color: #a94442;
+}
+.list-group-item-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.list-group-item-text {
+  margin-bottom: 0;
+  line-height: 1.3;
+}
+.panel {
+  margin-bottom: 18px;
+  background-color: #fff;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+.panel-body {
+  padding: 15px;
+}
+.panel-heading {
+  padding: 10px 15px;
+  border-bottom: 1px solid transparent;
+  border-top-right-radius: 1px;
+  border-top-left-radius: 1px;
+}
+.panel-heading > .dropdown .dropdown-toggle {
+  color: inherit;
+}
+.panel-title {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 15px;
+  color: inherit;
+}
+.panel-title > a,
+.panel-title > small,
+.panel-title > .small,
+.panel-title > small > a,
+.panel-title > .small > a {
+  color: inherit;
+}
+.panel-footer {
+  padding: 10px 15px;
+  background-color: #f5f5f5;
+  border-top: 1px solid #ddd;
+  border-bottom-right-radius: 1px;
+  border-bottom-left-radius: 1px;
+}
+.panel > .list-group,
+.panel > .panel-collapse > .list-group {
+  margin-bottom: 0;
+}
+.panel > .list-group .list-group-item,
+.panel > .panel-collapse > .list-group .list-group-item {
+  border-width: 1px 0;
+  border-radius: 0;
+}
+.panel > .list-group:first-child .list-group-item:first-child,
+.panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
+  border-top: 0;
+  border-top-right-radius: 1px;
+  border-top-left-radius: 1px;
+}
+.panel > .list-group:last-child .list-group-item:last-child,
+.panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
+  border-bottom: 0;
+  border-bottom-right-radius: 1px;
+  border-bottom-left-radius: 1px;
+}
+.panel > .panel-heading + .panel-collapse > .list-group .list-group-item:first-child {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.panel-heading + .list-group .list-group-item:first-child {
+  border-top-width: 0;
+}
+.list-group + .panel-footer {
+  border-top-width: 0;
+}
+.panel > .table,
+.panel > .table-responsive > .table,
+.panel > .panel-collapse > .table {
+  margin-bottom: 0;
+}
+.panel > .table caption,
+.panel > .table-responsive > .table caption,
+.panel > .panel-collapse > .table caption {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.panel > .table:first-child,
+.panel > .table-responsive:first-child > .table:first-child {
+  border-top-right-radius: 1px;
+  border-top-left-radius: 1px;
+}
+.panel > .table:first-child > thead:first-child > tr:first-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child {
+  border-top-left-radius: 1px;
+  border-top-right-radius: 1px;
+}
+.panel > .table:first-child > thead:first-child > tr:first-child td:first-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:first-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child td:first-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:first-child,
+.panel > .table:first-child > thead:first-child > tr:first-child th:first-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:first-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child th:first-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child {
+  border-top-left-radius: 1px;
+}
+.panel > .table:first-child > thead:first-child > tr:first-child td:last-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:last-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child td:last-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:last-child,
+.panel > .table:first-child > thead:first-child > tr:first-child th:last-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:last-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child th:last-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child {
+  border-top-right-radius: 1px;
+}
+.panel > .table:last-child,
+.panel > .table-responsive:last-child > .table:last-child {
+  border-bottom-right-radius: 1px;
+  border-bottom-left-radius: 1px;
+}
+.panel > .table:last-child > tbody:last-child > tr:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child {
+  border-bottom-left-radius: 1px;
+  border-bottom-right-radius: 1px;
+}
+.panel > .table:last-child > tbody:last-child > tr:last-child td:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:first-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
+.panel > .table:last-child > tbody:last-child > tr:last-child th:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:first-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child th:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child {
+  border-bottom-left-radius: 1px;
+}
+.panel > .table:last-child > tbody:last-child > tr:last-child td:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:last-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
+.panel > .table:last-child > tbody:last-child > tr:last-child th:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:last-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child th:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child {
+  border-bottom-right-radius: 1px;
+}
+.panel > .panel-body + .table,
+.panel > .panel-body + .table-responsive,
+.panel > .table + .panel-body,
+.panel > .table-responsive + .panel-body {
+  border-top: 1px solid #ddd;
+}
+.panel > .table > tbody:first-child > tr:first-child th,
+.panel > .table > tbody:first-child > tr:first-child td {
+  border-top: 0;
+}
+.panel > .table-bordered,
+.panel > .table-responsive > .table-bordered {
+  border: 0;
+}
+.panel > .table-bordered > thead > tr > th:first-child,
+.panel > .table-responsive > .table-bordered > thead > tr > th:first-child,
+.panel > .table-bordered > tbody > tr > th:first-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > th:first-child,
+.panel > .table-bordered > tfoot > tr > th:first-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > th:first-child,
+.panel > .table-bordered > thead > tr > td:first-child,
+.panel > .table-responsive > .table-bordered > thead > tr > td:first-child,
+.panel > .table-bordered > tbody > tr > td:first-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > td:first-child,
+.panel > .table-bordered > tfoot > tr > td:first-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+  border-left: 0;
+}
+.panel > .table-bordered > thead > tr > th:last-child,
+.panel > .table-responsive > .table-bordered > thead > tr > th:last-child,
+.panel > .table-bordered > tbody > tr > th:last-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > th:last-child,
+.panel > .table-bordered > tfoot > tr > th:last-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > th:last-child,
+.panel > .table-bordered > thead > tr > td:last-child,
+.panel > .table-responsive > .table-bordered > thead > tr > td:last-child,
+.panel > .table-bordered > tbody > tr > td:last-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > td:last-child,
+.panel > .table-bordered > tfoot > tr > td:last-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+  border-right: 0;
+}
+.panel > .table-bordered > thead > tr:first-child > td,
+.panel > .table-responsive > .table-bordered > thead > tr:first-child > td,
+.panel > .table-bordered > tbody > tr:first-child > td,
+.panel > .table-responsive > .table-bordered > tbody > tr:first-child > td,
+.panel > .table-bordered > thead > tr:first-child > th,
+.panel > .table-responsive > .table-bordered > thead > tr:first-child > th,
+.panel > .table-bordered > tbody > tr:first-child > th,
+.panel > .table-responsive > .table-bordered > tbody > tr:first-child > th {
+  border-bottom: 0;
+}
+.panel > .table-bordered > tbody > tr:last-child > td,
+.panel > .table-responsive > .table-bordered > tbody > tr:last-child > td,
+.panel > .table-bordered > tfoot > tr:last-child > td,
+.panel > .table-responsive > .table-bordered > tfoot > tr:last-child > td,
+.panel > .table-bordered > tbody > tr:last-child > th,
+.panel > .table-responsive > .table-bordered > tbody > tr:last-child > th,
+.panel > .table-bordered > tfoot > tr:last-child > th,
+.panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th {
+  border-bottom: 0;
+}
+.panel > .table-responsive {
+  border: 0;
+  margin-bottom: 0;
+}
+.panel-group {
+  margin-bottom: 18px;
+}
+.panel-group .panel {
+  margin-bottom: 0;
+  border-radius: 2px;
+}
+.panel-group .panel + .panel {
+  margin-top: 5px;
+}
+.panel-group .panel-heading {
+  border-bottom: 0;
+}
+.panel-group .panel-heading + .panel-collapse > .panel-body,
+.panel-group .panel-heading + .panel-collapse > .list-group {
+  border-top: 1px solid #ddd;
+}
+.panel-group .panel-footer {
+  border-top: 0;
+}
+.panel-group .panel-footer + .panel-collapse .panel-body {
+  border-bottom: 1px solid #ddd;
+}
+.panel-default {
+  border-color: #ddd;
+}
+.panel-default > .panel-heading {
+  color: #333333;
+  background-color: #f5f5f5;
+  border-color: #ddd;
+}
+.panel-default > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #ddd;
+}
+.panel-default > .panel-heading .badge {
+  color: #f5f5f5;
+  background-color: #333333;
+}
+.panel-default > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #ddd;
+}
+.panel-primary {
+  border-color: #337ab7;
+}
+.panel-primary > .panel-heading {
+  color: #fff;
+  background-color: #337ab7;
+  border-color: #337ab7;
+}
+.panel-primary > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #337ab7;
+}
+.panel-primary > .panel-heading .badge {
+  color: #337ab7;
+  background-color: #fff;
+}
+.panel-primary > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #337ab7;
+}
+.panel-success {
+  border-color: #d6e9c6;
+}
+.panel-success > .panel-heading {
+  color: #3c763d;
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+}
+.panel-success > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #d6e9c6;
+}
+.panel-success > .panel-heading .badge {
+  color: #dff0d8;
+  background-color: #3c763d;
+}
+.panel-success > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #d6e9c6;
+}
+.panel-info {
+  border-color: #bce8f1;
+}
+.panel-info > .panel-heading {
+  color: #31708f;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+.panel-info > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #bce8f1;
+}
+.panel-info > .panel-heading .badge {
+  color: #d9edf7;
+  background-color: #31708f;
+}
+.panel-info > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #bce8f1;
+}
+.panel-warning {
+  border-color: #faebcc;
+}
+.panel-warning > .panel-heading {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+}
+.panel-warning > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #faebcc;
+}
+.panel-warning > .panel-heading .badge {
+  color: #fcf8e3;
+  background-color: #8a6d3b;
+}
+.panel-warning > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #faebcc;
+}
+.panel-danger {
+  border-color: #ebccd1;
+}
+.panel-danger > .panel-heading {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+}
+.panel-danger > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #ebccd1;
+}
+.panel-danger > .panel-heading .badge {
+  color: #f2dede;
+  background-color: #a94442;
+}
+.panel-danger > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #ebccd1;
+}
+.embed-responsive {
+  position: relative;
+  display: block;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+}
+.embed-responsive .embed-responsive-item,
+.embed-responsive iframe,
+.embed-responsive embed,
+.embed-responsive object,
+.embed-responsive video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+  border: 0;
+}
+.embed-responsive-16by9 {
+  padding-bottom: 56.25%;
+}
+.embed-responsive-4by3 {
+  padding-bottom: 75%;
+}
+.well {
+  min-height: 20px;
+  padding: 19px;
+  margin-bottom: 20px;
+  background-color: #f5f5f5;
+  border: 1px solid #e3e3e3;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+.well blockquote {
+  border-color: #ddd;
+  border-color: rgba(0, 0, 0, 0.15);
+}
+.well-lg {
+  padding: 24px;
+  border-radius: 3px;
+}
+.well-sm {
+  padding: 9px;
+  border-radius: 1px;
+}
+.close {
+  float: right;
+  font-size: 19.5px;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  text-shadow: 0 1px 0 #fff;
+  opacity: 0.2;
+  filter: alpha(opacity=20);
+}
+.close:hover,
+.close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+}
+button.close {
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  -webkit-appearance: none;
+}
+.modal-open {
+  overflow: hidden;
+}
+.modal {
+  display: none;
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1050;
+  -webkit-overflow-scrolling: touch;
+  outline: 0;
+}
+.modal.fade .modal-dialog {
+  -webkit-transform: translate(0, -25%);
+  -ms-transform: translate(0, -25%);
+  -o-transform: translate(0, -25%);
+  transform: translate(0, -25%);
+  -webkit-transition: -webkit-transform 0.3s ease-out;
+  -moz-transition: -moz-transform 0.3s ease-out;
+  -o-transition: -o-transform 0.3s ease-out;
+  transition: transform 0.3s ease-out;
+}
+.modal.in .modal-dialog {
+  -webkit-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.modal-open .modal {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.modal-dialog {
+  position: relative;
+  width: auto;
+  margin: 10px;
+}
+.modal-content {
+  position: relative;
+  background-color: #fff;
+  border: 1px solid #999;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  background-clip: padding-box;
+  outline: 0;
+}
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1040;
+  background-color: #000;
+}
+.modal-backdrop.fade {
+  opacity: 0;
+  filter: alpha(opacity=0);
+}
+.modal-backdrop.in {
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+}
+.modal-header {
+  padding: 15px;
+  border-bottom: 1px solid #e5e5e5;
+}
+.modal-header .close {
+  margin-top: -2px;
+}
+.modal-title {
+  margin: 0;
+  line-height: 1.42857143;
+}
+.modal-body {
+  position: relative;
+  padding: 15px;
+}
+.modal-footer {
+  padding: 15px;
+  text-align: right;
+  border-top: 1px solid #e5e5e5;
+}
+.modal-footer .btn + .btn {
+  margin-left: 5px;
+  margin-bottom: 0;
+}
+.modal-footer .btn-group .btn + .btn {
+  margin-left: -1px;
+}
+.modal-footer .btn-block + .btn-block {
+  margin-left: 0;
+}
+.modal-scrollbar-measure {
+  position: absolute;
+  top: -9999px;
+  width: 50px;
+  height: 50px;
+  overflow: scroll;
+}
+@media (min-width: 768px) {
+  .modal-dialog {
+    width: 600px;
+    margin: 30px auto;
+  }
+  .modal-content {
+    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+  }
+  .modal-sm {
+    width: 300px;
+  }
+}
+@media (min-width: 992px) {
+  .modal-lg {
+    width: 900px;
+  }
+}
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  display: block;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  line-break: auto;
+  line-height: 1.42857143;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+  font-size: 12px;
+  opacity: 0;
+  filter: alpha(opacity=0);
+}
+.tooltip.in {
+  opacity: 0.9;
+  filter: alpha(opacity=90);
+}
+.tooltip.top {
+  margin-top: -3px;
+  padding: 5px 0;
+}
+.tooltip.right {
+  margin-left: 3px;
+  padding: 0 5px;
+}
+.tooltip.bottom {
+  margin-top: 3px;
+  padding: 5px 0;
+}
+.tooltip.left {
+  margin-left: -3px;
+  padding: 0 5px;
+}
+.tooltip-inner {
+  max-width: 200px;
+  padding: 3px 8px;
+  color: #fff;
+  text-align: center;
+  background-color: #000;
+  border-radius: 2px;
+}
+.tooltip-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+.tooltip.top .tooltip-arrow {
+  bottom: 0;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000;
+}
+.tooltip.top-left .tooltip-arrow {
+  bottom: 0;
+  right: 5px;
+  margin-bottom: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000;
+}
+.tooltip.top-right .tooltip-arrow {
+  bottom: 0;
+  left: 5px;
+  margin-bottom: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000;
+}
+.tooltip.right .tooltip-arrow {
+  top: 50%;
+  left: 0;
+  margin-top: -5px;
+  border-width: 5px 5px 5px 0;
+  border-right-color: #000;
+}
+.tooltip.left .tooltip-arrow {
+  top: 50%;
+  right: 0;
+  margin-top: -5px;
+  border-width: 5px 0 5px 5px;
+  border-left-color: #000;
+}
+.tooltip.bottom .tooltip-arrow {
+  top: 0;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: #000;
+}
+.tooltip.bottom-left .tooltip-arrow {
+  top: 0;
+  right: 5px;
+  margin-top: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: #000;
+}
+.tooltip.bottom-right .tooltip-arrow {
+  top: 0;
+  left: 5px;
+  margin-top: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: #000;
+}
+.popover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1060;
+  display: none;
+  max-width: 276px;
+  padding: 1px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  line-break: auto;
+  line-height: 1.42857143;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+  font-size: 13px;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+}
+.popover.top {
+  margin-top: -10px;
+}
+.popover.right {
+  margin-left: 10px;
+}
+.popover.bottom {
+  margin-top: 10px;
+}
+.popover.left {
+  margin-left: -10px;
+}
+.popover-title {
+  margin: 0;
+  padding: 8px 14px;
+  font-size: 13px;
+  background-color: #f7f7f7;
+  border-bottom: 1px solid #ebebeb;
+  border-radius: 2px 2px 0 0;
+}
+.popover-content {
+  padding: 9px 14px;
+}
+.popover > .arrow,
+.popover > .arrow:after {
+  position: absolute;
+  display: block;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+.popover > .arrow {
+  border-width: 11px;
+}
+.popover > .arrow:after {
+  border-width: 10px;
+  content: "";
+}
+.popover.top > .arrow {
+  left: 50%;
+  margin-left: -11px;
+  border-bottom-width: 0;
+  border-top-color: #999999;
+  border-top-color: rgba(0, 0, 0, 0.25);
+  bottom: -11px;
+}
+.popover.top > .arrow:after {
+  content: " ";
+  bottom: 1px;
+  margin-left: -10px;
+  border-bottom-width: 0;
+  border-top-color: #fff;
+}
+.popover.right > .arrow {
+  top: 50%;
+  left: -11px;
+  margin-top: -11px;
+  border-left-width: 0;
+  border-right-color: #999999;
+  border-right-color: rgba(0, 0, 0, 0.25);
+}
+.popover.right > .arrow:after {
+  content: " ";
+  left: 1px;
+  bottom: -10px;
+  border-left-width: 0;
+  border-right-color: #fff;
+}
+.popover.bottom > .arrow {
+  left: 50%;
+  margin-left: -11px;
+  border-top-width: 0;
+  border-bottom-color: #999999;
+  border-bottom-color: rgba(0, 0, 0, 0.25);
+  top: -11px;
+}
+.popover.bottom > .arrow:after {
+  content: " ";
+  top: 1px;
+  margin-left: -10px;
+  border-top-width: 0;
+  border-bottom-color: #fff;
+}
+.popover.left > .arrow {
+  top: 50%;
+  right: -11px;
+  margin-top: -11px;
+  border-right-width: 0;
+  border-left-color: #999999;
+  border-left-color: rgba(0, 0, 0, 0.25);
+}
+.popover.left > .arrow:after {
+  content: " ";
+  right: 1px;
+  border-right-width: 0;
+  border-left-color: #fff;
+  bottom: -10px;
+}
+.carousel {
+  position: relative;
+}
+.carousel-inner {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+}
+.carousel-inner > .item {
+  display: none;
+  position: relative;
+  -webkit-transition: 0.6s ease-in-out left;
+  -o-transition: 0.6s ease-in-out left;
+  transition: 0.6s ease-in-out left;
+}
+.carousel-inner > .item > img,
+.carousel-inner > .item > a > img {
+  line-height: 1;
+}
+@media all and (transform-3d), (-webkit-transform-3d) {
+  .carousel-inner > .item {
+    -webkit-transition: -webkit-transform 0.6s ease-in-out;
+    -moz-transition: -moz-transform 0.6s ease-in-out;
+    -o-transition: -o-transform 0.6s ease-in-out;
+    transition: transform 0.6s ease-in-out;
+    -webkit-backface-visibility: hidden;
+    -moz-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -webkit-perspective: 1000px;
+    -moz-perspective: 1000px;
+    perspective: 1000px;
+  }
+  .carousel-inner > .item.next,
+  .carousel-inner > .item.active.right {
+    -webkit-transform: translate3d(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);
+    left: 0;
+  }
+  .carousel-inner > .item.prev,
+  .carousel-inner > .item.active.left {
+    -webkit-transform: translate3d(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0);
+    left: 0;
+  }
+  .carousel-inner > .item.next.left,
+  .carousel-inner > .item.prev.right,
+  .carousel-inner > .item.active {
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+    left: 0;
+  }
+}
+.carousel-inner > .active,
+.carousel-inner > .next,
+.carousel-inner > .prev {
+  display: block;
+}
+.carousel-inner > .active {
+  left: 0;
+}
+.carousel-inner > .next,
+.carousel-inner > .prev {
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+.carousel-inner > .next {
+  left: 100%;
+}
+.carousel-inner > .prev {
+  left: -100%;
+}
+.carousel-inner > .next.left,
+.carousel-inner > .prev.right {
+  left: 0;
+}
+.carousel-inner > .active.left {
+  left: -100%;
+}
+.carousel-inner > .active.right {
+  left: 100%;
+}
+.carousel-control {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 15%;
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+  font-size: 20px;
+  color: #fff;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0);
+}
+.carousel-control.left {
+  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+  background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1);
+}
+.carousel-control.right {
+  left: auto;
+  right: 0;
+  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+  background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1);
+}
+.carousel-control:hover,
+.carousel-control:focus {
+  outline: 0;
+  color: #fff;
+  text-decoration: none;
+  opacity: 0.9;
+  filter: alpha(opacity=90);
+}
+.carousel-control .icon-prev,
+.carousel-control .icon-next,
+.carousel-control .glyphicon-chevron-left,
+.carousel-control .glyphicon-chevron-right {
+  position: absolute;
+  top: 50%;
+  margin-top: -10px;
+  z-index: 5;
+  display: inline-block;
+}
+.carousel-control .icon-prev,
+.carousel-control .glyphicon-chevron-left {
+  left: 50%;
+  margin-left: -10px;
+}
+.carousel-control .icon-next,
+.carousel-control .glyphicon-chevron-right {
+  right: 50%;
+  margin-right: -10px;
+}
+.carousel-control .icon-prev,
+.carousel-control .icon-next {
+  width: 20px;
+  height: 20px;
+  line-height: 1;
+  font-family: serif;
+}
+.carousel-control .icon-prev:before {
+  content: '\2039';
+}
+.carousel-control .icon-next:before {
+  content: '\203a';
+}
+.carousel-indicators {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  z-index: 15;
+  width: 60%;
+  margin-left: -30%;
+  padding-left: 0;
+  list-style: none;
+  text-align: center;
+}
+.carousel-indicators li {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin: 1px;
+  text-indent: -999px;
+  border: 1px solid #fff;
+  border-radius: 10px;
+  cursor: pointer;
+  background-color: #000 \9;
+  background-color: rgba(0, 0, 0, 0);
+}
+.carousel-indicators .active {
+  margin: 0;
+  width: 12px;
+  height: 12px;
+  background-color: #fff;
+}
+.carousel-caption {
+  position: absolute;
+  left: 15%;
+  right: 15%;
+  bottom: 20px;
+  z-index: 10;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: #fff;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+.carousel-caption .btn {
+  text-shadow: none;
+}
+@media screen and (min-width: 768px) {
+  .carousel-control .glyphicon-chevron-left,
+  .carousel-control .glyphicon-chevron-right,
+  .carousel-control .icon-prev,
+  .carousel-control .icon-next {
+    width: 30px;
+    height: 30px;
+    margin-top: -10px;
+    font-size: 30px;
+  }
+  .carousel-control .glyphicon-chevron-left,
+  .carousel-control .icon-prev {
+    margin-left: -10px;
+  }
+  .carousel-control .glyphicon-chevron-right,
+  .carousel-control .icon-next {
+    margin-right: -10px;
+  }
+  .carousel-caption {
+    left: 20%;
+    right: 20%;
+    padding-bottom: 30px;
+  }
+  .carousel-indicators {
+    bottom: 20px;
+  }
+}
+.clearfix:before,
+.clearfix:after,
+.dl-horizontal dd:before,
+.dl-horizontal dd:after,
+.container:before,
+.container:after,
+.container-fluid:before,
+.container-fluid:after,
+.row:before,
+.row:after,
+.form-horizontal .form-group:before,
+.form-horizontal .form-group:after,
+.btn-toolbar:before,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:before,
+.btn-group-vertical > .btn-group:after,
+.nav:before,
+.nav:after,
+.navbar:before,
+.navbar:after,
+.navbar-header:before,
+.navbar-header:after,
+.navbar-collapse:before,
+.navbar-collapse:after,
+.pager:before,
+.pager:after,
+.panel-body:before,
+.panel-body:after,
+.modal-header:before,
+.modal-header:after,
+.modal-footer:before,
+.modal-footer:after,
+.item_buttons:before,
+.item_buttons:after {
+  content: " ";
+  display: table;
+}
+.clearfix:after,
+.dl-horizontal dd:after,
+.container:after,
+.container-fluid:after,
+.row:after,
+.form-horizontal .form-group:after,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:after,
+.nav:after,
+.navbar:after,
+.navbar-header:after,
+.navbar-collapse:after,
+.pager:after,
+.panel-body:after,
+.modal-header:after,
+.modal-footer:after,
+.item_buttons:after {
+  clear: both;
+}
+.center-block {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.pull-right {
+  float: right !important;
+}
+.pull-left {
+  float: left !important;
+}
+.hide {
+  display: none !important;
+}
+.show {
+  display: block !important;
+}
+.invisible {
+  visibility: hidden;
+}
+.text-hide {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+.hidden {
+  display: none !important;
+}
+.affix {
+  position: fixed;
+}
+@-ms-viewport {
+  width: device-width;
+}
+.visible-xs,
+.visible-sm,
+.visible-md,
+.visible-lg {
+  display: none !important;
+}
+.visible-xs-block,
+.visible-xs-inline,
+.visible-xs-inline-block,
+.visible-sm-block,
+.visible-sm-inline,
+.visible-sm-inline-block,
+.visible-md-block,
+.visible-md-inline,
+.visible-md-inline-block,
+.visible-lg-block,
+.visible-lg-inline,
+.visible-lg-inline-block {
+  display: none !important;
+}
+@media (max-width: 767px) {
+  .visible-xs {
+    display: block !important;
+  }
+  table.visible-xs {
+    display: table !important;
+  }
+  tr.visible-xs {
+    display: table-row !important;
+  }
+  th.visible-xs,
+  td.visible-xs {
+    display: table-cell !important;
+  }
+}
+@media (max-width: 767px) {
+  .visible-xs-block {
+    display: block !important;
+  }
+}
+@media (max-width: 767px) {
+  .visible-xs-inline {
+    display: inline !important;
+  }
+}
+@media (max-width: 767px) {
+  .visible-xs-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm {
+    display: block !important;
+  }
+  table.visible-sm {
+    display: table !important;
+  }
+  tr.visible-sm {
+    display: table-row !important;
+  }
+  th.visible-sm,
+  td.visible-sm {
+    display: table-cell !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm-block {
+    display: block !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm-inline {
+    display: inline !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md {
+    display: block !important;
+  }
+  table.visible-md {
+    display: table !important;
+  }
+  tr.visible-md {
+    display: table-row !important;
+  }
+  th.visible-md,
+  td.visible-md {
+    display: table-cell !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md-block {
+    display: block !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md-inline {
+    display: inline !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg {
+    display: block !important;
+  }
+  table.visible-lg {
+    display: table !important;
+  }
+  tr.visible-lg {
+    display: table-row !important;
+  }
+  th.visible-lg,
+  td.visible-lg {
+    display: table-cell !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg-block {
+    display: block !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg-inline {
+    display: inline !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (max-width: 767px) {
+  .hidden-xs {
+    display: none !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .hidden-sm {
+    display: none !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .hidden-md {
+    display: none !important;
+  }
+}
+@media (min-width: 1200px) {
+  .hidden-lg {
+    display: none !important;
+  }
+}
+.visible-print {
+  display: none !important;
+}
+@media print {
+  .visible-print {
+    display: block !important;
+  }
+  table.visible-print {
+    display: table !important;
+  }
+  tr.visible-print {
+    display: table-row !important;
+  }
+  th.visible-print,
+  td.visible-print {
+    display: table-cell !important;
+  }
+}
+.visible-print-block {
+  display: none !important;
+}
+@media print {
+  .visible-print-block {
+    display: block !important;
+  }
+}
+.visible-print-inline {
+  display: none !important;
+}
+@media print {
+  .visible-print-inline {
+    display: inline !important;
+  }
+}
+.visible-print-inline-block {
+  display: none !important;
+}
+@media print {
+  .visible-print-inline-block {
+    display: inline-block !important;
+  }
+}
+@media print {
+  .hidden-print {
+    display: none !important;
+  }
+}
+/*!
+*
+* Font Awesome
+*
+*/
+/*!
+ *  Font Awesome 4.7.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+ */
+/* FONT PATH
+ * -------------------------- */
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.7.0');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.7.0') format('embedded-opentype'), url('../components/font-awesome/fonts/fontawesome-webfont.woff2?v=4.7.0') format('woff2'), url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.7.0') format('woff'), url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.7.0') format('truetype'), url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+.fa {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+/* makes the font 33% larger relative to the icon container */
+.fa-lg {
+  font-size: 1.33333333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}
+.fa-2x {
+  font-size: 2em;
+}
+.fa-3x {
+  font-size: 3em;
+}
+.fa-4x {
+  font-size: 4em;
+}
+.fa-5x {
+  font-size: 5em;
+}
+.fa-fw {
+  width: 1.28571429em;
+  text-align: center;
+}
+.fa-ul {
+  padding-left: 0;
+  margin-left: 2.14285714em;
+  list-style-type: none;
+}
+.fa-ul > li {
+  position: relative;
+}
+.fa-li {
+  position: absolute;
+  left: -2.14285714em;
+  width: 2.14285714em;
+  top: 0.14285714em;
+  text-align: center;
+}
+.fa-li.fa-lg {
+  left: -1.85714286em;
+}
+.fa-border {
+  padding: .2em .25em .15em;
+  border: solid 0.08em #eee;
+  border-radius: .1em;
+}
+.fa-pull-left {
+  float: left;
+}
+.fa-pull-right {
+  float: right;
+}
+.fa.fa-pull-left {
+  margin-right: .3em;
+}
+.fa.fa-pull-right {
+  margin-left: .3em;
+}
+/* Deprecated as of 4.4.0 */
+.pull-right {
+  float: right;
+}
+.pull-left {
+  float: left;
+}
+.fa.pull-left {
+  margin-right: .3em;
+}
+.fa.pull-right {
+  margin-left: .3em;
+}
+.fa-spin {
+  -webkit-animation: fa-spin 2s infinite linear;
+  animation: fa-spin 2s infinite linear;
+}
+.fa-pulse {
+  -webkit-animation: fa-spin 1s infinite steps(8);
+  animation: fa-spin 1s infinite steps(8);
+}
+@-webkit-keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+.fa-rotate-90 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+  -webkit-transform: rotate(90deg);
+  -ms-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+.fa-rotate-180 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+.fa-rotate-270 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+  -webkit-transform: rotate(270deg);
+  -ms-transform: rotate(270deg);
+  transform: rotate(270deg);
+}
+.fa-flip-horizontal {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+  -webkit-transform: scale(-1, 1);
+  -ms-transform: scale(-1, 1);
+  transform: scale(-1, 1);
+}
+.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  -webkit-transform: scale(1, -1);
+  -ms-transform: scale(1, -1);
+  transform: scale(1, -1);
+}
+:root .fa-rotate-90,
+:root .fa-rotate-180,
+:root .fa-rotate-270,
+:root .fa-flip-horizontal,
+:root .fa-flip-vertical {
+  filter: none;
+}
+.fa-stack {
+  position: relative;
+  display: inline-block;
+  width: 2em;
+  height: 2em;
+  line-height: 2em;
+  vertical-align: middle;
+}
+.fa-stack-1x,
+.fa-stack-2x {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  text-align: center;
+}
+.fa-stack-1x {
+  line-height: inherit;
+}
+.fa-stack-2x {
+  font-size: 2em;
+}
+.fa-inverse {
+  color: #fff;
+}
+/* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+   readers do not read off random characters that represent icons */
+.fa-glass:before {
+  content: "\f000";
+}
+.fa-music:before {
+  content: "\f001";
+}
+.fa-search:before {
+  content: "\f002";
+}
+.fa-envelope-o:before {
+  content: "\f003";
+}
+.fa-heart:before {
+  content: "\f004";
+}
+.fa-star:before {
+  content: "\f005";
+}
+.fa-star-o:before {
+  content: "\f006";
+}
+.fa-user:before {
+  content: "\f007";
+}
+.fa-film:before {
+  content: "\f008";
+}
+.fa-th-large:before {
+  content: "\f009";
+}
+.fa-th:before {
+  content: "\f00a";
+}
+.fa-th-list:before {
+  content: "\f00b";
+}
+.fa-check:before {
+  content: "\f00c";
+}
+.fa-remove:before,
+.fa-close:before,
+.fa-times:before {
+  content: "\f00d";
+}
+.fa-search-plus:before {
+  content: "\f00e";
+}
+.fa-search-minus:before {
+  content: "\f010";
+}
+.fa-power-off:before {
+  content: "\f011";
+}
+.fa-signal:before {
+  content: "\f012";
+}
+.fa-gear:before,
+.fa-cog:before {
+  content: "\f013";
+}
+.fa-trash-o:before {
+  content: "\f014";
+}
+.fa-home:before {
+  content: "\f015";
+}
+.fa-file-o:before {
+  content: "\f016";
+}
+.fa-clock-o:before {
+  content: "\f017";
+}
+.fa-road:before {
+  content: "\f018";
+}
+.fa-download:before {
+  content: "\f019";
+}
+.fa-arrow-circle-o-down:before {
+  content: "\f01a";
+}
+.fa-arrow-circle-o-up:before {
+  content: "\f01b";
+}
+.fa-inbox:before {
+  content: "\f01c";
+}
+.fa-play-circle-o:before {
+  content: "\f01d";
+}
+.fa-rotate-right:before,
+.fa-repeat:before {
+  content: "\f01e";
+}
+.fa-refresh:before {
+  content: "\f021";
+}
+.fa-list-alt:before {
+  content: "\f022";
+}
+.fa-lock:before {
+  content: "\f023";
+}
+.fa-flag:before {
+  content: "\f024";
+}
+.fa-headphones:before {
+  content: "\f025";
+}
+.fa-volume-off:before {
+  content: "\f026";
+}
+.fa-volume-down:before {
+  content: "\f027";
+}
+.fa-volume-up:before {
+  content: "\f028";
+}
+.fa-qrcode:before {
+  content: "\f029";
+}
+.fa-barcode:before {
+  content: "\f02a";
+}
+.fa-tag:before {
+  content: "\f02b";
+}
+.fa-tags:before {
+  content: "\f02c";
+}
+.fa-book:before {
+  content: "\f02d";
+}
+.fa-bookmark:before {
+  content: "\f02e";
+}
+.fa-print:before {
+  content: "\f02f";
+}
+.fa-camera:before {
+  content: "\f030";
+}
+.fa-font:before {
+  content: "\f031";
+}
+.fa-bold:before {
+  content: "\f032";
+}
+.fa-italic:before {
+  content: "\f033";
+}
+.fa-text-height:before {
+  content: "\f034";
+}
+.fa-text-width:before {
+  content: "\f035";
+}
+.fa-align-left:before {
+  content: "\f036";
+}
+.fa-align-center:before {
+  content: "\f037";
+}
+.fa-align-right:before {
+  content: "\f038";
+}
+.fa-align-justify:before {
+  content: "\f039";
+}
+.fa-list:before {
+  content: "\f03a";
+}
+.fa-dedent:before,
+.fa-outdent:before {
+  content: "\f03b";
+}
+.fa-indent:before {
+  content: "\f03c";
+}
+.fa-video-camera:before {
+  content: "\f03d";
+}
+.fa-photo:before,
+.fa-image:before,
+.fa-picture-o:before {
+  content: "\f03e";
+}
+.fa-pencil:before {
+  content: "\f040";
+}
+.fa-map-marker:before {
+  content: "\f041";
+}
+.fa-adjust:before {
+  content: "\f042";
+}
+.fa-tint:before {
+  content: "\f043";
+}
+.fa-edit:before,
+.fa-pencil-square-o:before {
+  content: "\f044";
+}
+.fa-share-square-o:before {
+  content: "\f045";
+}
+.fa-check-square-o:before {
+  content: "\f046";
+}
+.fa-arrows:before {
+  content: "\f047";
+}
+.fa-step-backward:before {
+  content: "\f048";
+}
+.fa-fast-backward:before {
+  content: "\f049";
+}
+.fa-backward:before {
+  content: "\f04a";
+}
+.fa-play:before {
+  content: "\f04b";
+}
+.fa-pause:before {
+  content: "\f04c";
+}
+.fa-stop:before {
+  content: "\f04d";
+}
+.fa-forward:before {
+  content: "\f04e";
+}
+.fa-fast-forward:before {
+  content: "\f050";
+}
+.fa-step-forward:before {
+  content: "\f051";
+}
+.fa-eject:before {
+  content: "\f052";
+}
+.fa-chevron-left:before {
+  content: "\f053";
+}
+.fa-chevron-right:before {
+  content: "\f054";
+}
+.fa-plus-circle:before {
+  content: "\f055";
+}
+.fa-minus-circle:before {
+  content: "\f056";
+}
+.fa-times-circle:before {
+  content: "\f057";
+}
+.fa-check-circle:before {
+  content: "\f058";
+}
+.fa-question-circle:before {
+  content: "\f059";
+}
+.fa-info-circle:before {
+  content: "\f05a";
+}
+.fa-crosshairs:before {
+  content: "\f05b";
+}
+.fa-times-circle-o:before {
+  content: "\f05c";
+}
+.fa-check-circle-o:before {
+  content: "\f05d";
+}
+.fa-ban:before {
+  content: "\f05e";
+}
+.fa-arrow-left:before {
+  content: "\f060";
+}
+.fa-arrow-right:before {
+  content: "\f061";
+}
+.fa-arrow-up:before {
+  content: "\f062";
+}
+.fa-arrow-down:before {
+  content: "\f063";
+}
+.fa-mail-forward:before,
+.fa-share:before {
+  content: "\f064";
+}
+.fa-expand:before {
+  content: "\f065";
+}
+.fa-compress:before {
+  content: "\f066";
+}
+.fa-plus:before {
+  content: "\f067";
+}
+.fa-minus:before {
+  content: "\f068";
+}
+.fa-asterisk:before {
+  content: "\f069";
+}
+.fa-exclamation-circle:before {
+  content: "\f06a";
+}
+.fa-gift:before {
+  content: "\f06b";
+}
+.fa-leaf:before {
+  content: "\f06c";
+}
+.fa-fire:before {
+  content: "\f06d";
+}
+.fa-eye:before {
+  content: "\f06e";
+}
+.fa-eye-slash:before {
+  content: "\f070";
+}
+.fa-warning:before,
+.fa-exclamation-triangle:before {
+  content: "\f071";
+}
+.fa-plane:before {
+  content: "\f072";
+}
+.fa-calendar:before {
+  content: "\f073";
+}
+.fa-random:before {
+  content: "\f074";
+}
+.fa-comment:before {
+  content: "\f075";
+}
+.fa-magnet:before {
+  content: "\f076";
+}
+.fa-chevron-up:before {
+  content: "\f077";
+}
+.fa-chevron-down:before {
+  content: "\f078";
+}
+.fa-retweet:before {
+  content: "\f079";
+}
+.fa-shopping-cart:before {
+  content: "\f07a";
+}
+.fa-folder:before {
+  content: "\f07b";
+}
+.fa-folder-open:before {
+  content: "\f07c";
+}
+.fa-arrows-v:before {
+  content: "\f07d";
+}
+.fa-arrows-h:before {
+  content: "\f07e";
+}
+.fa-bar-chart-o:before,
+.fa-bar-chart:before {
+  content: "\f080";
+}
+.fa-twitter-square:before {
+  content: "\f081";
+}
+.fa-facebook-square:before {
+  content: "\f082";
+}
+.fa-camera-retro:before {
+  content: "\f083";
+}
+.fa-key:before {
+  content: "\f084";
+}
+.fa-gears:before,
+.fa-cogs:before {
+  content: "\f085";
+}
+.fa-comments:before {
+  content: "\f086";
+}
+.fa-thumbs-o-up:before {
+  content: "\f087";
+}
+.fa-thumbs-o-down:before {
+  content: "\f088";
+}
+.fa-star-half:before {
+  content: "\f089";
+}
+.fa-heart-o:before {
+  content: "\f08a";
+}
+.fa-sign-out:before {
+  content: "\f08b";
+}
+.fa-linkedin-square:before {
+  content: "\f08c";
+}
+.fa-thumb-tack:before {
+  content: "\f08d";
+}
+.fa-external-link:before {
+  content: "\f08e";
+}
+.fa-sign-in:before {
+  content: "\f090";
+}
+.fa-trophy:before {
+  content: "\f091";
+}
+.fa-github-square:before {
+  content: "\f092";
+}
+.fa-upload:before {
+  content: "\f093";
+}
+.fa-lemon-o:before {
+  content: "\f094";
+}
+.fa-phone:before {
+  content: "\f095";
+}
+.fa-square-o:before {
+  content: "\f096";
+}
+.fa-bookmark-o:before {
+  content: "\f097";
+}
+.fa-phone-square:before {
+  content: "\f098";
+}
+.fa-twitter:before {
+  content: "\f099";
+}
+.fa-facebook-f:before,
+.fa-facebook:before {
+  content: "\f09a";
+}
+.fa-github:before {
+  content: "\f09b";
+}
+.fa-unlock:before {
+  content: "\f09c";
+}
+.fa-credit-card:before {
+  content: "\f09d";
+}
+.fa-feed:before,
+.fa-rss:before {
+  content: "\f09e";
+}
+.fa-hdd-o:before {
+  content: "\f0a0";
+}
+.fa-bullhorn:before {
+  content: "\f0a1";
+}
+.fa-bell:before {
+  content: "\f0f3";
+}
+.fa-certificate:before {
+  content: "\f0a3";
+}
+.fa-hand-o-right:before {
+  content: "\f0a4";
+}
+.fa-hand-o-left:before {
+  content: "\f0a5";
+}
+.fa-hand-o-up:before {
+  content: "\f0a6";
+}
+.fa-hand-o-down:before {
+  content: "\f0a7";
+}
+.fa-arrow-circle-left:before {
+  content: "\f0a8";
+}
+.fa-arrow-circle-right:before {
+  content: "\f0a9";
+}
+.fa-arrow-circle-up:before {
+  content: "\f0aa";
+}
+.fa-arrow-circle-down:before {
+  content: "\f0ab";
+}
+.fa-globe:before {
+  content: "\f0ac";
+}
+.fa-wrench:before {
+  content: "\f0ad";
+}
+.fa-tasks:before {
+  content: "\f0ae";
+}
+.fa-filter:before {
+  content: "\f0b0";
+}
+.fa-briefcase:before {
+  content: "\f0b1";
+}
+.fa-arrows-alt:before {
+  content: "\f0b2";
+}
+.fa-group:before,
+.fa-users:before {
+  content: "\f0c0";
+}
+.fa-chain:before,
+.fa-link:before {
+  content: "\f0c1";
+}
+.fa-cloud:before {
+  content: "\f0c2";
+}
+.fa-flask:before {
+  content: "\f0c3";
+}
+.fa-cut:before,
+.fa-scissors:before {
+  content: "\f0c4";
+}
+.fa-copy:before,
+.fa-files-o:before {
+  content: "\f0c5";
+}
+.fa-paperclip:before {
+  content: "\f0c6";
+}
+.fa-save:before,
+.fa-floppy-o:before {
+  content: "\f0c7";
+}
+.fa-square:before {
+  content: "\f0c8";
+}
+.fa-navicon:before,
+.fa-reorder:before,
+.fa-bars:before {
+  content: "\f0c9";
+}
+.fa-list-ul:before {
+  content: "\f0ca";
+}
+.fa-list-ol:before {
+  content: "\f0cb";
+}
+.fa-strikethrough:before {
+  content: "\f0cc";
+}
+.fa-underline:before {
+  content: "\f0cd";
+}
+.fa-table:before {
+  content: "\f0ce";
+}
+.fa-magic:before {
+  content: "\f0d0";
+}
+.fa-truck:before {
+  content: "\f0d1";
+}
+.fa-pinterest:before {
+  content: "\f0d2";
+}
+.fa-pinterest-square:before {
+  content: "\f0d3";
+}
+.fa-google-plus-square:before {
+  content: "\f0d4";
+}
+.fa-google-plus:before {
+  content: "\f0d5";
+}
+.fa-money:before {
+  content: "\f0d6";
+}
+.fa-caret-down:before {
+  content: "\f0d7";
+}
+.fa-caret-up:before {
+  content: "\f0d8";
+}
+.fa-caret-left:before {
+  content: "\f0d9";
+}
+.fa-caret-right:before {
+  content: "\f0da";
+}
+.fa-columns:before {
+  content: "\f0db";
+}
+.fa-unsorted:before,
+.fa-sort:before {
+  content: "\f0dc";
+}
+.fa-sort-down:before,
+.fa-sort-desc:before {
+  content: "\f0dd";
+}
+.fa-sort-up:before,
+.fa-sort-asc:before {
+  content: "\f0de";
+}
+.fa-envelope:before {
+  content: "\f0e0";
+}
+.fa-linkedin:before {
+  content: "\f0e1";
+}
+.fa-rotate-left:before,
+.fa-undo:before {
+  content: "\f0e2";
+}
+.fa-legal:before,
+.fa-gavel:before {
+  content: "\f0e3";
+}
+.fa-dashboard:before,
+.fa-tachometer:before {
+  content: "\f0e4";
+}
+.fa-comment-o:before {
+  content: "\f0e5";
+}
+.fa-comments-o:before {
+  content: "\f0e6";
+}
+.fa-flash:before,
+.fa-bolt:before {
+  content: "\f0e7";
+}
+.fa-sitemap:before {
+  content: "\f0e8";
+}
+.fa-umbrella:before {
+  content: "\f0e9";
+}
+.fa-paste:before,
+.fa-clipboard:before {
+  content: "\f0ea";
+}
+.fa-lightbulb-o:before {
+  content: "\f0eb";
+}
+.fa-exchange:before {
+  content: "\f0ec";
+}
+.fa-cloud-download:before {
+  content: "\f0ed";
+}
+.fa-cloud-upload:before {
+  content: "\f0ee";
+}
+.fa-user-md:before {
+  content: "\f0f0";
+}
+.fa-stethoscope:before {
+  content: "\f0f1";
+}
+.fa-suitcase:before {
+  content: "\f0f2";
+}
+.fa-bell-o:before {
+  content: "\f0a2";
+}
+.fa-coffee:before {
+  content: "\f0f4";
+}
+.fa-cutlery:before {
+  content: "\f0f5";
+}
+.fa-file-text-o:before {
+  content: "\f0f6";
+}
+.fa-building-o:before {
+  content: "\f0f7";
+}
+.fa-hospital-o:before {
+  content: "\f0f8";
+}
+.fa-ambulance:before {
+  content: "\f0f9";
+}
+.fa-medkit:before {
+  content: "\f0fa";
+}
+.fa-fighter-jet:before {
+  content: "\f0fb";
+}
+.fa-beer:before {
+  content: "\f0fc";
+}
+.fa-h-square:before {
+  content: "\f0fd";
+}
+.fa-plus-square:before {
+  content: "\f0fe";
+}
+.fa-angle-double-left:before {
+  content: "\f100";
+}
+.fa-angle-double-right:before {
+  content: "\f101";
+}
+.fa-angle-double-up:before {
+  content: "\f102";
+}
+.fa-angle-double-down:before {
+  content: "\f103";
+}
+.fa-angle-left:before {
+  content: "\f104";
+}
+.fa-angle-right:before {
+  content: "\f105";
+}
+.fa-angle-up:before {
+  content: "\f106";
+}
+.fa-angle-down:before {
+  content: "\f107";
+}
+.fa-desktop:before {
+  content: "\f108";
+}
+.fa-laptop:before {
+  content: "\f109";
+}
+.fa-tablet:before {
+  content: "\f10a";
+}
+.fa-mobile-phone:before,
+.fa-mobile:before {
+  content: "\f10b";
+}
+.fa-circle-o:before {
+  content: "\f10c";
+}
+.fa-quote-left:before {
+  content: "\f10d";
+}
+.fa-quote-right:before {
+  content: "\f10e";
+}
+.fa-spinner:before {
+  content: "\f110";
+}
+.fa-circle:before {
+  content: "\f111";
+}
+.fa-mail-reply:before,
+.fa-reply:before {
+  content: "\f112";
+}
+.fa-github-alt:before {
+  content: "\f113";
+}
+.fa-folder-o:before {
+  content: "\f114";
+}
+.fa-folder-open-o:before {
+  content: "\f115";
+}
+.fa-smile-o:before {
+  content: "\f118";
+}
+.fa-frown-o:before {
+  content: "\f119";
+}
+.fa-meh-o:before {
+  content: "\f11a";
+}
+.fa-gamepad:before {
+  content: "\f11b";
+}
+.fa-keyboard-o:before {
+  content: "\f11c";
+}
+.fa-flag-o:before {
+  content: "\f11d";
+}
+.fa-flag-checkered:before {
+  content: "\f11e";
+}
+.fa-terminal:before {
+  content: "\f120";
+}
+.fa-code:before {
+  content: "\f121";
+}
+.fa-mail-reply-all:before,
+.fa-reply-all:before {
+  content: "\f122";
+}
+.fa-star-half-empty:before,
+.fa-star-half-full:before,
+.fa-star-half-o:before {
+  content: "\f123";
+}
+.fa-location-arrow:before {
+  content: "\f124";
+}
+.fa-crop:before {
+  content: "\f125";
+}
+.fa-code-fork:before {
+  content: "\f126";
+}
+.fa-unlink:before,
+.fa-chain-broken:before {
+  content: "\f127";
+}
+.fa-question:before {
+  content: "\f128";
+}
+.fa-info:before {
+  content: "\f129";
+}
+.fa-exclamation:before {
+  content: "\f12a";
+}
+.fa-superscript:before {
+  content: "\f12b";
+}
+.fa-subscript:before {
+  content: "\f12c";
+}
+.fa-eraser:before {
+  content: "\f12d";
+}
+.fa-puzzle-piece:before {
+  content: "\f12e";
+}
+.fa-microphone:before {
+  content: "\f130";
+}
+.fa-microphone-slash:before {
+  content: "\f131";
+}
+.fa-shield:before {
+  content: "\f132";
+}
+.fa-calendar-o:before {
+  content: "\f133";
+}
+.fa-fire-extinguisher:before {
+  content: "\f134";
+}
+.fa-rocket:before {
+  content: "\f135";
+}
+.fa-maxcdn:before {
+  content: "\f136";
+}
+.fa-chevron-circle-left:before {
+  content: "\f137";
+}
+.fa-chevron-circle-right:before {
+  content: "\f138";
+}
+.fa-chevron-circle-up:before {
+  content: "\f139";
+}
+.fa-chevron-circle-down:before {
+  content: "\f13a";
+}
+.fa-html5:before {
+  content: "\f13b";
+}
+.fa-css3:before {
+  content: "\f13c";
+}
+.fa-anchor:before {
+  content: "\f13d";
+}
+.fa-unlock-alt:before {
+  content: "\f13e";
+}
+.fa-bullseye:before {
+  content: "\f140";
+}
+.fa-ellipsis-h:before {
+  content: "\f141";
+}
+.fa-ellipsis-v:before {
+  content: "\f142";
+}
+.fa-rss-square:before {
+  content: "\f143";
+}
+.fa-play-circle:before {
+  content: "\f144";
+}
+.fa-ticket:before {
+  content: "\f145";
+}
+.fa-minus-square:before {
+  content: "\f146";
+}
+.fa-minus-square-o:before {
+  content: "\f147";
+}
+.fa-level-up:before {
+  content: "\f148";
+}
+.fa-level-down:before {
+  content: "\f149";
+}
+.fa-check-square:before {
+  content: "\f14a";
+}
+.fa-pencil-square:before {
+  content: "\f14b";
+}
+.fa-external-link-square:before {
+  content: "\f14c";
+}
+.fa-share-square:before {
+  content: "\f14d";
+}
+.fa-compass:before {
+  content: "\f14e";
+}
+.fa-toggle-down:before,
+.fa-caret-square-o-down:before {
+  content: "\f150";
+}
+.fa-toggle-up:before,
+.fa-caret-square-o-up:before {
+  content: "\f151";
+}
+.fa-toggle-right:before,
+.fa-caret-square-o-right:before {
+  content: "\f152";
+}
+.fa-euro:before,
+.fa-eur:before {
+  content: "\f153";
+}
+.fa-gbp:before {
+  content: "\f154";
+}
+.fa-dollar:before,
+.fa-usd:before {
+  content: "\f155";
+}
+.fa-rupee:before,
+.fa-inr:before {
+  content: "\f156";
+}
+.fa-cny:before,
+.fa-rmb:before,
+.fa-yen:before,
+.fa-jpy:before {
+  content: "\f157";
+}
+.fa-ruble:before,
+.fa-rouble:before,
+.fa-rub:before {
+  content: "\f158";
+}
+.fa-won:before,
+.fa-krw:before {
+  content: "\f159";
+}
+.fa-bitcoin:before,
+.fa-btc:before {
+  content: "\f15a";
+}
+.fa-file:before {
+  content: "\f15b";
+}
+.fa-file-text:before {
+  content: "\f15c";
+}
+.fa-sort-alpha-asc:before {
+  content: "\f15d";
+}
+.fa-sort-alpha-desc:before {
+  content: "\f15e";
+}
+.fa-sort-amount-asc:before {
+  content: "\f160";
+}
+.fa-sort-amount-desc:before {
+  content: "\f161";
+}
+.fa-sort-numeric-asc:before {
+  content: "\f162";
+}
+.fa-sort-numeric-desc:before {
+  content: "\f163";
+}
+.fa-thumbs-up:before {
+  content: "\f164";
+}
+.fa-thumbs-down:before {
+  content: "\f165";
+}
+.fa-youtube-square:before {
+  content: "\f166";
+}
+.fa-youtube:before {
+  content: "\f167";
+}
+.fa-xing:before {
+  content: "\f168";
+}
+.fa-xing-square:before {
+  content: "\f169";
+}
+.fa-youtube-play:before {
+  content: "\f16a";
+}
+.fa-dropbox:before {
+  content: "\f16b";
+}
+.fa-stack-overflow:before {
+  content: "\f16c";
+}
+.fa-instagram:before {
+  content: "\f16d";
+}
+.fa-flickr:before {
+  content: "\f16e";
+}
+.fa-adn:before {
+  content: "\f170";
+}
+.fa-bitbucket:before {
+  content: "\f171";
+}
+.fa-bitbucket-square:before {
+  content: "\f172";
+}
+.fa-tumblr:before {
+  content: "\f173";
+}
+.fa-tumblr-square:before {
+  content: "\f174";
+}
+.fa-long-arrow-down:before {
+  content: "\f175";
+}
+.fa-long-arrow-up:before {
+  content: "\f176";
+}
+.fa-long-arrow-left:before {
+  content: "\f177";
+}
+.fa-long-arrow-right:before {
+  content: "\f178";
+}
+.fa-apple:before {
+  content: "\f179";
+}
+.fa-windows:before {
+  content: "\f17a";
+}
+.fa-android:before {
+  content: "\f17b";
+}
+.fa-linux:before {
+  content: "\f17c";
+}
+.fa-dribbble:before {
+  content: "\f17d";
+}
+.fa-skype:before {
+  content: "\f17e";
+}
+.fa-foursquare:before {
+  content: "\f180";
+}
+.fa-trello:before {
+  content: "\f181";
+}
+.fa-female:before {
+  content: "\f182";
+}
+.fa-male:before {
+  content: "\f183";
+}
+.fa-gittip:before,
+.fa-gratipay:before {
+  content: "\f184";
+}
+.fa-sun-o:before {
+  content: "\f185";
+}
+.fa-moon-o:before {
+  content: "\f186";
+}
+.fa-archive:before {
+  content: "\f187";
+}
+.fa-bug:before {
+  content: "\f188";
+}
+.fa-vk:before {
+  content: "\f189";
+}
+.fa-weibo:before {
+  content: "\f18a";
+}
+.fa-renren:before {
+  content: "\f18b";
+}
+.fa-pagelines:before {
+  content: "\f18c";
+}
+.fa-stack-exchange:before {
+  content: "\f18d";
+}
+.fa-arrow-circle-o-right:before {
+  content: "\f18e";
+}
+.fa-arrow-circle-o-left:before {
+  content: "\f190";
+}
+.fa-toggle-left:before,
+.fa-caret-square-o-left:before {
+  content: "\f191";
+}
+.fa-dot-circle-o:before {
+  content: "\f192";
+}
+.fa-wheelchair:before {
+  content: "\f193";
+}
+.fa-vimeo-square:before {
+  content: "\f194";
+}
+.fa-turkish-lira:before,
+.fa-try:before {
+  content: "\f195";
+}
+.fa-plus-square-o:before {
+  content: "\f196";
+}
+.fa-space-shuttle:before {
+  content: "\f197";
+}
+.fa-slack:before {
+  content: "\f198";
+}
+.fa-envelope-square:before {
+  content: "\f199";
+}
+.fa-wordpress:before {
+  content: "\f19a";
+}
+.fa-openid:before {
+  content: "\f19b";
+}
+.fa-institution:before,
+.fa-bank:before,
+.fa-university:before {
+  content: "\f19c";
+}
+.fa-mortar-board:before,
+.fa-graduation-cap:before {
+  content: "\f19d";
+}
+.fa-yahoo:before {
+  content: "\f19e";
+}
+.fa-google:before {
+  content: "\f1a0";
+}
+.fa-reddit:before {
+  content: "\f1a1";
+}
+.fa-reddit-square:before {
+  content: "\f1a2";
+}
+.fa-stumbleupon-circle:before {
+  content: "\f1a3";
+}
+.fa-stumbleupon:before {
+  content: "\f1a4";
+}
+.fa-delicious:before {
+  content: "\f1a5";
+}
+.fa-digg:before {
+  content: "\f1a6";
+}
+.fa-pied-piper-pp:before {
+  content: "\f1a7";
+}
+.fa-pied-piper-alt:before {
+  content: "\f1a8";
+}
+.fa-drupal:before {
+  content: "\f1a9";
+}
+.fa-joomla:before {
+  content: "\f1aa";
+}
+.fa-language:before {
+  content: "\f1ab";
+}
+.fa-fax:before {
+  content: "\f1ac";
+}
+.fa-building:before {
+  content: "\f1ad";
+}
+.fa-child:before {
+  content: "\f1ae";
+}
+.fa-paw:before {
+  content: "\f1b0";
+}
+.fa-spoon:before {
+  content: "\f1b1";
+}
+.fa-cube:before {
+  content: "\f1b2";
+}
+.fa-cubes:before {
+  content: "\f1b3";
+}
+.fa-behance:before {
+  content: "\f1b4";
+}
+.fa-behance-square:before {
+  content: "\f1b5";
+}
+.fa-steam:before {
+  content: "\f1b6";
+}
+.fa-steam-square:before {
+  content: "\f1b7";
+}
+.fa-recycle:before {
+  content: "\f1b8";
+}
+.fa-automobile:before,
+.fa-car:before {
+  content: "\f1b9";
+}
+.fa-cab:before,
+.fa-taxi:before {
+  content: "\f1ba";
+}
+.fa-tree:before {
+  content: "\f1bb";
+}
+.fa-spotify:before {
+  content: "\f1bc";
+}
+.fa-deviantart:before {
+  content: "\f1bd";
+}
+.fa-soundcloud:before {
+  content: "\f1be";
+}
+.fa-database:before {
+  content: "\f1c0";
+}
+.fa-file-pdf-o:before {
+  content: "\f1c1";
+}
+.fa-file-word-o:before {
+  content: "\f1c2";
+}
+.fa-file-excel-o:before {
+  content: "\f1c3";
+}
+.fa-file-powerpoint-o:before {
+  content: "\f1c4";
+}
+.fa-file-photo-o:before,
+.fa-file-picture-o:before,
+.fa-file-image-o:before {
+  content: "\f1c5";
+}
+.fa-file-zip-o:before,
+.fa-file-archive-o:before {
+  content: "\f1c6";
+}
+.fa-file-sound-o:before,
+.fa-file-audio-o:before {
+  content: "\f1c7";
+}
+.fa-file-movie-o:before,
+.fa-file-video-o:before {
+  content: "\f1c8";
+}
+.fa-file-code-o:before {
+  content: "\f1c9";
+}
+.fa-vine:before {
+  content: "\f1ca";
+}
+.fa-codepen:before {
+  content: "\f1cb";
+}
+.fa-jsfiddle:before {
+  content: "\f1cc";
+}
+.fa-life-bouy:before,
+.fa-life-buoy:before,
+.fa-life-saver:before,
+.fa-support:before,
+.fa-life-ring:before {
+  content: "\f1cd";
+}
+.fa-circle-o-notch:before {
+  content: "\f1ce";
+}
+.fa-ra:before,
+.fa-resistance:before,
+.fa-rebel:before {
+  content: "\f1d0";
+}
+.fa-ge:before,
+.fa-empire:before {
+  content: "\f1d1";
+}
+.fa-git-square:before {
+  content: "\f1d2";
+}
+.fa-git:before {
+  content: "\f1d3";
+}
+.fa-y-combinator-square:before,
+.fa-yc-square:before,
+.fa-hacker-news:before {
+  content: "\f1d4";
+}
+.fa-tencent-weibo:before {
+  content: "\f1d5";
+}
+.fa-qq:before {
+  content: "\f1d6";
+}
+.fa-wechat:before,
+.fa-weixin:before {
+  content: "\f1d7";
+}
+.fa-send:before,
+.fa-paper-plane:before {
+  content: "\f1d8";
+}
+.fa-send-o:before,
+.fa-paper-plane-o:before {
+  content: "\f1d9";
+}
+.fa-history:before {
+  content: "\f1da";
+}
+.fa-circle-thin:before {
+  content: "\f1db";
+}
+.fa-header:before {
+  content: "\f1dc";
+}
+.fa-paragraph:before {
+  content: "\f1dd";
+}
+.fa-sliders:before {
+  content: "\f1de";
+}
+.fa-share-alt:before {
+  content: "\f1e0";
+}
+.fa-share-alt-square:before {
+  content: "\f1e1";
+}
+.fa-bomb:before {
+  content: "\f1e2";
+}
+.fa-soccer-ball-o:before,
+.fa-futbol-o:before {
+  content: "\f1e3";
+}
+.fa-tty:before {
+  content: "\f1e4";
+}
+.fa-binoculars:before {
+  content: "\f1e5";
+}
+.fa-plug:before {
+  content: "\f1e6";
+}
+.fa-slideshare:before {
+  content: "\f1e7";
+}
+.fa-twitch:before {
+  content: "\f1e8";
+}
+.fa-yelp:before {
+  content: "\f1e9";
+}
+.fa-newspaper-o:before {
+  content: "\f1ea";
+}
+.fa-wifi:before {
+  content: "\f1eb";
+}
+.fa-calculator:before {
+  content: "\f1ec";
+}
+.fa-paypal:before {
+  content: "\f1ed";
+}
+.fa-google-wallet:before {
+  content: "\f1ee";
+}
+.fa-cc-visa:before {
+  content: "\f1f0";
+}
+.fa-cc-mastercard:before {
+  content: "\f1f1";
+}
+.fa-cc-discover:before {
+  content: "\f1f2";
+}
+.fa-cc-amex:before {
+  content: "\f1f3";
+}
+.fa-cc-paypal:before {
+  content: "\f1f4";
+}
+.fa-cc-stripe:before {
+  content: "\f1f5";
+}
+.fa-bell-slash:before {
+  content: "\f1f6";
+}
+.fa-bell-slash-o:before {
+  content: "\f1f7";
+}
+.fa-trash:before {
+  content: "\f1f8";
+}
+.fa-copyright:before {
+  content: "\f1f9";
+}
+.fa-at:before {
+  content: "\f1fa";
+}
+.fa-eyedropper:before {
+  content: "\f1fb";
+}
+.fa-paint-brush:before {
+  content: "\f1fc";
+}
+.fa-birthday-cake:before {
+  content: "\f1fd";
+}
+.fa-area-chart:before {
+  content: "\f1fe";
+}
+.fa-pie-chart:before {
+  content: "\f200";
+}
+.fa-line-chart:before {
+  content: "\f201";
+}
+.fa-lastfm:before {
+  content: "\f202";
+}
+.fa-lastfm-square:before {
+  content: "\f203";
+}
+.fa-toggle-off:before {
+  content: "\f204";
+}
+.fa-toggle-on:before {
+  content: "\f205";
+}
+.fa-bicycle:before {
+  content: "\f206";
+}
+.fa-bus:before {
+  content: "\f207";
+}
+.fa-ioxhost:before {
+  content: "\f208";
+}
+.fa-angellist:before {
+  content: "\f209";
+}
+.fa-cc:before {
+  content: "\f20a";
+}
+.fa-shekel:before,
+.fa-sheqel:before,
+.fa-ils:before {
+  content: "\f20b";
+}
+.fa-meanpath:before {
+  content: "\f20c";
+}
+.fa-buysellads:before {
+  content: "\f20d";
+}
+.fa-connectdevelop:before {
+  content: "\f20e";
+}
+.fa-dashcube:before {
+  content: "\f210";
+}
+.fa-forumbee:before {
+  content: "\f211";
+}
+.fa-leanpub:before {
+  content: "\f212";
+}
+.fa-sellsy:before {
+  content: "\f213";
+}
+.fa-shirtsinbulk:before {
+  content: "\f214";
+}
+.fa-simplybuilt:before {
+  content: "\f215";
+}
+.fa-skyatlas:before {
+  content: "\f216";
+}
+.fa-cart-plus:before {
+  content: "\f217";
+}
+.fa-cart-arrow-down:before {
+  content: "\f218";
+}
+.fa-diamond:before {
+  content: "\f219";
+}
+.fa-ship:before {
+  content: "\f21a";
+}
+.fa-user-secret:before {
+  content: "\f21b";
+}
+.fa-motorcycle:before {
+  content: "\f21c";
+}
+.fa-street-view:before {
+  content: "\f21d";
+}
+.fa-heartbeat:before {
+  content: "\f21e";
+}
+.fa-venus:before {
+  content: "\f221";
+}
+.fa-mars:before {
+  content: "\f222";
+}
+.fa-mercury:before {
+  content: "\f223";
+}
+.fa-intersex:before,
+.fa-transgender:before {
+  content: "\f224";
+}
+.fa-transgender-alt:before {
+  content: "\f225";
+}
+.fa-venus-double:before {
+  content: "\f226";
+}
+.fa-mars-double:before {
+  content: "\f227";
+}
+.fa-venus-mars:before {
+  content: "\f228";
+}
+.fa-mars-stroke:before {
+  content: "\f229";
+}
+.fa-mars-stroke-v:before {
+  content: "\f22a";
+}
+.fa-mars-stroke-h:before {
+  content: "\f22b";
+}
+.fa-neuter:before {
+  content: "\f22c";
+}
+.fa-genderless:before {
+  content: "\f22d";
+}
+.fa-facebook-official:before {
+  content: "\f230";
+}
+.fa-pinterest-p:before {
+  content: "\f231";
+}
+.fa-whatsapp:before {
+  content: "\f232";
+}
+.fa-server:before {
+  content: "\f233";
+}
+.fa-user-plus:before {
+  content: "\f234";
+}
+.fa-user-times:before {
+  content: "\f235";
+}
+.fa-hotel:before,
+.fa-bed:before {
+  content: "\f236";
+}
+.fa-viacoin:before {
+  content: "\f237";
+}
+.fa-train:before {
+  content: "\f238";
+}
+.fa-subway:before {
+  content: "\f239";
+}
+.fa-medium:before {
+  content: "\f23a";
+}
+.fa-yc:before,
+.fa-y-combinator:before {
+  content: "\f23b";
+}
+.fa-optin-monster:before {
+  content: "\f23c";
+}
+.fa-opencart:before {
+  content: "\f23d";
+}
+.fa-expeditedssl:before {
+  content: "\f23e";
+}
+.fa-battery-4:before,
+.fa-battery:before,
+.fa-battery-full:before {
+  content: "\f240";
+}
+.fa-battery-3:before,
+.fa-battery-three-quarters:before {
+  content: "\f241";
+}
+.fa-battery-2:before,
+.fa-battery-half:before {
+  content: "\f242";
+}
+.fa-battery-1:before,
+.fa-battery-quarter:before {
+  content: "\f243";
+}
+.fa-battery-0:before,
+.fa-battery-empty:before {
+  content: "\f244";
+}
+.fa-mouse-pointer:before {
+  content: "\f245";
+}
+.fa-i-cursor:before {
+  content: "\f246";
+}
+.fa-object-group:before {
+  content: "\f247";
+}
+.fa-object-ungroup:before {
+  content: "\f248";
+}
+.fa-sticky-note:before {
+  content: "\f249";
+}
+.fa-sticky-note-o:before {
+  content: "\f24a";
+}
+.fa-cc-jcb:before {
+  content: "\f24b";
+}
+.fa-cc-diners-club:before {
+  content: "\f24c";
+}
+.fa-clone:before {
+  content: "\f24d";
+}
+.fa-balance-scale:before {
+  content: "\f24e";
+}
+.fa-hourglass-o:before {
+  content: "\f250";
+}
+.fa-hourglass-1:before,
+.fa-hourglass-start:before {
+  content: "\f251";
+}
+.fa-hourglass-2:before,
+.fa-hourglass-half:before {
+  content: "\f252";
+}
+.fa-hourglass-3:before,
+.fa-hourglass-end:before {
+  content: "\f253";
+}
+.fa-hourglass:before {
+  content: "\f254";
+}
+.fa-hand-grab-o:before,
+.fa-hand-rock-o:before {
+  content: "\f255";
+}
+.fa-hand-stop-o:before,
+.fa-hand-paper-o:before {
+  content: "\f256";
+}
+.fa-hand-scissors-o:before {
+  content: "\f257";
+}
+.fa-hand-lizard-o:before {
+  content: "\f258";
+}
+.fa-hand-spock-o:before {
+  content: "\f259";
+}
+.fa-hand-pointer-o:before {
+  content: "\f25a";
+}
+.fa-hand-peace-o:before {
+  content: "\f25b";
+}
+.fa-trademark:before {
+  content: "\f25c";
+}
+.fa-registered:before {
+  content: "\f25d";
+}
+.fa-creative-commons:before {
+  content: "\f25e";
+}
+.fa-gg:before {
+  content: "\f260";
+}
+.fa-gg-circle:before {
+  content: "\f261";
+}
+.fa-tripadvisor:before {
+  content: "\f262";
+}
+.fa-odnoklassniki:before {
+  content: "\f263";
+}
+.fa-odnoklassniki-square:before {
+  content: "\f264";
+}
+.fa-get-pocket:before {
+  content: "\f265";
+}
+.fa-wikipedia-w:before {
+  content: "\f266";
+}
+.fa-safari:before {
+  content: "\f267";
+}
+.fa-chrome:before {
+  content: "\f268";
+}
+.fa-firefox:before {
+  content: "\f269";
+}
+.fa-opera:before {
+  content: "\f26a";
+}
+.fa-internet-explorer:before {
+  content: "\f26b";
+}
+.fa-tv:before,
+.fa-television:before {
+  content: "\f26c";
+}
+.fa-contao:before {
+  content: "\f26d";
+}
+.fa-500px:before {
+  content: "\f26e";
+}
+.fa-amazon:before {
+  content: "\f270";
+}
+.fa-calendar-plus-o:before {
+  content: "\f271";
+}
+.fa-calendar-minus-o:before {
+  content: "\f272";
+}
+.fa-calendar-times-o:before {
+  content: "\f273";
+}
+.fa-calendar-check-o:before {
+  content: "\f274";
+}
+.fa-industry:before {
+  content: "\f275";
+}
+.fa-map-pin:before {
+  content: "\f276";
+}
+.fa-map-signs:before {
+  content: "\f277";
+}
+.fa-map-o:before {
+  content: "\f278";
+}
+.fa-map:before {
+  content: "\f279";
+}
+.fa-commenting:before {
+  content: "\f27a";
+}
+.fa-commenting-o:before {
+  content: "\f27b";
+}
+.fa-houzz:before {
+  content: "\f27c";
+}
+.fa-vimeo:before {
+  content: "\f27d";
+}
+.fa-black-tie:before {
+  content: "\f27e";
+}
+.fa-fonticons:before {
+  content: "\f280";
+}
+.fa-reddit-alien:before {
+  content: "\f281";
+}
+.fa-edge:before {
+  content: "\f282";
+}
+.fa-credit-card-alt:before {
+  content: "\f283";
+}
+.fa-codiepie:before {
+  content: "\f284";
+}
+.fa-modx:before {
+  content: "\f285";
+}
+.fa-fort-awesome:before {
+  content: "\f286";
+}
+.fa-usb:before {
+  content: "\f287";
+}
+.fa-product-hunt:before {
+  content: "\f288";
+}
+.fa-mixcloud:before {
+  content: "\f289";
+}
+.fa-scribd:before {
+  content: "\f28a";
+}
+.fa-pause-circle:before {
+  content: "\f28b";
+}
+.fa-pause-circle-o:before {
+  content: "\f28c";
+}
+.fa-stop-circle:before {
+  content: "\f28d";
+}
+.fa-stop-circle-o:before {
+  content: "\f28e";
+}
+.fa-shopping-bag:before {
+  content: "\f290";
+}
+.fa-shopping-basket:before {
+  content: "\f291";
+}
+.fa-hashtag:before {
+  content: "\f292";
+}
+.fa-bluetooth:before {
+  content: "\f293";
+}
+.fa-bluetooth-b:before {
+  content: "\f294";
+}
+.fa-percent:before {
+  content: "\f295";
+}
+.fa-gitlab:before {
+  content: "\f296";
+}
+.fa-wpbeginner:before {
+  content: "\f297";
+}
+.fa-wpforms:before {
+  content: "\f298";
+}
+.fa-envira:before {
+  content: "\f299";
+}
+.fa-universal-access:before {
+  content: "\f29a";
+}
+.fa-wheelchair-alt:before {
+  content: "\f29b";
+}
+.fa-question-circle-o:before {
+  content: "\f29c";
+}
+.fa-blind:before {
+  content: "\f29d";
+}
+.fa-audio-description:before {
+  content: "\f29e";
+}
+.fa-volume-control-phone:before {
+  content: "\f2a0";
+}
+.fa-braille:before {
+  content: "\f2a1";
+}
+.fa-assistive-listening-systems:before {
+  content: "\f2a2";
+}
+.fa-asl-interpreting:before,
+.fa-american-sign-language-interpreting:before {
+  content: "\f2a3";
+}
+.fa-deafness:before,
+.fa-hard-of-hearing:before,
+.fa-deaf:before {
+  content: "\f2a4";
+}
+.fa-glide:before {
+  content: "\f2a5";
+}
+.fa-glide-g:before {
+  content: "\f2a6";
+}
+.fa-signing:before,
+.fa-sign-language:before {
+  content: "\f2a7";
+}
+.fa-low-vision:before {
+  content: "\f2a8";
+}
+.fa-viadeo:before {
+  content: "\f2a9";
+}
+.fa-viadeo-square:before {
+  content: "\f2aa";
+}
+.fa-snapchat:before {
+  content: "\f2ab";
+}
+.fa-snapchat-ghost:before {
+  content: "\f2ac";
+}
+.fa-snapchat-square:before {
+  content: "\f2ad";
+}
+.fa-pied-piper:before {
+  content: "\f2ae";
+}
+.fa-first-order:before {
+  content: "\f2b0";
+}
+.fa-yoast:before {
+  content: "\f2b1";
+}
+.fa-themeisle:before {
+  content: "\f2b2";
+}
+.fa-google-plus-circle:before,
+.fa-google-plus-official:before {
+  content: "\f2b3";
+}
+.fa-fa:before,
+.fa-font-awesome:before {
+  content: "\f2b4";
+}
+.fa-handshake-o:before {
+  content: "\f2b5";
+}
+.fa-envelope-open:before {
+  content: "\f2b6";
+}
+.fa-envelope-open-o:before {
+  content: "\f2b7";
+}
+.fa-linode:before {
+  content: "\f2b8";
+}
+.fa-address-book:before {
+  content: "\f2b9";
+}
+.fa-address-book-o:before {
+  content: "\f2ba";
+}
+.fa-vcard:before,
+.fa-address-card:before {
+  content: "\f2bb";
+}
+.fa-vcard-o:before,
+.fa-address-card-o:before {
+  content: "\f2bc";
+}
+.fa-user-circle:before {
+  content: "\f2bd";
+}
+.fa-user-circle-o:before {
+  content: "\f2be";
+}
+.fa-user-o:before {
+  content: "\f2c0";
+}
+.fa-id-badge:before {
+  content: "\f2c1";
+}
+.fa-drivers-license:before,
+.fa-id-card:before {
+  content: "\f2c2";
+}
+.fa-drivers-license-o:before,
+.fa-id-card-o:before {
+  content: "\f2c3";
+}
+.fa-quora:before {
+  content: "\f2c4";
+}
+.fa-free-code-camp:before {
+  content: "\f2c5";
+}
+.fa-telegram:before {
+  content: "\f2c6";
+}
+.fa-thermometer-4:before,
+.fa-thermometer:before,
+.fa-thermometer-full:before {
+  content: "\f2c7";
+}
+.fa-thermometer-3:before,
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8";
+}
+.fa-thermometer-2:before,
+.fa-thermometer-half:before {
+  content: "\f2c9";
+}
+.fa-thermometer-1:before,
+.fa-thermometer-quarter:before {
+  content: "\f2ca";
+}
+.fa-thermometer-0:before,
+.fa-thermometer-empty:before {
+  content: "\f2cb";
+}
+.fa-shower:before {
+  content: "\f2cc";
+}
+.fa-bathtub:before,
+.fa-s15:before,
+.fa-bath:before {
+  content: "\f2cd";
+}
+.fa-podcast:before {
+  content: "\f2ce";
+}
+.fa-window-maximize:before {
+  content: "\f2d0";
+}
+.fa-window-minimize:before {
+  content: "\f2d1";
+}
+.fa-window-restore:before {
+  content: "\f2d2";
+}
+.fa-times-rectangle:before,
+.fa-window-close:before {
+  content: "\f2d3";
+}
+.fa-times-rectangle-o:before,
+.fa-window-close-o:before {
+  content: "\f2d4";
+}
+.fa-bandcamp:before {
+  content: "\f2d5";
+}
+.fa-grav:before {
+  content: "\f2d6";
+}
+.fa-etsy:before {
+  content: "\f2d7";
+}
+.fa-imdb:before {
+  content: "\f2d8";
+}
+.fa-ravelry:before {
+  content: "\f2d9";
+}
+.fa-eercast:before {
+  content: "\f2da";
+}
+.fa-microchip:before {
+  content: "\f2db";
+}
+.fa-snowflake-o:before {
+  content: "\f2dc";
+}
+.fa-superpowers:before {
+  content: "\f2dd";
+}
+.fa-wpexplorer:before {
+  content: "\f2de";
+}
+.fa-meetup:before {
+  content: "\f2e0";
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+/*!
+*
+* IPython base
+*
+*/
+.modal.fade .modal-dialog {
+  -webkit-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+code {
+  color: #000;
+}
+pre {
+  font-size: inherit;
+  line-height: inherit;
+}
+label {
+  font-weight: normal;
+}
+/* Make the page background atleast 100% the height of the view port */
+/* Make the page itself atleast 70% the height of the view port */
+.border-box-sizing {
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+.corner-all {
+  border-radius: 2px;
+}
+.no-padding {
+  padding: 0px;
+}
+/* Flexible box model classes */
+/* Taken from Alex Russell http://infrequently.org/2009/08/css-3-progress/ */
+/* This file is a compatability layer.  It allows the usage of flexible box 
+model layouts accross multiple browsers, including older browsers.  The newest,
+universal implementation of the flexible box model is used when available (see
+`Modern browsers` comments below).  Browsers that are known to implement this 
+new spec completely include:
+
+    Firefox 28.0+
+    Chrome 29.0+
+    Internet Explorer 11+ 
+    Opera 17.0+
+
+Browsers not listed, including Safari, are supported via the styling under the
+`Old browsers` comments below.
+*/
+.hbox {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+.hbox > * {
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+}
+.vbox {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+.vbox > * {
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+}
+.hbox.reverse,
+.vbox.reverse,
+.reverse {
+  /* Old browsers */
+  -webkit-box-direction: reverse;
+  -moz-box-direction: reverse;
+  box-direction: reverse;
+  /* Modern browsers */
+  flex-direction: row-reverse;
+}
+.hbox.box-flex0,
+.vbox.box-flex0,
+.box-flex0 {
+  /* Old browsers */
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  /* Modern browsers */
+  flex: none;
+  width: auto;
+}
+.hbox.box-flex1,
+.vbox.box-flex1,
+.box-flex1 {
+  /* Old browsers */
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  /* Modern browsers */
+  flex: 1;
+}
+.hbox.box-flex,
+.vbox.box-flex,
+.box-flex {
+  /* Old browsers */
+  /* Old browsers */
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  /* Modern browsers */
+  flex: 1;
+}
+.hbox.box-flex2,
+.vbox.box-flex2,
+.box-flex2 {
+  /* Old browsers */
+  -webkit-box-flex: 2;
+  -moz-box-flex: 2;
+  box-flex: 2;
+  /* Modern browsers */
+  flex: 2;
+}
+.box-group1 {
+  /*  Deprecated */
+  -webkit-box-flex-group: 1;
+  -moz-box-flex-group: 1;
+  box-flex-group: 1;
+}
+.box-group2 {
+  /* Deprecated */
+  -webkit-box-flex-group: 2;
+  -moz-box-flex-group: 2;
+  box-flex-group: 2;
+}
+.hbox.start,
+.vbox.start,
+.start {
+  /* Old browsers */
+  -webkit-box-pack: start;
+  -moz-box-pack: start;
+  box-pack: start;
+  /* Modern browsers */
+  justify-content: flex-start;
+}
+.hbox.end,
+.vbox.end,
+.end {
+  /* Old browsers */
+  -webkit-box-pack: end;
+  -moz-box-pack: end;
+  box-pack: end;
+  /* Modern browsers */
+  justify-content: flex-end;
+}
+.hbox.center,
+.vbox.center,
+.center {
+  /* Old browsers */
+  -webkit-box-pack: center;
+  -moz-box-pack: center;
+  box-pack: center;
+  /* Modern browsers */
+  justify-content: center;
+}
+.hbox.baseline,
+.vbox.baseline,
+.baseline {
+  /* Old browsers */
+  -webkit-box-pack: baseline;
+  -moz-box-pack: baseline;
+  box-pack: baseline;
+  /* Modern browsers */
+  justify-content: baseline;
+}
+.hbox.stretch,
+.vbox.stretch,
+.stretch {
+  /* Old browsers */
+  -webkit-box-pack: stretch;
+  -moz-box-pack: stretch;
+  box-pack: stretch;
+  /* Modern browsers */
+  justify-content: stretch;
+}
+.hbox.align-start,
+.vbox.align-start,
+.align-start {
+  /* Old browsers */
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  box-align: start;
+  /* Modern browsers */
+  align-items: flex-start;
+}
+.hbox.align-end,
+.vbox.align-end,
+.align-end {
+  /* Old browsers */
+  -webkit-box-align: end;
+  -moz-box-align: end;
+  box-align: end;
+  /* Modern browsers */
+  align-items: flex-end;
+}
+.hbox.align-center,
+.vbox.align-center,
+.align-center {
+  /* Old browsers */
+  -webkit-box-align: center;
+  -moz-box-align: center;
+  box-align: center;
+  /* Modern browsers */
+  align-items: center;
+}
+.hbox.align-baseline,
+.vbox.align-baseline,
+.align-baseline {
+  /* Old browsers */
+  -webkit-box-align: baseline;
+  -moz-box-align: baseline;
+  box-align: baseline;
+  /* Modern browsers */
+  align-items: baseline;
+}
+.hbox.align-stretch,
+.vbox.align-stretch,
+.align-stretch {
+  /* Old browsers */
+  -webkit-box-align: stretch;
+  -moz-box-align: stretch;
+  box-align: stretch;
+  /* Modern browsers */
+  align-items: stretch;
+}
+div.error {
+  margin: 2em;
+  text-align: center;
+}
+div.error > h1 {
+  font-size: 500%;
+  line-height: normal;
+}
+div.error > p {
+  font-size: 200%;
+  line-height: normal;
+}
+div.traceback-wrapper {
+  text-align: left;
+  max-width: 800px;
+  margin: auto;
+}
+div.traceback-wrapper pre.traceback {
+  max-height: 600px;
+  overflow: auto;
+}
+/**
+ * Primary styles
+ *
+ * Author: Jupyter Development Team
+ */
+body {
+  background-color: #fff;
+  /* This makes sure that the body covers the entire window and needs to
+       be in a different element than the display: box in wrapper below */
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  overflow: visible;
+}
+body > #header {
+  /* Initially hidden to prevent FLOUC */
+  display: none;
+  background-color: #fff;
+  /* Display over codemirror */
+  position: relative;
+  z-index: 100;
+}
+body > #header #header-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 5px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+body > #header .header-bar {
+  width: 100%;
+  height: 1px;
+  background: #e7e7e7;
+  margin-bottom: -1px;
+}
+@media print {
+  body > #header {
+    display: none !important;
+  }
+}
+#header-spacer {
+  width: 100%;
+  visibility: hidden;
+}
+@media print {
+  #header-spacer {
+    display: none;
+  }
+}
+#ipython_notebook {
+  padding-left: 0px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+[dir="rtl"] #ipython_notebook {
+  margin-right: 10px;
+  margin-left: 0;
+}
+[dir="rtl"] #ipython_notebook.pull-left {
+  float: right !important;
+  float: right;
+}
+.flex-spacer {
+  flex: 1;
+}
+#noscript {
+  width: auto;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  text-align: center;
+  font-size: 22px;
+  color: red;
+  font-weight: bold;
+}
+#ipython_notebook img {
+  height: 28px;
+}
+#site {
+  width: 100%;
+  display: none;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  overflow: auto;
+}
+@media print {
+  #site {
+    height: auto !important;
+  }
+}
+/* Smaller buttons */
+.ui-button .ui-button-text {
+  padding: 0.2em 0.8em;
+  font-size: 77%;
+}
+input.ui-button {
+  padding: 0.3em 0.9em;
+}
+span#kernel_logo_widget {
+  margin: 0 10px;
+}
+span#login_widget {
+  float: right;
+}
+[dir="rtl"] span#login_widget {
+  float: left;
+}
+span#login_widget > .button,
+#logout {
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+span#login_widget > .button:focus,
+#logout:focus,
+span#login_widget > .button.focus,
+#logout.focus {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #8c8c8c;
+}
+span#login_widget > .button:hover,
+#logout:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+span#login_widget > .button:active,
+#logout:active,
+span#login_widget > .button.active,
+#logout.active,
+.open > .dropdown-togglespan#login_widget > .button,
+.open > .dropdown-toggle#logout {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+span#login_widget > .button:active:hover,
+#logout:active:hover,
+span#login_widget > .button.active:hover,
+#logout.active:hover,
+.open > .dropdown-togglespan#login_widget > .button:hover,
+.open > .dropdown-toggle#logout:hover,
+span#login_widget > .button:active:focus,
+#logout:active:focus,
+span#login_widget > .button.active:focus,
+#logout.active:focus,
+.open > .dropdown-togglespan#login_widget > .button:focus,
+.open > .dropdown-toggle#logout:focus,
+span#login_widget > .button:active.focus,
+#logout:active.focus,
+span#login_widget > .button.active.focus,
+#logout.active.focus,
+.open > .dropdown-togglespan#login_widget > .button.focus,
+.open > .dropdown-toggle#logout.focus {
+  color: #333;
+  background-color: #d4d4d4;
+  border-color: #8c8c8c;
+}
+span#login_widget > .button:active,
+#logout:active,
+span#login_widget > .button.active,
+#logout.active,
+.open > .dropdown-togglespan#login_widget > .button,
+.open > .dropdown-toggle#logout {
+  background-image: none;
+}
+span#login_widget > .button.disabled:hover,
+#logout.disabled:hover,
+span#login_widget > .button[disabled]:hover,
+#logout[disabled]:hover,
+fieldset[disabled] span#login_widget > .button:hover,
+fieldset[disabled] #logout:hover,
+span#login_widget > .button.disabled:focus,
+#logout.disabled:focus,
+span#login_widget > .button[disabled]:focus,
+#logout[disabled]:focus,
+fieldset[disabled] span#login_widget > .button:focus,
+fieldset[disabled] #logout:focus,
+span#login_widget > .button.disabled.focus,
+#logout.disabled.focus,
+span#login_widget > .button[disabled].focus,
+#logout[disabled].focus,
+fieldset[disabled] span#login_widget > .button.focus,
+fieldset[disabled] #logout.focus {
+  background-color: #fff;
+  border-color: #ccc;
+}
+span#login_widget > .button .badge,
+#logout .badge {
+  color: #fff;
+  background-color: #333;
+}
+.nav-header {
+  text-transform: none;
+}
+#header > span {
+  margin-top: 10px;
+}
+.modal_stretch .modal-dialog {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-height: 80vh;
+}
+.modal_stretch .modal-dialog .modal-body {
+  max-height: calc(100vh - 200px);
+  overflow: auto;
+  flex: 1;
+}
+.modal-header {
+  cursor: move;
+}
+@media (min-width: 768px) {
+  .modal .modal-dialog {
+    width: 700px;
+  }
+}
+@media (min-width: 768px) {
+  select.form-control {
+    margin-left: 12px;
+    margin-right: 12px;
+  }
+}
+/*!
+*
+* IPython auth
+*
+*/
+.center-nav {
+  display: inline-block;
+  margin-bottom: -4px;
+}
+[dir="rtl"] .center-nav form.pull-left {
+  float: right !important;
+  float: right;
+}
+[dir="rtl"] .center-nav .navbar-text {
+  float: right;
+}
+[dir="rtl"] .navbar-inner {
+  text-align: right;
+}
+[dir="rtl"] div.text-left {
+  text-align: right;
+}
+/*!
+*
+* IPython tree view
+*
+*/
+/* We need an invisible input field on top of the sentense*/
+/* "Drag file onto the list ..." */
+.alternate_upload {
+  background-color: none;
+  display: inline;
+}
+.alternate_upload.form {
+  padding: 0;
+  margin: 0;
+}
+.alternate_upload input.fileinput {
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  cursor: pointer;
+  opacity: 0;
+  z-index: 2;
+}
+.alternate_upload .btn-xs > input.fileinput {
+  margin: -1px -5px;
+}
+.alternate_upload .btn-upload {
+  position: relative;
+  height: 22px;
+}
+::-webkit-file-upload-button {
+  cursor: pointer;
+}
+/**
+ * Primary styles
+ *
+ * Author: Jupyter Development Team
+ */
+ul#tabs {
+  margin-bottom: 4px;
+}
+ul#tabs a {
+  padding-top: 6px;
+  padding-bottom: 4px;
+}
+[dir="rtl"] ul#tabs.nav-tabs > li {
+  float: right;
+}
+[dir="rtl"] ul#tabs.nav.nav-tabs {
+  padding-right: 0;
+}
+ul.breadcrumb a:focus,
+ul.breadcrumb a:hover {
+  text-decoration: none;
+}
+ul.breadcrumb i.icon-home {
+  font-size: 16px;
+  margin-right: 4px;
+}
+ul.breadcrumb span {
+  color: #5e5e5e;
+}
+.list_toolbar {
+  padding: 4px 0 4px 0;
+  vertical-align: middle;
+}
+.list_toolbar .tree-buttons {
+  padding-top: 1px;
+}
+[dir="rtl"] .list_toolbar .tree-buttons .pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .list_toolbar .col-sm-4,
+[dir="rtl"] .list_toolbar .col-sm-8 {
+  float: right;
+}
+.dynamic-buttons {
+  padding-top: 3px;
+  display: inline-block;
+}
+.list_toolbar [class*="span"] {
+  min-height: 24px;
+}
+.list_header {
+  font-weight: bold;
+  background-color: #EEE;
+}
+.list_placeholder {
+  font-weight: bold;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 7px;
+  padding-right: 7px;
+}
+.list_container {
+  margin-top: 4px;
+  margin-bottom: 20px;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+}
+.list_container > div {
+  border-bottom: 1px solid #ddd;
+}
+.list_container > div:hover .list-item {
+  background-color: red;
+}
+.list_container > div:last-child {
+  border: none;
+}
+.list_item:hover .list_item {
+  background-color: #ddd;
+}
+.list_item a {
+  text-decoration: none;
+}
+.list_item:hover {
+  background-color: #fafafa;
+}
+.list_header > div,
+.list_item > div {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 7px;
+  padding-right: 7px;
+  line-height: 22px;
+}
+.list_header > div input,
+.list_item > div input {
+  margin-right: 7px;
+  margin-left: 14px;
+  vertical-align: text-bottom;
+  line-height: 22px;
+  position: relative;
+  top: -1px;
+}
+.list_header > div .item_link,
+.list_item > div .item_link {
+  margin-left: -1px;
+  vertical-align: baseline;
+  line-height: 22px;
+}
+[dir="rtl"] .list_item > div input {
+  margin-right: 0;
+}
+.new-file input[type=checkbox] {
+  visibility: hidden;
+}
+.item_name {
+  line-height: 22px;
+  height: 24px;
+}
+.item_icon {
+  font-size: 14px;
+  color: #5e5e5e;
+  margin-right: 7px;
+  margin-left: 7px;
+  line-height: 22px;
+  vertical-align: baseline;
+}
+.item_modified {
+  margin-right: 7px;
+  margin-left: 7px;
+}
+[dir="rtl"] .item_modified.pull-right {
+  float: left !important;
+  float: left;
+}
+.item_buttons {
+  line-height: 1em;
+  margin-left: -5px;
+}
+.item_buttons .btn,
+.item_buttons .btn-group,
+.item_buttons .input-group {
+  float: left;
+}
+.item_buttons > .btn,
+.item_buttons > .btn-group,
+.item_buttons > .input-group {
+  margin-left: 5px;
+}
+.item_buttons .btn {
+  min-width: 13ex;
+}
+.item_buttons .running-indicator {
+  padding-top: 4px;
+  color: #5cb85c;
+}
+.item_buttons .kernel-name {
+  padding-top: 4px;
+  color: #5bc0de;
+  margin-right: 7px;
+  float: left;
+}
+[dir="rtl"] .item_buttons.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .item_buttons .kernel-name {
+  margin-left: 7px;
+  float: right;
+}
+.toolbar_info {
+  height: 24px;
+  line-height: 24px;
+}
+.list_item input:not([type=checkbox]) {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  height: 22px;
+  line-height: 14px;
+  margin: 0px;
+}
+.highlight_text {
+  color: blue;
+}
+#project_name {
+  display: inline-block;
+  padding-left: 7px;
+  margin-left: -2px;
+}
+#project_name > .breadcrumb {
+  padding: 0px;
+  margin-bottom: 0px;
+  background-color: transparent;
+  font-weight: bold;
+}
+.sort_button {
+  display: inline-block;
+  padding-left: 7px;
+}
+[dir="rtl"] .sort_button.pull-right {
+  float: left !important;
+  float: left;
+}
+#tree-selector {
+  padding-right: 0px;
+}
+#button-select-all {
+  min-width: 50px;
+}
+[dir="rtl"] #button-select-all.btn {
+  float: right ;
+}
+#select-all {
+  margin-left: 7px;
+  margin-right: 2px;
+  margin-top: 2px;
+  height: 16px;
+}
+[dir="rtl"] #select-all.pull-left {
+  float: right !important;
+  float: right;
+}
+.menu_icon {
+  margin-right: 2px;
+}
+.tab-content .row {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+.folder_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f114";
+}
+.folder_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.folder_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.folder_icon:before.pull-left {
+  margin-right: .3em;
+}
+.folder_icon:before.pull-right {
+  margin-left: .3em;
+}
+.notebook_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f02d";
+  position: relative;
+  top: -1px;
+}
+.notebook_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.notebook_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.notebook_icon:before.pull-left {
+  margin-right: .3em;
+}
+.notebook_icon:before.pull-right {
+  margin-left: .3em;
+}
+.running_notebook_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f02d";
+  position: relative;
+  top: -1px;
+  color: #5cb85c;
+}
+.running_notebook_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.running_notebook_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.running_notebook_icon:before.pull-left {
+  margin-right: .3em;
+}
+.running_notebook_icon:before.pull-right {
+  margin-left: .3em;
+}
+.file_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f016";
+  position: relative;
+  top: -2px;
+}
+.file_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.file_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.file_icon:before.pull-left {
+  margin-right: .3em;
+}
+.file_icon:before.pull-right {
+  margin-left: .3em;
+}
+#notebook_toolbar .pull-right {
+  padding-top: 0px;
+  margin-right: -1px;
+}
+ul#new-menu {
+  left: auto;
+  right: 0;
+}
+#new-menu .dropdown-header {
+  font-size: 10px;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 0 0 3px;
+  margin: -3px 20px 0;
+}
+.kernel-menu-icon {
+  padding-right: 12px;
+  width: 24px;
+  content: "\f096";
+}
+.kernel-menu-icon:before {
+  content: "\f096";
+}
+.kernel-menu-icon-current:before {
+  content: "\f00c";
+}
+#tab_content {
+  padding-top: 20px;
+}
+#running .panel-group .panel {
+  margin-top: 3px;
+  margin-bottom: 1em;
+}
+#running .panel-group .panel .panel-heading {
+  background-color: #EEE;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 7px;
+  padding-right: 7px;
+  line-height: 22px;
+}
+#running .panel-group .panel .panel-heading a:focus,
+#running .panel-group .panel .panel-heading a:hover {
+  text-decoration: none;
+}
+#running .panel-group .panel .panel-body {
+  padding: 0px;
+}
+#running .panel-group .panel .panel-body .list_container {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  border: 0px;
+  border-radius: 0px;
+}
+#running .panel-group .panel .panel-body .list_container .list_item {
+  border-bottom: 1px solid #ddd;
+}
+#running .panel-group .panel .panel-body .list_container .list_item:last-child {
+  border-bottom: 0px;
+}
+.delete-button {
+  display: none;
+}
+.duplicate-button {
+  display: none;
+}
+.rename-button {
+  display: none;
+}
+.move-button {
+  display: none;
+}
+.download-button {
+  display: none;
+}
+.shutdown-button {
+  display: none;
+}
+.dynamic-instructions {
+  display: inline-block;
+  padding-top: 4px;
+}
+/*!
+*
+* IPython text editor webapp
+*
+*/
+.selected-keymap i.fa {
+  padding: 0px 5px;
+}
+.selected-keymap i.fa:before {
+  content: "\f00c";
+}
+#mode-menu {
+  overflow: auto;
+  max-height: 20em;
+}
+.edit_app #header {
+  -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+}
+.edit_app #menubar .navbar {
+  /* Use a negative 1 bottom margin, so the border overlaps the border of the
+    header */
+  margin-bottom: -1px;
+}
+.dirty-indicator {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  width: 20px;
+}
+.dirty-indicator.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator.fa-pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator.pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator.pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator-dirty {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  width: 20px;
+}
+.dirty-indicator-dirty.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-dirty.fa-pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator-dirty.pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-dirty.pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator-clean {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  width: 20px;
+}
+.dirty-indicator-clean.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean.fa-pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator-clean.pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean.pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator-clean:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f00c";
+}
+.dirty-indicator-clean:before.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean:before.fa-pull-right {
+  margin-left: .3em;
+}
+.dirty-indicator-clean:before.pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean:before.pull-right {
+  margin-left: .3em;
+}
+#filename {
+  font-size: 16pt;
+  display: table;
+  padding: 0px 5px;
+}
+#current-mode {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+#texteditor-backdrop {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+@media not print {
+  #texteditor-backdrop {
+    background-color: #EEE;
+  }
+}
+@media print {
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutter,
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutters {
+    background-color: #fff;
+  }
+}
+@media not print {
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutter,
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutters {
+    background-color: #fff;
+  }
+}
+@media not print {
+  #texteditor-backdrop #texteditor-container {
+    padding: 0px;
+    background-color: #fff;
+    -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+    box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  }
+}
+.CodeMirror-dialog {
+  background-color: #fff;
+}
+/*!
+*
+* IPython notebook
+*
+*/
+/* CSS font colors for translated ANSI escape sequences */
+/* The color values are a mix of
+   http://www.xcolors.net/dl/baskerville-ivorylight and
+   http://www.xcolors.net/dl/euphrasia */
+.ansi-black-fg {
+  color: #3E424D;
+}
+.ansi-black-bg {
+  background-color: #3E424D;
+}
+.ansi-black-intense-fg {
+  color: #282C36;
+}
+.ansi-black-intense-bg {
+  background-color: #282C36;
+}
+.ansi-red-fg {
+  color: #E75C58;
+}
+.ansi-red-bg {
+  background-color: #E75C58;
+}
+.ansi-red-intense-fg {
+  color: #B22B31;
+}
+.ansi-red-intense-bg {
+  background-color: #B22B31;
+}
+.ansi-green-fg {
+  color: #00A250;
+}
+.ansi-green-bg {
+  background-color: #00A250;
+}
+.ansi-green-intense-fg {
+  color: #007427;
+}
+.ansi-green-intense-bg {
+  background-color: #007427;
+}
+.ansi-yellow-fg {
+  color: #DDB62B;
+}
+.ansi-yellow-bg {
+  background-color: #DDB62B;
+}
+.ansi-yellow-intense-fg {
+  color: #B27D12;
+}
+.ansi-yellow-intense-bg {
+  background-color: #B27D12;
+}
+.ansi-blue-fg {
+  color: #208FFB;
+}
+.ansi-blue-bg {
+  background-color: #208FFB;
+}
+.ansi-blue-intense-fg {
+  color: #0065CA;
+}
+.ansi-blue-intense-bg {
+  background-color: #0065CA;
+}
+.ansi-magenta-fg {
+  color: #D160C4;
+}
+.ansi-magenta-bg {
+  background-color: #D160C4;
+}
+.ansi-magenta-intense-fg {
+  color: #A03196;
+}
+.ansi-magenta-intense-bg {
+  background-color: #A03196;
+}
+.ansi-cyan-fg {
+  color: #60C6C8;
+}
+.ansi-cyan-bg {
+  background-color: #60C6C8;
+}
+.ansi-cyan-intense-fg {
+  color: #258F8F;
+}
+.ansi-cyan-intense-bg {
+  background-color: #258F8F;
+}
+.ansi-white-fg {
+  color: #C5C1B4;
+}
+.ansi-white-bg {
+  background-color: #C5C1B4;
+}
+.ansi-white-intense-fg {
+  color: #A1A6B2;
+}
+.ansi-white-intense-bg {
+  background-color: #A1A6B2;
+}
+.ansi-default-inverse-fg {
+  color: #FFFFFF;
+}
+.ansi-default-inverse-bg {
+  background-color: #000000;
+}
+.ansi-bold {
+  font-weight: bold;
+}
+.ansi-underline {
+  text-decoration: underline;
+}
+/* The following styles are deprecated an will be removed in a future version */
+.ansibold {
+  font-weight: bold;
+}
+.ansi-inverse {
+  outline: 0.5px dotted;
+}
+/* use dark versions for foreground, to improve visibility */
+.ansiblack {
+  color: black;
+}
+.ansired {
+  color: darkred;
+}
+.ansigreen {
+  color: darkgreen;
+}
+.ansiyellow {
+  color: #c4a000;
+}
+.ansiblue {
+  color: darkblue;
+}
+.ansipurple {
+  color: darkviolet;
+}
+.ansicyan {
+  color: steelblue;
+}
+.ansigray {
+  color: gray;
+}
+/* and light for background, for the same reason */
+.ansibgblack {
+  background-color: black;
+}
+.ansibgred {
+  background-color: red;
+}
+.ansibggreen {
+  background-color: green;
+}
+.ansibgyellow {
+  background-color: yellow;
+}
+.ansibgblue {
+  background-color: blue;
+}
+.ansibgpurple {
+  background-color: magenta;
+}
+.ansibgcyan {
+  background-color: cyan;
+}
+.ansibggray {
+  background-color: gray;
+}
+div.cell {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  border-radius: 2px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  border-width: 1px;
+  border-style: solid;
+  border-color: transparent;
+  width: 100%;
+  padding: 5px;
+  /* This acts as a spacer between cells, that is outside the border */
+  margin: 0px;
+  outline: none;
+  position: relative;
+  overflow: visible;
+}
+div.cell:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: transparent;
+}
+div.cell.jupyter-soft-selected {
+  border-left-color: #E3F2FD;
+  border-left-width: 1px;
+  padding-left: 5px;
+  border-right-color: #E3F2FD;
+  border-right-width: 1px;
+  background: #E3F2FD;
+}
+@media print {
+  div.cell.jupyter-soft-selected {
+    border-color: transparent;
+  }
+}
+div.cell.selected,
+div.cell.selected.jupyter-soft-selected {
+  border-color: #ababab;
+}
+div.cell.selected:before,
+div.cell.selected.jupyter-soft-selected:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: #42A5F5;
+}
+@media print {
+  div.cell.selected,
+  div.cell.selected.jupyter-soft-selected {
+    border-color: transparent;
+  }
+}
+.edit_mode div.cell.selected {
+  border-color: #66BB6A;
+}
+.edit_mode div.cell.selected:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: #66BB6A;
+}
+@media print {
+  .edit_mode div.cell.selected {
+    border-color: transparent;
+  }
+}
+.prompt {
+  /* This needs to be wide enough for 3 digit prompt numbers: In[100]: */
+  min-width: 14ex;
+  /* This padding is tuned to match the padding on the CodeMirror editor. */
+  padding: 0.4em;
+  margin: 0px;
+  font-family: monospace;
+  text-align: right;
+  /* This has to match that of the the CodeMirror class line-height below */
+  line-height: 1.21429em;
+  /* Don't highlight prompt number selection */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  /* Use default cursor */
+  cursor: default;
+}
+@media (max-width: 540px) {
+  .prompt {
+    text-align: left;
+  }
+}
+div.inner_cell {
+  min-width: 0;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  /* Old browsers */
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  /* Modern browsers */
+  flex: 1;
+}
+/* input_area and input_prompt must match in top border and margin for alignment */
+div.input_area {
+  border: 1px solid #cfcfcf;
+  border-radius: 2px;
+  background: #f7f7f7;
+  line-height: 1.21429em;
+}
+/* This is needed so that empty prompt areas can collapse to zero height when there
+   is no content in the output_subarea and the prompt. The main purpose of this is
+   to make sure that empty JavaScript output_subareas have no height. */
+div.prompt:empty {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+div.unrecognized_cell {
+  padding: 5px 5px 5px 0px;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+div.unrecognized_cell .inner_cell {
+  border-radius: 2px;
+  padding: 5px;
+  font-weight: bold;
+  color: red;
+  border: 1px solid #cfcfcf;
+  background: #eaeaea;
+}
+div.unrecognized_cell .inner_cell a {
+  color: inherit;
+  text-decoration: none;
+}
+div.unrecognized_cell .inner_cell a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+@media (max-width: 540px) {
+  div.unrecognized_cell > div.prompt {
+    display: none;
+  }
+}
+div.code_cell {
+  /* avoid page breaking on code cells when printing */
+}
+@media print {
+  div.code_cell {
+    page-break-inside: avoid;
+  }
+}
+/* any special styling for code cells that are currently running goes here */
+div.input {
+  page-break-inside: avoid;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+@media (max-width: 540px) {
+  div.input {
+    /* Old browsers */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-box-align: stretch;
+    display: -moz-box;
+    -moz-box-orient: vertical;
+    -moz-box-align: stretch;
+    display: box;
+    box-orient: vertical;
+    box-align: stretch;
+    /* Modern browsers */
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+/* input_area and input_prompt must match in top border and margin for alignment */
+div.input_prompt {
+  color: #303F9F;
+  border-top: 1px solid transparent;
+}
+div.input_area > div.highlight {
+  margin: 0.4em;
+  border: none;
+  padding: 0px;
+  background-color: transparent;
+}
+div.input_area > div.highlight > pre {
+  margin: 0px;
+  border: none;
+  padding: 0px;
+  background-color: transparent;
+}
+/* The following gets added to the <head> if it is detected that the user has a
+ * monospace font with inconsistent normal/bold/italic height.  See
+ * notebookmain.js.  Such fonts will have keywords vertically offset with
+ * respect to the rest of the text.  The user should select a better font.
+ * See: https://github.com/ipython/ipython/issues/1503
+ *
+ * .CodeMirror span {
+ *      vertical-align: bottom;
+ * }
+ */
+.CodeMirror {
+  line-height: 1.21429em;
+  /* Changed from 1em to our global default */
+  font-size: 14px;
+  height: auto;
+  /* Changed to auto to autogrow */
+  background: none;
+  /* Changed from white to allow our bg to show through */
+}
+.CodeMirror-scroll {
+  /*  The CodeMirror docs are a bit fuzzy on if overflow-y should be hidden or visible.*/
+  /*  We have found that if it is visible, vertical scrollbars appear with font size changes.*/
+  overflow-y: hidden;
+  overflow-x: auto;
+}
+.CodeMirror-lines {
+  /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
+  /* we have set a different line-height and want this to scale with that. */
+  /* Note that this should set vertical padding only, since CodeMirror assumes
+       that horizontal padding will be set on CodeMirror pre */
+  padding: 0.4em 0;
+}
+.CodeMirror-linenumber {
+  padding: 0 8px 0 4px;
+}
+.CodeMirror-gutters {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+}
+.CodeMirror pre {
+  /* In CM3 this went to 4px from 0 in CM2. This sets horizontal padding only,
+    use .CodeMirror-lines for vertical */
+  padding: 0 0.4em;
+  border: 0;
+  border-radius: 0;
+}
+.CodeMirror-cursor {
+  border-left: 1.4px solid black;
+}
+@media screen and (min-width: 2138px) and (max-width: 4319px) {
+  .CodeMirror-cursor {
+    border-left: 2px solid black;
+  }
+}
+@media screen and (min-width: 4320px) {
+  .CodeMirror-cursor {
+    border-left: 4px solid black;
+  }
+}
+/*
+
+Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Org>
+Adapted from GitHub theme
+
+*/
+.highlight-base {
+  color: #000;
+}
+.highlight-variable {
+  color: #000;
+}
+.highlight-variable-2 {
+  color: #1a1a1a;
+}
+.highlight-variable-3 {
+  color: #333333;
+}
+.highlight-string {
+  color: #BA2121;
+}
+.highlight-comment {
+  color: #408080;
+  font-style: italic;
+}
+.highlight-number {
+  color: #080;
+}
+.highlight-atom {
+  color: #88F;
+}
+.highlight-keyword {
+  color: #008000;
+  font-weight: bold;
+}
+.highlight-builtin {
+  color: #008000;
+}
+.highlight-error {
+  color: #f00;
+}
+.highlight-operator {
+  color: #AA22FF;
+  font-weight: bold;
+}
+.highlight-meta {
+  color: #AA22FF;
+}
+/* previously not defined, copying from default codemirror */
+.highlight-def {
+  color: #00f;
+}
+.highlight-string-2 {
+  color: #f50;
+}
+.highlight-qualifier {
+  color: #555;
+}
+.highlight-bracket {
+  color: #997;
+}
+.highlight-tag {
+  color: #170;
+}
+.highlight-attribute {
+  color: #00c;
+}
+.highlight-header {
+  color: blue;
+}
+.highlight-quote {
+  color: #090;
+}
+.highlight-link {
+  color: #00c;
+}
+/* apply the same style to codemirror */
+.cm-s-ipython span.cm-keyword {
+  color: #008000;
+  font-weight: bold;
+}
+.cm-s-ipython span.cm-atom {
+  color: #88F;
+}
+.cm-s-ipython span.cm-number {
+  color: #080;
+}
+.cm-s-ipython span.cm-def {
+  color: #00f;
+}
+.cm-s-ipython span.cm-variable {
+  color: #000;
+}
+.cm-s-ipython span.cm-operator {
+  color: #AA22FF;
+  font-weight: bold;
+}
+.cm-s-ipython span.cm-variable-2 {
+  color: #1a1a1a;
+}
+.cm-s-ipython span.cm-variable-3 {
+  color: #333333;
+}
+.cm-s-ipython span.cm-comment {
+  color: #408080;
+  font-style: italic;
+}
+.cm-s-ipython span.cm-string {
+  color: #BA2121;
+}
+.cm-s-ipython span.cm-string-2 {
+  color: #f50;
+}
+.cm-s-ipython span.cm-meta {
+  color: #AA22FF;
+}
+.cm-s-ipython span.cm-qualifier {
+  color: #555;
+}
+.cm-s-ipython span.cm-builtin {
+  color: #008000;
+}
+.cm-s-ipython span.cm-bracket {
+  color: #997;
+}
+.cm-s-ipython span.cm-tag {
+  color: #170;
+}
+.cm-s-ipython span.cm-attribute {
+  color: #00c;
+}
+.cm-s-ipython span.cm-header {
+  color: blue;
+}
+.cm-s-ipython span.cm-quote {
+  color: #090;
+}
+.cm-s-ipython span.cm-link {
+  color: #00c;
+}
+.cm-s-ipython span.cm-error {
+  color: #f00;
+}
+.cm-s-ipython span.cm-tab {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+  background-position: right;
+  background-repeat: no-repeat;
+}
+div.output_wrapper {
+  /* this position must be relative to enable descendents to be absolute within it */
+  position: relative;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  z-index: 1;
+}
+/* class for the output area when it should be height-limited */
+div.output_scroll {
+  /* ideally, this would be max-height, but FF barfs all over that */
+  height: 24em;
+  /* FF needs this *and the wrapper* to specify full width, or it will shrinkwrap */
+  width: 100%;
+  overflow: auto;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.8);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.8);
+  display: block;
+}
+/* output div while it is collapsed */
+div.output_collapsed {
+  margin: 0px;
+  padding: 0px;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+div.out_prompt_overlay {
+  height: 100%;
+  padding: 0px 0.4em;
+  position: absolute;
+  border-radius: 2px;
+}
+div.out_prompt_overlay:hover {
+  /* use inner shadow to get border that is computed the same on WebKit/FF */
+  -webkit-box-shadow: inset 0 0 1px #000;
+  box-shadow: inset 0 0 1px #000;
+  background: rgba(240, 240, 240, 0.5);
+}
+div.output_prompt {
+  color: #D84315;
+}
+/* This class is the outer container of all output sections. */
+div.output_area {
+  padding: 0px;
+  page-break-inside: avoid;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+div.output_area .MathJax_Display {
+  text-align: left !important;
+}
+div.output_area .rendered_html table {
+  margin-left: 0;
+  margin-right: 0;
+}
+div.output_area .rendered_html img {
+  margin-left: 0;
+  margin-right: 0;
+}
+div.output_area img,
+div.output_area svg {
+  max-width: 100%;
+  height: auto;
+}
+div.output_area img.unconfined,
+div.output_area svg.unconfined {
+  max-width: none;
+}
+div.output_area .mglyph > img {
+  max-width: none;
+}
+/* This is needed to protect the pre formating from global settings such
+   as that of bootstrap */
+.output {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: vertical;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: vertical;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+@media (max-width: 540px) {
+  div.output_area {
+    /* Old browsers */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-box-align: stretch;
+    display: -moz-box;
+    -moz-box-orient: vertical;
+    -moz-box-align: stretch;
+    display: box;
+    box-orient: vertical;
+    box-align: stretch;
+    /* Modern browsers */
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+div.output_area pre {
+  margin: 0;
+  padding: 1px 0 1px 0;
+  border: 0;
+  vertical-align: baseline;
+  color: black;
+  background-color: transparent;
+  border-radius: 0;
+}
+/* This class is for the output subarea inside the output_area and after
+   the prompt div. */
+div.output_subarea {
+  overflow-x: auto;
+  padding: 0.4em;
+  /* Old browsers */
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  /* Modern browsers */
+  flex: 1;
+  max-width: calc(100% - 14ex);
+}
+div.output_scroll div.output_subarea {
+  overflow-x: visible;
+}
+/* The rest of the output_* classes are for special styling of the different
+   output types */
+/* all text output has this class: */
+div.output_text {
+  text-align: left;
+  color: #000;
+  /* This has to match that of the the CodeMirror class line-height below */
+  line-height: 1.21429em;
+}
+/* stdout/stderr are 'text' as well as 'stream', but execute_result/error are *not* streams */
+div.output_stderr {
+  background: #fdd;
+  /* very light red background for stderr */
+}
+div.output_latex {
+  text-align: left;
+}
+/* Empty output_javascript divs should have no height */
+div.output_javascript:empty {
+  padding: 0;
+}
+.js-error {
+  color: darkred;
+}
+/* raw_input styles */
+div.raw_input_container {
+  line-height: 1.21429em;
+  padding-top: 5px;
+}
+pre.raw_input_prompt {
+  /* nothing needed here. */
+}
+input.raw_input {
+  font-family: monospace;
+  font-size: inherit;
+  color: inherit;
+  width: auto;
+  /* make sure input baseline aligns with prompt */
+  vertical-align: baseline;
+  /* padding + margin = 0.5em between prompt and cursor */
+  padding: 0em 0.25em;
+  margin: 0em 0.25em;
+}
+input.raw_input:focus {
+  box-shadow: none;
+}
+p.p-space {
+  margin-bottom: 10px;
+}
+div.output_unrecognized {
+  padding: 5px;
+  font-weight: bold;
+  color: red;
+}
+div.output_unrecognized a {
+  color: inherit;
+  text-decoration: none;
+}
+div.output_unrecognized a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+.rendered_html {
+  color: #000;
+  /* any extras will just be numbers: */
+}
+.rendered_html em {
+  font-style: italic;
+}
+.rendered_html strong {
+  font-weight: bold;
+}
+.rendered_html u {
+  text-decoration: underline;
+}
+.rendered_html :link {
+  text-decoration: underline;
+}
+.rendered_html :visited {
+  text-decoration: underline;
+}
+.rendered_html h1 {
+  font-size: 185.7%;
+  margin: 1.08em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h2 {
+  font-size: 157.1%;
+  margin: 1.27em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h3 {
+  font-size: 128.6%;
+  margin: 1.55em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h4 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h5 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+  font-style: italic;
+}
+.rendered_html h6 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+  font-style: italic;
+}
+.rendered_html h1:first-child {
+  margin-top: 0.538em;
+}
+.rendered_html h2:first-child {
+  margin-top: 0.636em;
+}
+.rendered_html h3:first-child {
+  margin-top: 0.777em;
+}
+.rendered_html h4:first-child {
+  margin-top: 1em;
+}
+.rendered_html h5:first-child {
+  margin-top: 1em;
+}
+.rendered_html h6:first-child {
+  margin-top: 1em;
+}
+.rendered_html ul:not(.list-inline),
+.rendered_html ol:not(.list-inline) {
+  padding-left: 2em;
+}
+.rendered_html ul {
+  list-style: disc;
+}
+.rendered_html ul ul {
+  list-style: square;
+  margin-top: 0;
+}
+.rendered_html ul ul ul {
+  list-style: circle;
+}
+.rendered_html ol {
+  list-style: decimal;
+}
+.rendered_html ol ol {
+  list-style: upper-alpha;
+  margin-top: 0;
+}
+.rendered_html ol ol ol {
+  list-style: lower-alpha;
+}
+.rendered_html ol ol ol ol {
+  list-style: lower-roman;
+}
+.rendered_html ol ol ol ol ol {
+  list-style: decimal;
+}
+.rendered_html * + ul {
+  margin-top: 1em;
+}
+.rendered_html * + ol {
+  margin-top: 1em;
+}
+.rendered_html hr {
+  color: black;
+  background-color: black;
+}
+.rendered_html pre {
+  margin: 1em 2em;
+  padding: 0px;
+  background-color: #fff;
+}
+.rendered_html code {
+  background-color: #eff0f1;
+}
+.rendered_html p code {
+  padding: 1px 5px;
+}
+.rendered_html pre code {
+  background-color: #fff;
+}
+.rendered_html pre,
+.rendered_html code {
+  border: 0;
+  color: #000;
+  font-size: 100%;
+}
+.rendered_html blockquote {
+  margin: 1em 2em;
+}
+.rendered_html table {
+  margin-left: auto;
+  margin-right: auto;
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  color: black;
+  font-size: 12px;
+  table-layout: fixed;
+}
+.rendered_html thead {
+  border-bottom: 1px solid black;
+  vertical-align: bottom;
+}
+.rendered_html tr,
+.rendered_html th,
+.rendered_html td {
+  text-align: right;
+  vertical-align: middle;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
+}
+.rendered_html th {
+  font-weight: bold;
+}
+.rendered_html tbody tr:nth-child(odd) {
+  background: #f5f5f5;
+}
+.rendered_html tbody tr:hover {
+  background: rgba(66, 165, 245, 0.2);
+}
+.rendered_html * + table {
+  margin-top: 1em;
+}
+.rendered_html p {
+  text-align: left;
+}
+.rendered_html * + p {
+  margin-top: 1em;
+}
+.rendered_html img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.rendered_html * + img {
+  margin-top: 1em;
+}
+.rendered_html img,
+.rendered_html svg {
+  max-width: 100%;
+  height: auto;
+}
+.rendered_html img.unconfined,
+.rendered_html svg.unconfined {
+  max-width: none;
+}
+.rendered_html .alert {
+  margin-bottom: initial;
+}
+.rendered_html * + .alert {
+  margin-top: 1em;
+}
+[dir="rtl"] .rendered_html p {
+  text-align: right;
+}
+div.text_cell {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+@media (max-width: 540px) {
+  div.text_cell > div.prompt {
+    display: none;
+  }
+}
+div.text_cell_render {
+  /*font-family: "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;*/
+  outline: none;
+  resize: none;
+  width: inherit;
+  border-style: none;
+  padding: 0.5em 0.5em 0.5em 0.4em;
+  color: #000;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+a.anchor-link:link {
+  text-decoration: none;
+  padding: 0px 20px;
+  visibility: hidden;
+}
+h1:hover .anchor-link,
+h2:hover .anchor-link,
+h3:hover .anchor-link,
+h4:hover .anchor-link,
+h5:hover .anchor-link,
+h6:hover .anchor-link {
+  visibility: visible;
+}
+.text_cell.rendered .input_area {
+  display: none;
+}
+.text_cell.rendered .rendered_html {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.text_cell.rendered .rendered_html tr,
+.text_cell.rendered .rendered_html th,
+.text_cell.rendered .rendered_html td {
+  max-width: none;
+}
+.text_cell.unrendered .text_cell_render {
+  display: none;
+}
+.text_cell .dropzone .input_area {
+  border: 2px dashed #bababa;
+  margin: -1px;
+}
+.cm-header-1,
+.cm-header-2,
+.cm-header-3,
+.cm-header-4,
+.cm-header-5,
+.cm-header-6 {
+  font-weight: bold;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.cm-header-1 {
+  font-size: 185.7%;
+}
+.cm-header-2 {
+  font-size: 157.1%;
+}
+.cm-header-3 {
+  font-size: 128.6%;
+}
+.cm-header-4 {
+  font-size: 110%;
+}
+.cm-header-5 {
+  font-size: 100%;
+  font-style: italic;
+}
+.cm-header-6 {
+  font-size: 100%;
+  font-style: italic;
+}
+/*!
+*
+* IPython notebook webapp
+*
+*/
+@media (max-width: 767px) {
+  .notebook_app {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+#ipython-main-app {
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  height: 100%;
+}
+div#notebook_panel {
+  margin: 0px;
+  padding: 0px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  height: 100%;
+}
+div#notebook {
+  font-size: 14px;
+  line-height: 20px;
+  overflow-y: hidden;
+  overflow-x: auto;
+  width: 100%;
+  /* This spaces the page away from the edge of the notebook area */
+  padding-top: 20px;
+  margin: 0px;
+  outline: none;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  min-height: 100%;
+}
+@media not print {
+  #notebook-container {
+    padding: 15px;
+    background-color: #fff;
+    min-height: 0;
+    -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+    box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  }
+}
+@media print {
+  #notebook-container {
+    width: 100%;
+  }
+}
+div.ui-widget-content {
+  border: 1px solid #ababab;
+  outline: none;
+}
+pre.dialog {
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  padding: 0.4em;
+  padding-left: 2em;
+}
+p.dialog {
+  padding: 0.2em;
+}
+/* Word-wrap output correctly.  This is the CSS3 spelling, though Firefox seems
+   to not honor it correctly.  Webkit browsers (Chrome, rekonq, Safari) do.
+ */
+pre,
+code,
+kbd,
+samp {
+  white-space: pre-wrap;
+}
+#fonttest {
+  font-family: monospace;
+}
+p {
+  margin-bottom: 0;
+}
+.end_space {
+  min-height: 100px;
+  transition: height .2s ease;
+}
+.notebook_app > #header {
+  -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+}
+@media not print {
+  .notebook_app {
+    background-color: #EEE;
+  }
+}
+kbd {
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+  margin: 2px;
+  padding-left: 2px;
+  padding-right: 2px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+.jupyter-keybindings {
+  padding: 1px;
+  line-height: 24px;
+  border-bottom: 1px solid gray;
+}
+.jupyter-keybindings input {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+.jupyter-keybindings i {
+  padding: 6px;
+}
+.well code {
+  background-color: #ffffff;
+  border-color: #ababab;
+  border-width: 1px;
+  border-style: solid;
+  padding: 2px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+/* CSS for the cell toolbar */
+.celltoolbar {
+  border: thin solid #CFCFCF;
+  border-bottom: none;
+  background: #EEE;
+  border-radius: 2px 2px 0px 0px;
+  width: 100%;
+  height: 29px;
+  padding-right: 4px;
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  /* Old browsers */
+  -webkit-box-pack: end;
+  -moz-box-pack: end;
+  box-pack: end;
+  /* Modern browsers */
+  justify-content: flex-end;
+  display: -webkit-flex;
+}
+@media print {
+  .celltoolbar {
+    display: none;
+  }
+}
+.ctb_hideshow {
+  display: none;
+  vertical-align: bottom;
+}
+/* ctb_show is added to the ctb_hideshow div to show the cell toolbar.
+   Cell toolbars are only shown when the ctb_global_show class is also set.
+*/
+.ctb_global_show .ctb_show.ctb_hideshow {
+  display: block;
+}
+.ctb_global_show .ctb_show + .input_area,
+.ctb_global_show .ctb_show + div.text_cell_input,
+.ctb_global_show .ctb_show ~ div.text_cell_render {
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
+}
+.ctb_global_show .ctb_show ~ div.text_cell_render {
+  border: 1px solid #cfcfcf;
+}
+.celltoolbar {
+  font-size: 87%;
+  padding-top: 3px;
+}
+.celltoolbar select {
+  display: block;
+  width: 100%;
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #555555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+  width: inherit;
+  font-size: inherit;
+  height: 22px;
+  padding: 0px;
+  display: inline-block;
+}
+.celltoolbar select:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.celltoolbar select::-moz-placeholder {
+  color: #999;
+  opacity: 1;
+}
+.celltoolbar select:-ms-input-placeholder {
+  color: #999;
+}
+.celltoolbar select::-webkit-input-placeholder {
+  color: #999;
+}
+.celltoolbar select::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+.celltoolbar select[disabled],
+.celltoolbar select[readonly],
+fieldset[disabled] .celltoolbar select {
+  background-color: #eeeeee;
+  opacity: 1;
+}
+.celltoolbar select[disabled],
+fieldset[disabled] .celltoolbar select {
+  cursor: not-allowed;
+}
+textarea.celltoolbar select {
+  height: auto;
+}
+select.celltoolbar select {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.celltoolbar select,
+select[multiple].celltoolbar select {
+  height: auto;
+}
+.celltoolbar label {
+  margin-left: 5px;
+  margin-right: 5px;
+}
+.tags_button_container {
+  width: 100%;
+  display: flex;
+}
+.tag-container {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  overflow: hidden;
+  position: relative;
+}
+.tag-container > * {
+  margin: 0 4px;
+}
+.remove-tag-btn {
+  margin-left: 4px;
+}
+.tags-input {
+  display: flex;
+}
+.cell-tag:last-child:after {
+  content: "";
+  position: absolute;
+  right: 0;
+  width: 40px;
+  height: 100%;
+  /* Fade to background color of cell toolbar */
+  background: linear-gradient(to right, rgba(0, 0, 0, 0), #EEE);
+}
+.tags-input > * {
+  margin-left: 4px;
+}
+.cell-tag,
+.tags-input input,
+.tags-input button {
+  display: block;
+  width: 100%;
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #555555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+  box-shadow: none;
+  width: inherit;
+  font-size: inherit;
+  height: 22px;
+  line-height: 22px;
+  padding: 0px 4px;
+  display: inline-block;
+}
+.cell-tag:focus,
+.tags-input input:focus,
+.tags-input button:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.cell-tag::-moz-placeholder,
+.tags-input input::-moz-placeholder,
+.tags-input button::-moz-placeholder {
+  color: #999;
+  opacity: 1;
+}
+.cell-tag:-ms-input-placeholder,
+.tags-input input:-ms-input-placeholder,
+.tags-input button:-ms-input-placeholder {
+  color: #999;
+}
+.cell-tag::-webkit-input-placeholder,
+.tags-input input::-webkit-input-placeholder,
+.tags-input button::-webkit-input-placeholder {
+  color: #999;
+}
+.cell-tag::-ms-expand,
+.tags-input input::-ms-expand,
+.tags-input button::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+.cell-tag[disabled],
+.tags-input input[disabled],
+.tags-input button[disabled],
+.cell-tag[readonly],
+.tags-input input[readonly],
+.tags-input button[readonly],
+fieldset[disabled] .cell-tag,
+fieldset[disabled] .tags-input input,
+fieldset[disabled] .tags-input button {
+  background-color: #eeeeee;
+  opacity: 1;
+}
+.cell-tag[disabled],
+.tags-input input[disabled],
+.tags-input button[disabled],
+fieldset[disabled] .cell-tag,
+fieldset[disabled] .tags-input input,
+fieldset[disabled] .tags-input button {
+  cursor: not-allowed;
+}
+textarea.cell-tag,
+textarea.tags-input input,
+textarea.tags-input button {
+  height: auto;
+}
+select.cell-tag,
+select.tags-input input,
+select.tags-input button {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.cell-tag,
+textarea.tags-input input,
+textarea.tags-input button,
+select[multiple].cell-tag,
+select[multiple].tags-input input,
+select[multiple].tags-input button {
+  height: auto;
+}
+.cell-tag,
+.tags-input button {
+  padding: 0px 4px;
+}
+.cell-tag {
+  background-color: #fff;
+  white-space: nowrap;
+}
+.tags-input input[type=text]:focus {
+  outline: none;
+  box-shadow: none;
+  border-color: #ccc;
+}
+.completions {
+  position: absolute;
+  z-index: 110;
+  overflow: hidden;
+  border: 1px solid #ababab;
+  border-radius: 2px;
+  -webkit-box-shadow: 0px 6px 10px -1px #adadad;
+  box-shadow: 0px 6px 10px -1px #adadad;
+  line-height: 1;
+}
+.completions select {
+  background: white;
+  outline: none;
+  border: none;
+  padding: 0px;
+  margin: 0px;
+  overflow: auto;
+  font-family: monospace;
+  font-size: 110%;
+  color: #000;
+  width: auto;
+}
+.completions select option.context {
+  color: #286090;
+}
+#kernel_logo_widget .current_kernel_logo {
+  display: none;
+  margin-top: -1px;
+  margin-bottom: -1px;
+  width: 32px;
+  height: 32px;
+}
+[dir="rtl"] #kernel_logo_widget {
+  float: left !important;
+  float: left;
+}
+.modal .modal-body .move-path {
+  display: flex;
+  flex-direction: row;
+  justify-content: space;
+  align-items: center;
+}
+.modal .modal-body .move-path .server-root {
+  padding-right: 20px;
+}
+.modal .modal-body .move-path .path-input {
+  flex: 1;
+}
+#menubar {
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  margin-top: 1px;
+}
+#menubar .navbar {
+  border-top: 1px;
+  border-radius: 0px 0px 2px 2px;
+  margin-bottom: 0px;
+}
+#menubar .navbar-toggle {
+  float: left;
+  padding-top: 7px;
+  padding-bottom: 7px;
+  border: none;
+}
+#menubar .navbar-collapse {
+  clear: left;
+}
+[dir="rtl"] #menubar .navbar-toggle {
+  float: right;
+}
+[dir="rtl"] #menubar .navbar-collapse {
+  clear: right;
+}
+[dir="rtl"] #menubar .navbar-nav {
+  float: right;
+}
+[dir="rtl"] #menubar .nav {
+  padding-right: 0px;
+}
+[dir="rtl"] #menubar .navbar-nav > li {
+  float: right;
+}
+[dir="rtl"] #menubar .navbar-right {
+  float: left !important;
+}
+[dir="rtl"] ul.dropdown-menu {
+  text-align: right;
+  left: auto;
+}
+[dir="rtl"] ul#new-menu.dropdown-menu {
+  right: auto;
+  left: 0;
+}
+.nav-wrapper {
+  border-bottom: 1px solid #e7e7e7;
+}
+i.menu-icon {
+  padding-top: 4px;
+}
+[dir="rtl"] i.menu-icon.pull-right {
+  float: left !important;
+  float: left;
+}
+ul#help_menu li a {
+  overflow: hidden;
+  padding-right: 2.2em;
+}
+ul#help_menu li a i {
+  margin-right: -1.2em;
+}
+[dir="rtl"] ul#help_menu li a {
+  padding-left: 2.2em;
+}
+[dir="rtl"] ul#help_menu li a i {
+  margin-right: 0;
+  margin-left: -1.2em;
+}
+[dir="rtl"] ul#help_menu li a i.pull-right {
+  float: left !important;
+  float: left;
+}
+.dropdown-submenu {
+  position: relative;
+}
+.dropdown-submenu > .dropdown-menu {
+  top: 0;
+  left: 100%;
+  margin-top: -6px;
+  margin-left: -1px;
+}
+[dir="rtl"] .dropdown-submenu > .dropdown-menu {
+  right: 100%;
+  margin-right: -1px;
+}
+.dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+.dropdown-submenu > a:after {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: block;
+  content: "\f0da";
+  float: right;
+  color: #333333;
+  margin-top: 2px;
+  margin-right: -10px;
+}
+.dropdown-submenu > a:after.fa-pull-left {
+  margin-right: .3em;
+}
+.dropdown-submenu > a:after.fa-pull-right {
+  margin-left: .3em;
+}
+.dropdown-submenu > a:after.pull-left {
+  margin-right: .3em;
+}
+.dropdown-submenu > a:after.pull-right {
+  margin-left: .3em;
+}
+[dir="rtl"] .dropdown-submenu > a:after {
+  float: left;
+  content: "\f0d9";
+  margin-right: 0;
+  margin-left: -10px;
+}
+.dropdown-submenu:hover > a:after {
+  color: #262626;
+}
+.dropdown-submenu.pull-left {
+  float: none;
+}
+.dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+}
+#notification_area {
+  float: right !important;
+  float: right;
+  z-index: 10;
+}
+[dir="rtl"] #notification_area {
+  float: left !important;
+  float: left;
+}
+.indicator_area {
+  float: right !important;
+  float: right;
+  color: #777;
+  margin-left: 5px;
+  margin-right: 5px;
+  width: 11px;
+  z-index: 10;
+  text-align: center;
+  width: auto;
+}
+[dir="rtl"] .indicator_area {
+  float: left !important;
+  float: left;
+}
+#kernel_indicator {
+  float: right !important;
+  float: right;
+  color: #777;
+  margin-left: 5px;
+  margin-right: 5px;
+  width: 11px;
+  z-index: 10;
+  text-align: center;
+  width: auto;
+  border-left: 1px solid;
+}
+#kernel_indicator .kernel_indicator_name {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+[dir="rtl"] #kernel_indicator {
+  float: left !important;
+  float: left;
+  border-left: 0;
+  border-right: 1px solid;
+}
+#modal_indicator {
+  float: right !important;
+  float: right;
+  color: #777;
+  margin-left: 5px;
+  margin-right: 5px;
+  width: 11px;
+  z-index: 10;
+  text-align: center;
+  width: auto;
+}
+[dir="rtl"] #modal_indicator {
+  float: left !important;
+  float: left;
+}
+#readonly-indicator {
+  float: right !important;
+  float: right;
+  color: #777;
+  margin-left: 5px;
+  margin-right: 5px;
+  width: 11px;
+  z-index: 10;
+  text-align: center;
+  width: auto;
+  margin-top: 2px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  display: none;
+}
+.modal_indicator:before {
+  width: 1.28571429em;
+  text-align: center;
+}
+.edit_mode .modal_indicator:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f040";
+}
+.edit_mode .modal_indicator:before.fa-pull-left {
+  margin-right: .3em;
+}
+.edit_mode .modal_indicator:before.fa-pull-right {
+  margin-left: .3em;
+}
+.edit_mode .modal_indicator:before.pull-left {
+  margin-right: .3em;
+}
+.edit_mode .modal_indicator:before.pull-right {
+  margin-left: .3em;
+}
+.command_mode .modal_indicator:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: ' ';
+}
+.command_mode .modal_indicator:before.fa-pull-left {
+  margin-right: .3em;
+}
+.command_mode .modal_indicator:before.fa-pull-right {
+  margin-left: .3em;
+}
+.command_mode .modal_indicator:before.pull-left {
+  margin-right: .3em;
+}
+.command_mode .modal_indicator:before.pull-right {
+  margin-left: .3em;
+}
+.kernel_idle_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f10c";
+}
+.kernel_idle_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_idle_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.kernel_idle_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_idle_icon:before.pull-right {
+  margin-left: .3em;
+}
+.kernel_busy_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f111";
+}
+.kernel_busy_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_busy_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.kernel_busy_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_busy_icon:before.pull-right {
+  margin-left: .3em;
+}
+.kernel_dead_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f1e2";
+}
+.kernel_dead_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_dead_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.kernel_dead_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_dead_icon:before.pull-right {
+  margin-left: .3em;
+}
+.kernel_disconnected_icon:before {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: "\f127";
+}
+.kernel_disconnected_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_disconnected_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
+.kernel_disconnected_icon:before.pull-left {
+  margin-right: .3em;
+}
+.kernel_disconnected_icon:before.pull-right {
+  margin-left: .3em;
+}
+.notification_widget {
+  color: #777;
+  z-index: 10;
+  background: rgba(240, 240, 240, 0.5);
+  margin-right: 4px;
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+.notification_widget:focus,
+.notification_widget.focus {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #8c8c8c;
+}
+.notification_widget:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+.notification_widget:active,
+.notification_widget.active,
+.open > .dropdown-toggle.notification_widget {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+.notification_widget:active:hover,
+.notification_widget.active:hover,
+.open > .dropdown-toggle.notification_widget:hover,
+.notification_widget:active:focus,
+.notification_widget.active:focus,
+.open > .dropdown-toggle.notification_widget:focus,
+.notification_widget:active.focus,
+.notification_widget.active.focus,
+.open > .dropdown-toggle.notification_widget.focus {
+  color: #333;
+  background-color: #d4d4d4;
+  border-color: #8c8c8c;
+}
+.notification_widget:active,
+.notification_widget.active,
+.open > .dropdown-toggle.notification_widget {
+  background-image: none;
+}
+.notification_widget.disabled:hover,
+.notification_widget[disabled]:hover,
+fieldset[disabled] .notification_widget:hover,
+.notification_widget.disabled:focus,
+.notification_widget[disabled]:focus,
+fieldset[disabled] .notification_widget:focus,
+.notification_widget.disabled.focus,
+.notification_widget[disabled].focus,
+fieldset[disabled] .notification_widget.focus {
+  background-color: #fff;
+  border-color: #ccc;
+}
+.notification_widget .badge {
+  color: #fff;
+  background-color: #333;
+}
+.notification_widget.warning {
+  color: #fff;
+  background-color: #f0ad4e;
+  border-color: #eea236;
+}
+.notification_widget.warning:focus,
+.notification_widget.warning.focus {
+  color: #fff;
+  background-color: #ec971f;
+  border-color: #985f0d;
+}
+.notification_widget.warning:hover {
+  color: #fff;
+  background-color: #ec971f;
+  border-color: #d58512;
+}
+.notification_widget.warning:active,
+.notification_widget.warning.active,
+.open > .dropdown-toggle.notification_widget.warning {
+  color: #fff;
+  background-color: #ec971f;
+  border-color: #d58512;
+}
+.notification_widget.warning:active:hover,
+.notification_widget.warning.active:hover,
+.open > .dropdown-toggle.notification_widget.warning:hover,
+.notification_widget.warning:active:focus,
+.notification_widget.warning.active:focus,
+.open > .dropdown-toggle.notification_widget.warning:focus,
+.notification_widget.warning:active.focus,
+.notification_widget.warning.active.focus,
+.open > .dropdown-toggle.notification_widget.warning.focus {
+  color: #fff;
+  background-color: #d58512;
+  border-color: #985f0d;
+}
+.notification_widget.warning:active,
+.notification_widget.warning.active,
+.open > .dropdown-toggle.notification_widget.warning {
+  background-image: none;
+}
+.notification_widget.warning.disabled:hover,
+.notification_widget.warning[disabled]:hover,
+fieldset[disabled] .notification_widget.warning:hover,
+.notification_widget.warning.disabled:focus,
+.notification_widget.warning[disabled]:focus,
+fieldset[disabled] .notification_widget.warning:focus,
+.notification_widget.warning.disabled.focus,
+.notification_widget.warning[disabled].focus,
+fieldset[disabled] .notification_widget.warning.focus {
+  background-color: #f0ad4e;
+  border-color: #eea236;
+}
+.notification_widget.warning .badge {
+  color: #f0ad4e;
+  background-color: #fff;
+}
+.notification_widget.success {
+  color: #fff;
+  background-color: #5cb85c;
+  border-color: #4cae4c;
+}
+.notification_widget.success:focus,
+.notification_widget.success.focus {
+  color: #fff;
+  background-color: #449d44;
+  border-color: #255625;
+}
+.notification_widget.success:hover {
+  color: #fff;
+  background-color: #449d44;
+  border-color: #398439;
+}
+.notification_widget.success:active,
+.notification_widget.success.active,
+.open > .dropdown-toggle.notification_widget.success {
+  color: #fff;
+  background-color: #449d44;
+  border-color: #398439;
+}
+.notification_widget.success:active:hover,
+.notification_widget.success.active:hover,
+.open > .dropdown-toggle.notification_widget.success:hover,
+.notification_widget.success:active:focus,
+.notification_widget.success.active:focus,
+.open > .dropdown-toggle.notification_widget.success:focus,
+.notification_widget.success:active.focus,
+.notification_widget.success.active.focus,
+.open > .dropdown-toggle.notification_widget.success.focus {
+  color: #fff;
+  background-color: #398439;
+  border-color: #255625;
+}
+.notification_widget.success:active,
+.notification_widget.success.active,
+.open > .dropdown-toggle.notification_widget.success {
+  background-image: none;
+}
+.notification_widget.success.disabled:hover,
+.notification_widget.success[disabled]:hover,
+fieldset[disabled] .notification_widget.success:hover,
+.notification_widget.success.disabled:focus,
+.notification_widget.success[disabled]:focus,
+fieldset[disabled] .notification_widget.success:focus,
+.notification_widget.success.disabled.focus,
+.notification_widget.success[disabled].focus,
+fieldset[disabled] .notification_widget.success.focus {
+  background-color: #5cb85c;
+  border-color: #4cae4c;
+}
+.notification_widget.success .badge {
+  color: #5cb85c;
+  background-color: #fff;
+}
+.notification_widget.info {
+  color: #fff;
+  background-color: #5bc0de;
+  border-color: #46b8da;
+}
+.notification_widget.info:focus,
+.notification_widget.info.focus {
+  color: #fff;
+  background-color: #31b0d5;
+  border-color: #1b6d85;
+}
+.notification_widget.info:hover {
+  color: #fff;
+  background-color: #31b0d5;
+  border-color: #269abc;
+}
+.notification_widget.info:active,
+.notification_widget.info.active,
+.open > .dropdown-toggle.notification_widget.info {
+  color: #fff;
+  background-color: #31b0d5;
+  border-color: #269abc;
+}
+.notification_widget.info:active:hover,
+.notification_widget.info.active:hover,
+.open > .dropdown-toggle.notification_widget.info:hover,
+.notification_widget.info:active:focus,
+.notification_widget.info.active:focus,
+.open > .dropdown-toggle.notification_widget.info:focus,
+.notification_widget.info:active.focus,
+.notification_widget.info.active.focus,
+.open > .dropdown-toggle.notification_widget.info.focus {
+  color: #fff;
+  background-color: #269abc;
+  border-color: #1b6d85;
+}
+.notification_widget.info:active,
+.notification_widget.info.active,
+.open > .dropdown-toggle.notification_widget.info {
+  background-image: none;
+}
+.notification_widget.info.disabled:hover,
+.notification_widget.info[disabled]:hover,
+fieldset[disabled] .notification_widget.info:hover,
+.notification_widget.info.disabled:focus,
+.notification_widget.info[disabled]:focus,
+fieldset[disabled] .notification_widget.info:focus,
+.notification_widget.info.disabled.focus,
+.notification_widget.info[disabled].focus,
+fieldset[disabled] .notification_widget.info.focus {
+  background-color: #5bc0de;
+  border-color: #46b8da;
+}
+.notification_widget.info .badge {
+  color: #5bc0de;
+  background-color: #fff;
+}
+.notification_widget.danger {
+  color: #fff;
+  background-color: #d9534f;
+  border-color: #d43f3a;
+}
+.notification_widget.danger:focus,
+.notification_widget.danger.focus {
+  color: #fff;
+  background-color: #c9302c;
+  border-color: #761c19;
+}
+.notification_widget.danger:hover {
+  color: #fff;
+  background-color: #c9302c;
+  border-color: #ac2925;
+}
+.notification_widget.danger:active,
+.notification_widget.danger.active,
+.open > .dropdown-toggle.notification_widget.danger {
+  color: #fff;
+  background-color: #c9302c;
+  border-color: #ac2925;
+}
+.notification_widget.danger:active:hover,
+.notification_widget.danger.active:hover,
+.open > .dropdown-toggle.notification_widget.danger:hover,
+.notification_widget.danger:active:focus,
+.notification_widget.danger.active:focus,
+.open > .dropdown-toggle.notification_widget.danger:focus,
+.notification_widget.danger:active.focus,
+.notification_widget.danger.active.focus,
+.open > .dropdown-toggle.notification_widget.danger.focus {
+  color: #fff;
+  background-color: #ac2925;
+  border-color: #761c19;
+}
+.notification_widget.danger:active,
+.notification_widget.danger.active,
+.open > .dropdown-toggle.notification_widget.danger {
+  background-image: none;
+}
+.notification_widget.danger.disabled:hover,
+.notification_widget.danger[disabled]:hover,
+fieldset[disabled] .notification_widget.danger:hover,
+.notification_widget.danger.disabled:focus,
+.notification_widget.danger[disabled]:focus,
+fieldset[disabled] .notification_widget.danger:focus,
+.notification_widget.danger.disabled.focus,
+.notification_widget.danger[disabled].focus,
+fieldset[disabled] .notification_widget.danger.focus {
+  background-color: #d9534f;
+  border-color: #d43f3a;
+}
+.notification_widget.danger .badge {
+  color: #d9534f;
+  background-color: #fff;
+}
+div#pager {
+  background-color: #fff;
+  font-size: 14px;
+  line-height: 20px;
+  overflow: hidden;
+  display: none;
+  position: fixed;
+  bottom: 0px;
+  width: 100%;
+  max-height: 50%;
+  padding-top: 8px;
+  -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  /* Display over codemirror */
+  z-index: 100;
+  /* Hack which prevents jquery ui resizable from changing top. */
+  top: auto !important;
+}
+div#pager pre {
+  line-height: 1.21429em;
+  color: #000;
+  background-color: #f7f7f7;
+  padding: 0.4em;
+}
+div#pager #pager-button-area {
+  position: absolute;
+  top: 8px;
+  right: 20px;
+}
+div#pager #pager-contents {
+  position: relative;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+}
+div#pager #pager-contents #pager-container {
+  position: relative;
+  padding: 15px 0px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+div#pager .ui-resizable-handle {
+  top: 0px;
+  height: 8px;
+  background: #f7f7f7;
+  border-top: 1px solid #cfcfcf;
+  border-bottom: 1px solid #cfcfcf;
+  /* This injects handle bars (a short, wide = symbol) for 
+        the resize handle. */
+}
+div#pager .ui-resizable-handle::after {
+  content: '';
+  top: 2px;
+  left: 50%;
+  height: 3px;
+  width: 30px;
+  margin-left: -15px;
+  position: absolute;
+  border-top: 1px solid #cfcfcf;
+}
+.quickhelp {
+  /* Old browsers */
+  display: -webkit-box;
+  -webkit-box-orient: horizontal;
+  -webkit-box-align: stretch;
+  display: -moz-box;
+  -moz-box-orient: horizontal;
+  -moz-box-align: stretch;
+  display: box;
+  box-orient: horizontal;
+  box-align: stretch;
+  /* Modern browsers */
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  line-height: 1.8em;
+}
+.shortcut_key {
+  display: inline-block;
+  width: 21ex;
+  text-align: right;
+  font-family: monospace;
+}
+.shortcut_descr {
+  display: inline-block;
+  /* Old browsers */
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  /* Modern browsers */
+  flex: 1;
+}
+span.save_widget {
+  height: 30px;
+  margin-top: 4px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: baseline;
+  width: 50%;
+  flex: 1;
+}
+span.save_widget span.filename {
+  height: 100%;
+  line-height: 1em;
+  margin-left: 16px;
+  border: none;
+  font-size: 146.5%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  border-radius: 2px;
+}
+span.save_widget span.filename:hover {
+  background-color: #e6e6e6;
+}
+[dir="rtl"] span.save_widget.pull-left {
+  float: right !important;
+  float: right;
+}
+[dir="rtl"] span.save_widget span.filename {
+  margin-left: 0;
+  margin-right: 16px;
+}
+span.checkpoint_status,
+span.autosave_status {
+  font-size: small;
+  white-space: nowrap;
+  padding: 0 5px;
+}
+@media (max-width: 767px) {
+  span.save_widget {
+    font-size: small;
+    padding: 0 0 0 5px;
+  }
+  span.checkpoint_status,
+  span.autosave_status {
+    display: none;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  span.checkpoint_status {
+    display: none;
+  }
+  span.autosave_status {
+    font-size: x-small;
+  }
+}
+.toolbar {
+  padding: 0px;
+  margin-left: -5px;
+  margin-top: 2px;
+  margin-bottom: 5px;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+.toolbar select,
+.toolbar label {
+  width: auto;
+  vertical-align: middle;
+  margin-right: 2px;
+  margin-bottom: 0px;
+  display: inline;
+  font-size: 92%;
+  margin-left: 0.3em;
+  margin-right: 0.3em;
+  padding: 0px;
+  padding-top: 3px;
+}
+.toolbar .btn {
+  padding: 2px 8px;
+}
+.toolbar .btn-group {
+  margin-top: 0px;
+  margin-left: 5px;
+}
+.toolbar-btn-label {
+  margin-left: 6px;
+}
+#maintoolbar {
+  margin-bottom: -3px;
+  margin-top: -8px;
+  border: 0px;
+  min-height: 27px;
+  margin-left: 0px;
+  padding-top: 11px;
+  padding-bottom: 3px;
+}
+#maintoolbar .navbar-text {
+  float: none;
+  vertical-align: middle;
+  text-align: right;
+  margin-left: 5px;
+  margin-right: 0px;
+  margin-top: 0px;
+}
+.select-xs {
+  height: 24px;
+}
+[dir="rtl"] .btn-group > .btn,
+.btn-group-vertical > .btn {
+  float: right;
+}
+.pulse,
+.dropdown-menu > li > a.pulse,
+li.pulse > a.dropdown-toggle,
+li.pulse.open > a.dropdown-toggle {
+  background-color: #F37626;
+  color: white;
+}
+/**
+ * Primary styles
+ *
+ * Author: Jupyter Development Team
+ */
+/** WARNING IF YOU ARE EDITTING THIS FILE, if this is a .css file, It has a lot
+ * of chance of beeing generated from the ../less/[samename].less file, you can
+ * try to get back the less file by reverting somme commit in history
+ **/
+/*
+ * We'll try to get something pretty, so we
+ * have some strange css to have the scroll bar on
+ * the left with fix button on the top right of the tooltip
+ */
+@-moz-keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@-webkit-keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@-moz-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+/*properties of tooltip after "expand"*/
+.bigtooltip {
+  overflow: auto;
+  height: 200px;
+  -webkit-transition-property: height;
+  -webkit-transition-duration: 500ms;
+  -moz-transition-property: height;
+  -moz-transition-duration: 500ms;
+  transition-property: height;
+  transition-duration: 500ms;
+}
+/*properties of tooltip before "expand"*/
+.smalltooltip {
+  -webkit-transition-property: height;
+  -webkit-transition-duration: 500ms;
+  -moz-transition-property: height;
+  -moz-transition-duration: 500ms;
+  transition-property: height;
+  transition-duration: 500ms;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 80px;
+}
+.tooltipbuttons {
+  position: absolute;
+  padding-right: 15px;
+  top: 0px;
+  right: 0px;
+}
+.tooltiptext {
+  /*avoid the button to overlap on some docstring*/
+  padding-right: 30px;
+}
+.ipython_tooltip {
+  max-width: 700px;
+  /*fade-in animation when inserted*/
+  -webkit-animation: fadeOut 400ms;
+  -moz-animation: fadeOut 400ms;
+  animation: fadeOut 400ms;
+  -webkit-animation: fadeIn 400ms;
+  -moz-animation: fadeIn 400ms;
+  animation: fadeIn 400ms;
+  vertical-align: middle;
+  background-color: #f7f7f7;
+  overflow: visible;
+  border: #ababab 1px solid;
+  outline: none;
+  padding: 3px;
+  margin: 0px;
+  padding-left: 7px;
+  font-family: monospace;
+  min-height: 50px;
+  -moz-box-shadow: 0px 6px 10px -1px #adadad;
+  -webkit-box-shadow: 0px 6px 10px -1px #adadad;
+  box-shadow: 0px 6px 10px -1px #adadad;
+  border-radius: 2px;
+  position: absolute;
+  z-index: 1000;
+}
+.ipython_tooltip a {
+  float: right;
+}
+.ipython_tooltip .tooltiptext pre {
+  border: 0;
+  border-radius: 0;
+  font-size: 100%;
+  background-color: #f7f7f7;
+}
+.pretooltiparrow {
+  left: 0px;
+  margin: 0px;
+  top: -16px;
+  width: 40px;
+  height: 16px;
+  overflow: hidden;
+  position: absolute;
+}
+.pretooltiparrow:before {
+  background-color: #f7f7f7;
+  border: 1px #ababab solid;
+  z-index: 11;
+  content: "";
+  position: absolute;
+  left: 15px;
+  top: 10px;
+  width: 25px;
+  height: 25px;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+}
+ul.typeahead-list i {
+  margin-left: -10px;
+  width: 18px;
+}
+[dir="rtl"] ul.typeahead-list i {
+  margin-left: 0;
+  margin-right: -10px;
+}
+ul.typeahead-list {
+  max-height: 80vh;
+  overflow: auto;
+}
+ul.typeahead-list > li > a {
+  /** Firefox bug **/
+  /* see https://github.com/jupyter/notebook/issues/559 */
+  white-space: normal;
+}
+ul.typeahead-list  > li > a.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .typeahead-list {
+  text-align: right;
+}
+.cmd-palette .modal-body {
+  padding: 7px;
+}
+.cmd-palette form {
+  background: white;
+}
+.cmd-palette input {
+  outline: none;
+}
+.no-shortcut {
+  min-width: 20px;
+  color: transparent;
+}
+[dir="rtl"] .no-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .command-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
+.command-shortcut:before {
+  content: "(command mode)";
+  padding-right: 3px;
+  color: #777777;
+}
+.edit-shortcut:before {
+  content: "(edit)";
+  padding-right: 3px;
+  color: #777777;
+}
+[dir="rtl"] .edit-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
+#find-and-replace #replace-preview .match,
+#find-and-replace #replace-preview .insert {
+  background-color: #BBDEFB;
+  border-color: #90CAF9;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0px;
+}
+[dir="ltr"] #find-and-replace .input-group-btn + .form-control {
+  border-left: none;
+}
+[dir="rtl"] #find-and-replace .input-group-btn + .form-control {
+  border-right: none;
+}
+#find-and-replace #replace-preview .replace .match {
+  background-color: #FFCDD2;
+  border-color: #EF9A9A;
+  border-radius: 0px;
+}
+#find-and-replace #replace-preview .replace .insert {
+  background-color: #C8E6C9;
+  border-color: #A5D6A7;
+  border-radius: 0px;
+}
+#find-and-replace #replace-preview {
+  max-height: 60vh;
+  overflow: auto;
+}
+#find-and-replace #replace-preview pre {
+  padding: 5px 10px;
+}
+.terminal-app {
+  background: #EEE;
+}
+.terminal-app #header {
+  background: #fff;
+  -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+  box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
+}
+.terminal-app .terminal {
+  width: 100%;
+  float: left;
+  font-family: monospace;
+  color: white;
+  background: black;
+  padding: 0.4em;
+  border-radius: 2px;
+  -webkit-box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.4);
+  box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.4);
+}
+.terminal-app .terminal,
+.terminal-app .terminal dummy-screen {
+  line-height: 1em;
+  font-size: 14px;
+}
+.terminal-app .terminal .xterm-rows {
+  padding: 10px;
+}
+.terminal-app .terminal-cursor {
+  color: black;
+  background: white;
+}
+.terminal-app #terminado-container {
+  margin-top: 20px;
+}
+/*# sourceMappingURL=style.min.css.map */
+    </style>
+<style type="text/css">
+    .highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f8f8f8; }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #0000FF } /* Name.Function.Magic */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .vm { color: #19177C } /* Name.Variable.Magic */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+    </style>
+
+
+<style type="text/css">
+/* Overrides of notebook CSS for static HTML export */
+body {
+  overflow: visible;
+  padding: 8px;
+}
+
+div#notebook {
+  overflow: visible;
+  border-top: none;
+}@media print {
+  div.cell {
+    display: block;
+    page-break-inside: avoid;
+  } 
+  div.output_wrapper { 
+    display: block;
+    page-break-inside: avoid; 
+  }
+  div.output { 
+    display: block;
+    page-break-inside: avoid; 
+  }
+}
+</style>
+
+<!-- Custom stylesheet, it must be in the same directory as the html file -->
+<link rel="stylesheet" href="custom.css">
+
+<!-- Loading mathjax macro -->
+<!-- Load mathjax -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML"></script>
+    <!-- MathJax configuration -->
+    <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+        tex2jax: {
+            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+            processEscapes: true,
+            processEnvironments: true
+        },
+        // Center justify equations in code and markdown cells. Elsewhere
+        // we use CSS to left justify single line equations in code cells.
+        displayAlign: 'center',
+        "HTML-CSS": {
+            styles: {'.MathJax_Display': {"margin": 0}},
+            linebreaks: { automatic: true }
+        }
+    });
+    </script>
+    <!-- End of mathjax configuration --></head>
+<body>
+  <div tabindex="-1" id="notebook" class="border-box-sizing">
+    <div class="container" id="notebook-container">
+
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">nd</span>
+<span class="kn">import</span> <span class="nn">xarray</span> <span class="k">as</span> <span class="nn">xr</span>
+<span class="kn">import</span> <span class="nn">matplotlib.pyplot</span> <span class="k">as</span> <span class="nn">plt</span>
+<span class="kn">import</span> <span class="nn">numpy</span> <span class="k">as</span> <span class="nn">np</span>
+<span class="kn">import</span> <span class="nn">calendar</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[2]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">plt</span><span class="o">.</span><span class="n">rcParams</span><span class="p">[</span><span class="s1">&#39;figure.figsize&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="mi">12</span><span class="p">,</span> <span class="mi">8</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Reading-data">Reading data<a class="anchor-link" href="#Reading-data">&#182;</a></h1><p>For this example we are using a subset of the GHRSST sea surface temperature data set
+(<a href="https://www.ghrsst.org/ghrsst-data-services/products/">https://www.ghrsst.org/ghrsst-data-services/products/</a>).</p>
+<p>The provided subset contains the monthly mean temperature in the region of the gulf stream for the year 2019.</p>
+<p>We can read the NetCDF file using <code>xarray</code> and convert the temperature to degrees Celsius:</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">ds</span> <span class="o">=</span> <span class="n">xr</span><span class="o">.</span><span class="n">open_dataset</span><span class="p">(</span><span class="s1">&#39;ghrsst_gulf_2019.nc&#39;</span><span class="p">)</span>
+<span class="n">sst_celsius</span> <span class="o">=</span> <span class="n">ds</span><span class="p">[</span><span class="s1">&#39;analysed_sst&#39;</span><span class="p">]</span> <span class="o">-</span> <span class="mf">273.15</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>We can create a simple visualization of the data for January using built-in plotting methods in <code>xarray</code>:</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[4]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">sst_celsius</span><span class="o">.</span><span class="n">isel</span><span class="p">(</span><span class="n">time</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">cmap</span><span class="o">=</span><span class="s1">&#39;plasma&#39;</span><span class="p">,</span> <span class="n">vmin</span><span class="o">=-</span><span class="mi">10</span><span class="p">,</span> <span class="n">vmax</span><span class="o">=</span><span class="mi">30</span><span class="p">);</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+
+
+<div class="output_png output_subarea ">
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAqoAAAHxCAYAAAClJJ7DAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9a7B1x1km9ry99vkkWVd7fBNmbDMXxlNQgwmaTGoIyRDIZDIhITDAp6tlDLaDjTy2fEFCioSEVJItWZJlbMcSlm3pu8JgCoaaTMZDxVSmhgJkMBfHJAQwjLHx3bJkS/rOXv3mR/fb6+1evS57n332Xvucfqp2nbPXpVevXmv3etbz3oiZUVBQUFBQUFBQUDA1mE13oKCgoKCgoKCgoCCHQlQLCgoKCgoKCgomiUJUCwoKCgoKCgoKJolCVAsKCgoKCgoKCiaJQlQLCgoKCgoKCgomiUJUCwoKCgoKCgoKJolCVAsKDjmI6IVE9AQRVZvuS0FBQUFBgUYhqgUFhwxE9Eki+l75zsx/ycznMXO9yX51gYjOIqL3EdFfENHjRPR7RPTfJ9t8DxH9MRF9nYj+TyJ6kVr33X7ZY0T0yUz7/5iIftu3/QdE9F8O9OfFvr2v+2N+r1p3MRH9KhF9moiYiF480NZ3E9EfEtFXiOiLRPTLRPQCtf5HiOg/+mN9ZGisCgoKCg4aClEtKCiYOmYA/hOA/xrAhQD+VwC/ICSQiJ4N4EN++bMAPArgtNr/awAeAvDmtGEiehaAXwVwF4CLALwNwL8momf29OckgN8D8DcA3ADgXxHRc/w6C+DfAvgXI8/t/wbw3zHzRQC+AcCfAHiPWv8lAPcBuHNkewUFBQUHCoWoFhQcIhDRIwBeCEfGniCit3iFkIlo5rf5CBHd5pW8J4joXxPR3yCi40T0VSL6Ha0UEtFLiOjDRPQlIvp/iOhHVtlnZv4aM/8MM3+SmS0z/xqAPwfwHX6THwTwcWb+RWZ+CsDPAPg2InqJ3/+3mfkRAH+Waf4fA/is37dm5mMAPu/bbIGIvhnAfwbgZmZ+kpl/CcAfwhNTZv4sM78bwO+MPLfPMvOn1aIawN9R6/89M/8CgE+3di4oKCg4BChEtaDgEIGZrwLwlwD+R2/uf1vHppcCuArACwD8bQC/CeD9cIrlJwDcDABEdC6ADwM4AeC5AC4D8G4i+pZco0T0bm/mzn3+YMw5ENHzAHwzgI/7Rd8C4PfVOX4NwJ/65YPN+U+67Fs7tv8WAH/GzI+rZb8/8lj5Djgf4a8AeBLAm+BU3YKCgoICFKJaUFCQx/uZ+U+Z+TEA/zuAP/Xq3hzALwL4dr/d9wH4JDO/n5nnzPy7AH4JwA/lGmXm1zDzRR2ffzDUKSLaAXAcwAeZ+Y/94vMAPJZs+hiA80ec538E8A1EdBkR7RDR1XDE/Bkd2+/lWFl4H+GLADwbwI0A/nhgl4KCgoJDg0JUCwoKcvis+v/JzPfz/P8vAvCPtDIK4AoAz191h4jIAHgEwBkAP6lWPQHggmTzCwA8jgEw8xcBfD+Aa+HO8Z8B+PcAPuWP+XHv/vAEEX3XXo5FRN+l2vp4up6ZvwTggwB+RdwwCgoKCg47ymRYUHD4wCts6z8B+A1m/m/HbExE/xuAKztW/wUzd7kMEID3AXgegH/OzLtq9ccBXK22PRdOFW2RwRyY+TcA/EO/7wzObeDtfl3UH++j+reI6Hxl/v82ONeHoeP8X2gIfhdmcC4UF8AFUhUUFBQcahRFtaDg8OGzAP7Witr6NQDfTERXedP5DhH9QyL6+7mNmfl/8b6xuU+fn+d7APx9ON/aJ5N1vwzgW4noXxDR2QBuAvAH4hpARMYv33Ff6WwiOiI7E9G3+35fAOBuAJ9i5v+jo///L4CPAbjZt/MDAP4BnLuDtHc2gLP817P89yyI6AeJ6O/5Pj4HwD0Afs+rqyCiyu8/A2D8MXd6xqmgoKDgQKEQ1YKCw4c7ANzoTfVv2ktDXlX8p3DBV58G8NcA3oqGqO0ZPifqqwG8FMBfK/P5Fb4Pn4eLur8dwJcB/CPfH8F/Beeu8G/gMh48CeDfqfVvAfAFOHX4YgA/MNClSwFc4o91J4Af8n0QPAnnIgA4f9OUWGu8AC6d1eNw2QNscvyr/P7vAfBd/v8HB/pXUFBQcGBAzKu0AhYUFBQUFBQUFBSsBkVRLSgoKCgoKCgomCT2naiSK9f4h0T0MSJ61C97lk8Q/if+b18VmIKCgoKCgoKCghXC+7z/NhH9vs9wcotfPimOti5F9buZ+aXMfIn/fh2AX2fmvwvg1/33goKCgoKCgoKC9eBpAP8NM38bXAzAPyOi/wIT42ibMv1/P1y+QPi///OG+lFQUFBQUFBQcOjADhL4ueM/jIlxtHUQVQbw74joo0T0Kr/secz8GQDwf5+7hn4UFBQUFBQUFBR4+BR4HwPwOQAfZubfwsQ42joS/n8nM3+aiJ4L4MNENLo8oCe2rwKAc8899zte8pKX7FcfCzaEz/2ez2meVlvP4Lkvfdb+dqagoKATn/rolxfeZ8TPeuNYV96b/RiLF3xHv+ugXLNFjj1mPDZ1XfdyXJIzo3Zbf8V//gVmfs4emt8zvvefPoO/+MV65e1+7HfPfBzAU2rRA8z8gHxh5hrAS4noIgC/TETfuvJO7BH7TlSZ+dP+7+eI6JcB/OcAPktEFzPzZ4joYjgmn9v3AQAPAMAll1zCjz766H53t2CNuP/CY8B5AGVmH0PxdGmZcM2jXQWNCgoK9htvNKcB5M1wQwQi3Udvbyi/XGMRMml7Nk5X2QXaHWpLIz0P07MubJOsSLdLj3d7fbSnBw5v8dcs7cOd9iiu8+v0/8C4MekyxY4lkmPHziSkcsy9ohFvz2EZwT1j5Nlz/dOX/8WI5vYVX/xijY/85gtW3u5FZ/35Uyo+qBPM/BUi+ghcGelRHG1d2FfTPxGdS0Tny/9wicH/CMCvoil5eDWAX9nPfmwLbp6dxs2z08MbHgDcf+ExAG2SaohbJBUArvlKIakFBZvAG83pQFIBR2RSMsM9H72PVduH9rghl7n9bxsgZLK/bqerX9F+va0Og3o+AoPmIdtaR/EnbbPveIuSVKB9vnfao7jTHg1t6z4vi7EvFH3nGd03/prKsqF7JUW8PYVlri3CtNLIE2Cr1X/6jkj0HK+kgojOAfC9cEVKJsXR9ltRfR6clCzHOsHM/5aIfgfALxDRjwH4SwA/vM/9mDxunp3GLfOjgazeMh+eiAoKCgo2BSE+Q8SGERMS6/dpLedYAROCcb05jTts93x4fULIxnCPvZLUIYxVkLu22S/cmYzjDVUzdoRm7AyWH6P0ug5Bth1z3aRtuTfSsRw6NoMaFwBZNimyunZcDOCDRFTBXfZfYOZfI6LfxIQ42r4SVWb+MwDflln+RQDfs5/H3iaIiqrV1INOVl/32JVBVS0oKNhe5AhNStSECwiJ6COrKRjAdeZ0OM7bErKVktjrTL9VamokNUes0u30uAwpzF1Ix02TVN2XZYm+Pu8cYcy9hIw9dvoSk7aj1+WO3b0/ZS14GwEDZNfr/cvMfwDg2zPLJ8XR1hFMVZDgsJj3h5DzTbXsFk5m8igoOMR44wDp60JKZITEaMLapcgOKWxv9n26q0Nl1T6Xi5LSPnV4DCEX9JG0sT6qe8Xb7NEwVoM+xNQmj4uqql3XPLycKLLYRVr7rr3sn7706DakXb0/tbYhWObgqyrPnILpohDVCeOgq6p90G+6r/3yVRvuTUFBwV4gCqpAq165dbn9U7zZnO4lqxqpv2aKMX6ZY303p0BSU6RqalcfLC/mApC7Vqs4lTFtjCGsXdsxYrI6GRTSnMWmEv4XjMRhCrBKYZlgmfDOi4qLQEHB1MCc/3QhDcLSQTB24KPRFYTThz6itsqHYC5YKrdOr99vktpF5vuyIywKfa3Sa5oGzqVYZAz6AuZy2+lt04AsR1bXl55sCARn+l/15yCgKKobgKikKQHV6mm67iCqqzqSPyWjoqYWs0xBwWaQmv3HBp3IdjnXHiBv8s+pXkMgNErpGMVQtulK2bQXLKKiLkNMDQG3LjH/d5FUgeXYxzcNTBvTfnqfaIV8kfHNuR8sgq57KOcWUJ4q24WiqE4ImpympPSgkdQU13zlyvDJLS8oKNgclomMHtqnL83Vohgy7WuMIbVjkVN3lyGpfemagOVI6ibRR5D7yOgq1OW+gKz2trRSZXlPYIDs6j8HAUVRnRi6zPwHUVHtwjVfuRLveuYjm+5GQcGBxthAqb2k79H7DimsAskGoDGGv2iyOkRGZX1fhoBFONNQsv5NpqTqQi7ll16mMy2MwduT9saMcQ5D2QH08q5x7fKd1fs1wVlFX506ClFdMw6rv+miKAFUBQX7g0Ui+btIqiYwy5jlmBd3DViETowlrXcmxEyw3yR1bPtCrG5UqaSWTU+1KLpIajqeKUFNIWOs3Qq60kWlGCKtQ4RVY5G0VRvDAVFAV41CVAsKCgoKRiN9lg4l/r+H20TmWmr7v6bEtSsbwKK8YhGldZH2xxDQSZGgPeBt9ijeYk4v7TaxqO9rDnv1YQXiggFNeqo9d201YKBkZcyjENWCgoKCAwxNCrtUzBRjlNQUOUI6dttr6fQosgoslxJJ2kh9WfuS84dtehpfxfYafTxlXUpqFxYlqX3kdFkCL/utilyWwKrtQCGqa8SiZv/D4pPah9uPnAr/33Dm0g32pKDgcCMlqfctQEyHoIlrLooc6Hcx6FJb03362lhEDV2UoHbto5HjXpskp6sMOtNYZFy7+OhelOpUVZ2SiHlQgp9WjUJUJ4qxJFXI70EktZqkAsAdZ50EEVAZN7W8+euXb6JbBQVbgdS8vlc1VbBKgprD2zMpj4Duykcay9aZj9pdIPBpL+qpRm7Ity3SX+N6c3ohMtm1aZykf/WYnI9qQRaFqK4Rt8yPtohlXy7VPvTlWd128nqbJ6gyf6TlVMkniL73/OMAgDc8fsU6u1dQsHXYK0ldxKy/CiySLWCRYK5BF4GRJHWKUfxTwSL+qIu+VKyCrE76Gk3GYXZaKER1zdjP/KgHIaPAbUpFTdWR65++DHefe6K1jxDWMSiktmA/cOvOKdy0eylu3XH37027m3NTWVZJTbFuctqFIdI6lrCuiqQu2/4i2FY1VUjqmLKxy2BsW8ukN9s4SjBVJ0rC/y3FLfOjo0jutpVglaTXFbnsdjecuRQ7M8bOjHHPeSdgvOmfiEGEwU+KRUhtQcEiEJIq/+vv68JeSapsPxWSmqKvXKsQ1q5nfZ+/Y1cE/xhzf1+i/rFYRRtTgz6nZcrF6n0WNc9T8uk7RsH0URTVgsng9iOngpnfGMCAcfe5J8JkQn7dIg9f2XYvScsLCpbFFBTWsRjKh7lO3MNHW6Q7h658rCFgBqtVY/ZCbHL7ppZewva6bAFNwYAbVN7X9LzHpJnKjdWiY58eYytIaQmmyqIoqluOvkltW5TUO846iTvOOgmjVFJDjMqwy3VHnCWpqe9qH7TKet8FRVUtOHhYVk19uz06KZIqWEbVzT3n9bJVv6/uJedq3/Jth1ZSc1jHee9FkS2YFoqiegCgg7S6MLUSrHecdTL6btQrkyaoQD85HUNWLZdZqmBzWIeaukyuVGBaKmqK12cU1Wykv58C5LxFRdU+7tqPNU1l1VXdaKjAwJhhHlt9Sat/2x4Muwr0ReMf1NmcAFAJpsqiKKoHBKnPam6Sm4rCqkmqVlDbKmq8ziji2ueHmi7T+xYU7Ae6yOi6TP59v4cUoqBOmaSuCpv81ef9Xjn69GEq8/WqIYFit9VHl/I9LTh8KIrqAcYYpXUTkIepkFD5nqqoZqRP6hBZ5aCYNA+G+y88htc9duVS/S8oyEFI6bqDqHI5R7swdXKaU1HHoK+i1SLK6ljitEyATo6YEhgMyvptbqOiKvlTu8b0Vv9MIgA3zdoZAvoExXRY+66VbmfsdhsHo/iodqAQ1QOGrvRXUzL9N8R0MZKaU0WLWb9gatgvFfWN5nSLaI4hqVMnp4Ihkpoz/43OD4txatyyCeBX6QM5lXl6L7itPoobfUCVTrWlhRMZMj2rC2Hf63iO3X9qvqvF8JdHIaoFa8Vdz9BR/O6vNvW775ys7/71GuJBskpUov4LDgY0WX3zASKpy6CPpC7i05aS2JQoDZHcVZGdMdHwU4dE/d9YtStT3TxrlunzJLTJ6hCmRjAL9heFqG4IfSb5/XijnsJb+t3nnkgU0nbAlMkS1nj25hWoqJapmP8Ltg4GMUEVQpazGG6KpP7LRBl9R0/0/lhTvyaeQyrqGJKapq0aIqsaQxHt+X26GaiY/4FpzNOrQBAj0DzrDLXXA26sc+qqxqp46ZBf8MZRTP9ZFKK6AUzRb3S/kVaUiiqXZHPm5UlqijGm/1ZicL+PZcJ9FxzH679aqlUVTB9vt0cnp6JeQ23SnEKIa0pYlyGpi6xbFIuQ1RR7JUA37x4MgqoxltBrJTlVV1fbn4mT1IJOFKK6ZgyR1IPyRq2hSWpMUHkhJXUsipm/4LChT1ndD1yzRNCTJqyrCJpahKS2AnE6tusiq3p5uk0hQG3cOj+KW3ba1zgdK1GS+8hqjucu6se6FdeIASqKahaFqE4IB42k3nOeI6gpOdXo8kftIqna7C/KaI6YLhJkpQsApG3l3AyufeLy0W0XFKwLd61JSV2GpGoIYR2Vh1T9H+aIBY61jMk4JUmarPYRpEX9Jm88M61qZTdWp3Fbvfp7aMjtQWBILF2rDXzbCpIqKCpLFoWoFuwL7j3/+KAvWWUWI6kaOZK6CDnV+y1aD72gYGpYF0kFgHf2+Jym/qn7Df3TTWeNrp91SnRzIlaa2moVkegaUySpq8AdZ50M8/DNPena+lK5LRJU1lWsQdBFUksw1nahENWCPSNXkrTP7zTdRi/vI6msfEvdd0Tf9bJFoOuFy9+m2g2vJHiroGCvkFRUKdFaJ0kdwjv46L6Q1VRNzf0iF1Fohyysen3Yh+P0STnyOnamuP3IKdywQrIqRVSuf/qywW3vPPskrnvqsmifnRU6+8p8fvuRU71a5m1HTkVZAIRUSl5ZWT4GY18kpk5Qi+k/j0JU14yDZN6//8JjgypmLrVULjfqkIqaksUxJDVHMLuO8/qvXhER7q6UVsXsX7Bp5EjUlKCDptatsI5BFxfoUmTTDAFjMFQJb6z1586zHZm87ql+ArqoVUjatUy47cgpVPtA4Awx6sx55vIMd6moYwlrVxWwgoOBQlQLlsL9Fx4DMDwhC8YorGPQNcFrUtmngMq6NC1WThUuKJgKuhL7T0lNXQTLZgDYCwzGk1S9rC8TgPtOia9l3nKkccPT3WqqkEiNt54TL/upJ/PEVdTSHN56zkn81JOXJQFpcR5qrfR2kWStlN6oth2yZnGiN3epoDpdV+jnggprDlNXU0tlqm4UolowGu+86Fjv+q63+j5COsYflZmyymnOT7VxD+jqS7OdPnbaR8tUCgUUbBx96agOSjL/vZDUMf6msl1uXfrz1iVW9TaiqgaVdYSpWc+H6dyYEs+u/XIwxLjrGSd8P+TFe7jtZr94nyozB7/1nJNhvW6PWZNG948Q2tx8adkR1HQ+Ft9Uvfym3Utx686pFkmNz2EcWR2jpk6Rt5bKVHkUolowCilJHWNqGlJMx5LU5n/3dy9lU+UB00dSZZmNMgwsfciCgj0jJVrbQlK1z2pX4v803dNesGhFKg2b/J9rS0f+x3+7M4CuIlizay6V5X1zYrqv3if1yQf6STTQENIbzlyaVX81btq9NJumqgt9JDWHbS2VWrAYClEtGMSQkqrRNnu1J1gOSmi/D6kOntIkdS8qZ9+EpR8oTjlgWDTHY24m8S7TW0HBKpBTUoU4bZu5v68ylaCLrAph1AGPufV7RU5tTdsOfUGerBLc/zWT+x8cSN0qXuwF6Ty1yL6dxxvRP01sU3eArqIqtx85hZt3Lw35wyVGQxPYdfiSrjprw76hmP6zKES1oBfveuYjGKt3jCGpQ8iR12u+ciXuPf94WL9sIYAURO08ru3++PNI+iX+XgUFq8Zbesz920ZS94qcaX9dAWSLHseZuDlLiMaS1T7k9s8povsFme/uPPtkUFLHHrcviDgXXNWHQZeLLTX7F3SjENWCTrzrmY+0TErpxNQ1+S6SsD8HQ4zXfvmq7H6arHalk0qd77sqYuk2UpOYPFzEL6uOfGE7u15QsGfI7alvs4NIUoeyAvSZ4FdJNlLXirEkNVVXdfS8ZQqqKrAastqF/Sasb/66y3aiTf1dxxrrmrXJsrGrvn9WghJM1YlCVAuySElql3+onogFfeZ+3UbXREeEQFKlulWu/e5ghabhXNqVnJJqEp9VfZ6R+Y4R7VdQsEpcl6ipOcJ6UJCS1CHyIL9BbYIn5AOglsGY/fWxa2Xut9yY/V2/2C8ngIcCSn3bTEuZ8HNtCVZJXHMq6hApXSRX7CK+rDmUdFQHF4WoFrTgzP0NclH2qZ/UWOKm22iRXj9Jz2vCvecfXzrRfpe60K6AFX8vKNgkrlMJ/VNh5aCpqYvkV9Wqat9cM+QWkI5rd/jTahACN9GQUM686OpzWgVZ1dhL5hKZn8Xk3+WHui2Yup8qAaAtG9N1oRDVgggucCqvpMZpoPxyDE+suYpSuUnudY9dCQDBHzVb+WUEycylbBGsiqQW/9SCVUMTJ0247jxgJHUZ9AU2Uc92QxhDVtNpJCLO6MsCgOCzqskqgBZhTckq0J6b9tN1IEU6P6fR/WNIqlZTbz9yqrVslTgwamox/WdRiGoBgCaBf/qmrwmqzlHaEEgXGW/kb6bkaBq1L20LiFxlKAC4+9wmz1/7WDG6AqF0XsA+n9oukpp3eSh+qQX7gxur02C0c0QyDh5JvUYpqYua6tMMAMuQ1VwJ1WW4X4s4Z8gq4Air9ROHzgjQ9KeZw1LymiOsqyKrXWRYrwPGvZBLC7luSZnWISVzWbP/XgjqJP1UC7IoRLUAQNs0lcIl3dfbjzOjDJFUoCGpAPCmr10eklk3E/byJptlJ3Wt+qZpspjdBDymrnZBQR9urCRFD1pk9aCRVAB4Jx+NyOqyGCKrQ+irUrUK6P4wXOUqmcf0Oj3vrkMtTZXQMaR0KFcq0B77vSinQj6HcqoeGBVVUIKpOlGI6iHHXc84gcrIpN+eGDSpNATU6ofkHhLuESuqap2p6NRFUN/w+BXIoW/yloh/ZigFNw6QStvqQl851oaUUlBT5SMQtQBAIa0FC0NIqmC/fSangncmeVX36q+aI6tjXABy6uoY5Nptl1Vt3ALc+sYVoL19PI/llNVUVdXr+7BI4BPg0u7pY+UyoKToavXOs0+O6uMtO6ezpHMsYRWkYkYp0nJwUIjqIYablPzE6h+TXRPLtU9cHvYROHN/TFZluSA3OXYRVA2ZnN/0tcuj5fecd6Izl+oqAhG6SGrXJF+i/wsWRUpQNW6vD56K2oexJPU+PhpKreZI6LLKKrCYupoe9057FNf35L3tQmolWreymiO7aUWqvQRLjVFhBcsoo+k+OYvbULnVSU7dhVxnUYjqIYVMJI1/aUM4gWYC06Sy5VDv95VffFA4Mv5P2rw/FpK7T+PaJy4PKau0qhr6pMjqUA7YHLr2Kf6pBfuJ2w4ZQV0EmqSm2EsWAI0xZDVHUgHgDnsUN1Sns8RHiHOjslIgWTlXgC6sOhtA6N+KiXFfH9NqVmNB4IVLq24ryB6O81wUhagecrCaJXXC6hyxTAOghCjCMohckv1QyQnA67565b70WZNVKHcDwE2UdY8fVg46b2p8js3g5ExoooAUs39BwWqwjCKqXQCAhlASVpdjdQhRgBTll/eRVfd/28TfRyKXTQs41M5elNShWIfbfPQ/ANx45lLcunMqv2ECTVYXUWC7Yhvi61VUiKmjENVDiuueuiwopDnlMoVLLxITtFbN6YwKuwzGRJoKWdU+q0Dbz7avqIBgjHuC9kfV+5VJrmBRFPW0wTv4aDbxv17fpaZG+wyQtlWWXu0KcttLjs5NR6D3jd+iVqWuefH2IzEpHUtSBfuhrE5q/mYU038HClE9xFjWFKOhCar4sa4bcTqs9i8959O6jCtCDkVNLSjYP4whqSlWlWO1q90cciS1j1JpVbW1bkXm+HW5K8lhYvV4+ASGfEhzyI3Zoi8IsvmkSGpBLwpRLRiFXLqRRRTZ/cC1T1yOu889EU1U7Ryu7q+BI6t7VXuB/Fgce9GD4f8r/+KVez5GQcFhwTt8FoBFov9z0AFCmqwCcTYADfFNHUtgc2rqTbOm34twpjRtVR+6SNUqfUz7iG1X9gC9i/6/y193k0gJ6iQDYYuPahaFqBYsjVUosntFmhUAgPJfbbAOtbcEXBUU7B/SyH8gTzDTtFVD2G//1U1g03PR1KbClP5pkjopwrqBPKpE9DcBPAzg+b4HDzDzO4joZwC8EsDn/aY/zcz/Zv09LER1q5Cr3nHzbvF3S6FJqat0tXcMmfhtTWAmfP3pnVCwYFNK8xgMVYIp91XBFKDN94u4AbR86P3fu+xRvMWnk0oJqo78zxGtHJ9ZVk1dJfS5DhHUsdul7WeXj29i3zAmWKrZtlFS91pC+4BhDuCNzPy7RHQ+gI8S0Yf9unuZ+e4N9g1AIaoFBxw5xXW/UVvCmZpw8+x0NJnfOt8s+btl5/RoArrItgUFq0AusKoP9yWFA4TICgF9e8ZM/5Ylcp4K3pa0p0nqprGogjqWsKbru3xPU1/TvQSW7RVbS1I3FEzFzJ8B8Bn//+NE9AkAL1h/T7pxEK0eBQVrR20Nzsyr1uRH/lORI3+LRrquGrfsnB5dV3vZ+tsFBetAl8K6V+tpjivcNVDOdgwvG1tyehkIAdNELD52ngH17bMXrKMq1JgANkOc9UnNEdcDjGcT0aPq86quDYnoxQC+HcBv+UU/SUR/QEQPEdEz19DXfL94084sI3HJJZfwo48+uulubBzF/D9NPHTxQ5jXBk89PcO8NnjyjEE94qc1tp71TbvL187WWJR8lnurYN1IVdVRJLBj+T1KdX2jOQ2TtKf36zL750jqzWXlxWUAACAASURBVF5NHQogCsfJkiqO1ueCfXLkqtXOQK7VIfQVRulTVDlanm97HDlfbj+NPhUVaCupzf/u7xu/dsVHmfmSxY66WlzyknP4t3/+xStvt/quPx51bkR0HoDfAHA7M3+IiJ4H4Atwl/pnAVzMzK9YeQdHoJj+txyFSKwWt+6cisjj2PF9xWfc7/ee805gt5Y8gj7JdmZ7mZzH5AY05BJlp1vlsg8MQZ+PkNahZQUF68Q7Okz6q4AEWHVlAdC/1RxBld+HpFaizH63eBefVVgk9hrVL4VZ+pBW8tP7jNm/u93x22myukqSmo5djqQWAES0A+CXABxn5g8BADN/Vq1/EMCvbah7hahuGwqBWC9uVn5o8gC6/cipMBF2BVkRATPTFCKok7QjenIeU2llP+bU3L1U7q+CqaGvhCow3n8tlw1gkd/VrTunFDGN90z9z4dI6jL17XOJ9MeQ2LGKq67Q14Ux23T2Qx+31e7e2ovbao8t0QR9UnPYQ1WwZUFEBOB9AD7BzPeo5Rd7/1UA+AEAf7T2znkUolpw4NAXCCQR+QLLBGZfDpbJE0g3oTEomkDl4TPzy4hcLlmZBOWBUBm3v5BRrYpYCxgTV3vJTfyp24Dos3qxVHrpM8GtymWgoGAdeKMPdsoFQi2Da9OqV1LBTpvUR7al5wLLDON/1JbdC+0tI4IlV5GwflUwFCvKzA0RHaOqpvNRF3Knl1Oih/bpQhcx1X9ThdWE9RMirwzQBtJTAfhOAFcB+EMi+phf9tMALiOil7qe4ZMAXr2R3qEQ1YIDCHkYpCX7bjhzadsUBA5lVw1YkdW8Wd4tU9+TN/V0AqzIV8byM33ln4oy8c9r8subNmpLuGm3qYOdSwhOyf+yd2pGu3XnVCGrBVsDTRrf7EnrXfZoiPBflRtA9PLYcfyx0L+5PiV1GRW1D8u4BKTziHy33BDSIbI6TnntWh7vmyO7iyilOQyNSzH5x2Dm/4D8sG8kZ2oOJeq/4EDhtiOnUBFwx1knYYhRGcaschPcvecfx6xiHJlZHJlZzCq3bsf/NcYRxooYFUmAA4ePhiixAvLbG8OYVTYcd1Yxdvzx9OesHfc59+wa555dh++Vcf0DYjX0xjOXtnxSJaLVkOszwc02huLPbUc2m2mgoGAsKv95izmdfXKmKan2ArGkaFj10bh15xQsI3yAmHjeMj+aJam5+SP9fbrtZN1yZDZtU7ett+nbH+hWINP/0352nRMhnqeQ+U7JJ91G5vE0s0HXR/rady4CZmpVM9woLK3+cwBQFNWCAwuZrHY8OZXJLkxc/kFVW1diFd6ntLYUqatAo7AKtKm/OV4cZRpN5sm2WlWo/HbMsbIKtE33VXIMgSghuu0JGbUKCkYhEBU4sjiGrF5LpzurUI1RS/cSsKRdjMYopmNSKq0SovYuoiKOVVaBYfN/Gnkv6FNnu/YZ2/dcWyWAartRFNWCA4HbjpxqKYdE8OS0eRuvjPXfOZBN8kqoIWea14Q2VSlv2r0UN46Itm8mSM5+KmMzn4b83n/hMdx/4bGoTfGHzSkHqYKg+14R446zTi4/uAUFa8DNs9PYMXGqpjGQFFQ2WXZPQmhz7n+yzWDie6+LauiXyKH8yKnCmSqIbpt8Wqq9Yi/krE9Z1YqohlZSZfv2S318jJbK2jPHDampad+3CrwPnwOAoqgWHCjIBCkkVUzwlbGoKo5UT2ZCXRMq4/8nCgpCZZzSKmY+a4Favflf//RluPPsk+4BR017pFTNMOn618FYKWjPIMzu+GxdAQFm4L4LjgeVt8q8VuYqzIQ0M8xBLSIC3nqOI6s/9WR/OdiCgnXhreecDL+tihwhJAA1gDvqxc38KTlNoZXXdNvUlQdoCGhMKN3f246cGp0/NCVzY6L3+4hXTPTyfdgL9LwSLDWZ1wejmFCalSANaFrm+F3jNDZl1lYl82ccGFP9qlGIasHWI+eDKT6jjqw6kupUU20eZ1QVUNfkVc7YHaAyTRDUTz3ZLsV63VMx4bv3/OMRcQUc+YTlQFZd3/I+U0QMYkYNgwrW7+se4mmEriA8pKgh1fLw0A+WveZjLChYNe4574R/+SLYWu5lZwq+bUGS2uW7uohP6z18NGQJeLs9ituOnBokgdo1SH/XyKmmwDhymu6zbmQJq3IHSIOs9D5dZDNto+uYOfeqdBuNtK020W/vs44KWgV7RyGqBQcGoqZKUJQRB3zjTPuVaaie84GjYIp3aiaA2i2vDDu/VHZk857zXFqra59oE9YUlp2PqyiwRATDDCagqprJPHYPaCbayjBq65z8qSYQGdS26Us43yh5dePrxdxkGpD0V8xOFS4o2DTuu+A4DDFmlftumXBkBjx1xr3N3Thfb5YKrazmFNmU3+S4TWrWj9flyWlfcFIfutTUrlRLabDQGHLWInX6OJK+T6xNS/iY5l6m9f5j0ki1zit/qKidsO1UCeqUArsmhEJUC7Yat+6cSiZr99d4IlgZi1llo7d9pwSwI6vJxBCWgxb273nD41eE/+VhDPhcqSB/vDQgilsKRKN+Msg4kgsjRQPyAVtErl05FhEDltzknbgFiAJtueRZLVgP7j73RMiKIVHcggqMM3OD65++DPecdwJ3n3sCtSVYC+xaQs0uTGnXOpcAhiMlqYI2ZPZfBLlKcIL4V9hep7Fo9Hy2zRHcpS8fqLyIN8fsJ2pD5Nf4sxRiKPNOV3/j/LPNNlqljfvb7JcGqAI6sEvmV4qOs2iVqy2pIn+oUYKpCg4ERE0FmgCqyrBSMNuEcAh7Mbm9/qtX4HWPXRm+B2XTtpUAOZZWWEVVMMQwVRNokAscCNvJOXsyIAFiXedRUlcVrAtCOppUQ/6+9p+zdmq886JjETHRL5EpsQpqnvqsEznBMTXx50zh+reaBg6NCRDSyLoZdOw/JrF9lFoqBH622zNqfpV9XBCq+4xNkdXl+iD7pcdPz7H5HscedB07h8mRVLsPnwOAoqgWbC3SSNs0gMp4v1QX6d9sJ6bxXNJq8rJnRYx5bSKVdBkIWb3/wmPenC+Jd5yVpzJIJlkpQMBeeTXe1ObfKf3EI4ELQX2olPLgn+q11YUivWtA8sSvi6mpYMV4z7MfBgDMKnezzmuDs480wYYS1KgVMiYCYMFswEyYswQtN0mfDLlfwVNrIhfpC17L+tKzfW+UfIfpfhmk/u5Zf9CkDhQzdR5Xt6dfllttBjej/IuFRkoGjRo5i7yCm1qLcm21ffBjhbULMgVOjqSCium/A2shqkRUAXgUwF8x8/cR0c8AeCWAz/tNfpqZJ1MFoWD6yKWD0RHukvIp9ndq5+wT0hq+qzdQrYjuFa977Erce/5xWBBqa0DGovL9IXbkVCfEtqBgGqs9KWVy/q6pyUz73gKObLNF2McRYkdSOZExbny6mP4L+iHE0xDj1Z+/unO7B577AQDy8oXwgii/u+A7nRAgudeBhpQcmTHOPE1Jgn1HtVZVXrUPN565tJXSra8i06IktZUVIMlGskqk+VBzhC5HeBuy6tdJVT2rcz83L/ypC0DIPpIx2afm+rQPXUn60+AufYwul4AhDFXZKtg81qWo/ksAnwBwgVp2LzPfvabjFxxg6GlGFFUyQlrbb/whDdQG3qilGo6tCa5WOEdprTSCn6rfTvxV9YOdGa30V5YpKMNE5IOzHMldNL1LQQHQ3FtCRl/1uZcDAB66+CEATr2PSQ4rF5wm3RoHYtEmE1Xl7lOB+KYKFs0EsAyG8g1rctTnX5lTOHMkNf+7X+zH2Xes0O8keEkT1lw7If+0yZynCoIjMMgqH1hq5tk0dVXsg9/nm8rZc5J2ZNs+suq+88pJ/76CAS7pqbLYd6JKRN8I4H8AcDuAa/f7eAWHAy7fIkeT/jln+dKlM+vLmDaKDqCi35W6s8636XlN0QPE7laYzRpHIqb2AwZwylRtjVdOjYsooW4lIJyvIVSQfROTv58Q7zz7ZCvNVoFDWnBhlQr7NkGIp9yblbF4/zc85P93REHM/NH2Rrum1ADkJc3AMsGqh7IxDGsJ13ylGeObZqdhef9zli9aDKMrt+cYctpFDofQ9WLZ71agiCIS1bNDqWyuXayI9+Z9NvF3cT3S82tEWtXB82OVP55rx7ehFOI0bZY7trSZV1fLi/p2YR2K6n0A3gLg/GT5TxLRy+BcAt7IzF9OdySiVwF4FQC88IUv3O9+FmwJ0praDODcs+ooSCH1r9LkdNBHdZ8gaaskFdaOsS64itx3E84mfvgF5QCNC4CeeOdz4wlvHuI+IIEKtY2ViEJW20hJakFMhnTgX5WSL9PeTv/WiDjyxXvlZ1+ePd6tc6eg3lCdzq5fBfZSsW1RP9Su/MmLHmsMUjKdI63pem3i1yTVGG63IS4czA1Ble9EwR8+EEtNTpNXj/bYxa4GAraNSpq6M8j+i6qrkzP7T60/E8G+ElUi+j4An2PmjxLRP1Gr3gPgZ+Geyj8L4O0AXpHuz8wPAHgAAC655JLyDlSAm2enXUSoV1Nn6qGo1VSd3F9DT0x6YvuJL7ws+OLtNyQ/624tSqdWVMVXNc1S4Cd907SBuiHgu7sGZx2po+MYYljvm1r5GC7xV7XuEO643Dywr3+6EFag7Vd3mPHqz1+NB577gfCbStVSoDuzhM7tCzSmzSZocH1YlJR2mfgX8UHNkdNls4mMIVVpYY+cMhmlx1NkUCvnTdaQ/PWuEF9T7U6llVb534CbjCcd/UtdmFp+uxWigFBJL5j6rSJZ3oxLQ1ZzrgMF08V+K6rfCeB/IqJ/DuBsABcQ0TFmDvYdInoQwK/tcz8KDgBunjXKCqtshmftWDXJdpuNwr5qYvqJL7ws/K8fIH1BI8vip568DG8952RLgRKFNSiqkS+X+1/Iat8b96s/fzXe+5wP9vahrTQUMtYHGX9tkj6MeNXnXo6Hv/HnASCQlhyhEKR+4Knv3dV/9WOjj337GnxTc+jzQU3/1991/s9VENR0/xyxSsuXtsqZZixFsdk9VsGbFHlNejy9HaCsUoYBK24F5Cw2QMheEgilcQKDDlhNiXJ6DN2/oKQaCm2kxDStkpUbqzSP7F6vy0pxQNJJrRr7SlSZ+XoA1wOAV1TfxMxXEtHFzPwZv9kPAPij/exHwfZDk1TBjWdcxPr9Fx7DrLIqgKptpgLiQI5NOtnr6GfxF2OLKEghJbMCMf1DArDUebzrmY+44Kkqv6+PyXIPHxBMxditi5pQMIxHXvhgIBWtaPDMi1f436ttAiLGyz714/va17ue4arIpWruqvxB0//1XJMjqX2K7JjjphhSAVuqaqJUNv2I/UM1UZRAVFKqansfBrFXU4UkWpf1wVmN2KfI40BiAec7r88l7U9ufFqKqA8WbbIHcEtdTZenbUwOjGL678Cm8qi+jYheCndpPgng1RvqR8EWwnJjWnvXMx/BrHLO/xJAlTrjNyYi9gRvGipiqCLl1dS6BqoKkEwAQDN56/yqLpLfYm4Xd6jV7TATdirG05lIU0n/dVgrV+VedA4bREE1Vbvmes56weqF0DLB1hSi/QHnmrNXknrXM07gzV+/HPecdyKoYm/62uVhXQ6533srKn6J650z93eleRpzrHS7vjkqR1YjtyZlmWn6kY+mz/fZkdQQ/a+udS4S3wgJtcZ/dy8pMvbu3uDgBtB1Tl3QuWCD32sijZrs9nHFvqYNKuLlFmFtRJWZPwLgI/7/q9Z13IKDiZt3G3OgpFDJPRRSyGT4ys+/vLVuP8z9i0LUVDHdpeqIoM6Q1Nd+2f2sHnjuBwJp+IkvvAzvflbe91YePNc/ffmKen8wcVjN/pRkiogVtzypYKVi6sBFALj6r1phCAvh7nNPZH8Ld5+bJ6hd6At8AnSO0PFt5ss458cvtywb2DnST7qrfKm2zKS5a3OlSXV/Up/U3DkE4goAMmcZG1TWGkAFG1ybmDFYCrPLjSRWTGM3AKAJtNLb63EgcuTdKgHAgHpLyW4EJT1VFqWEasHkkZr9b5krkkpNuVDtV7VNSB9EwUTWo+zs1a9qrBk0V1jhMGCsv/NBRfBHpeYl0H3vJqipSXUVY/fWc05mldJrn1js5UpcglKlU0p+Sv7l+NOUBdX7p5/mGNoFoN/8n6JvfXqcPkie5u622qVRdaaU9Dz0PumydL0UWWm+SxCWysJi4t+V/p1pZTc3rlmSHIg1lGtKXgFuXFaatseWWi3YLEoJ1YLJ45b50UBWNUl91zMfgakQTYTbitQvVZTUYDJDjgRQMOVr1U+SsQte8yUXMPauZz4SlUztcoFIyemtO6cm4wLwi3/n3QCAH/7/XrOvx9nPNGXrgijpcv0FOuBOrAjv/4aHIpOvqbrUt7Y/qny0T6gET73iM6/A+57/fvzYX//owv2/6xknvDndqaZCKO45LyauXcSsi/xJhhBNXNIX3PRlMc2/3IWxKmSKVAXUx+5qWyuEaZ9ccGZD1Nw59+dF1Qp673aaHLbuB4CoVimrDNgQakswiDME5NruTqOl1dvGlYs5rpIlfv5uDCgEb4mPrIVzPbAqGHc6oOKj2oFCVAu2ApqgCsTfSRz/DxO06X+suiquAfddcDwse8PjV0TbTF1BPWzXeVl0uXsA+TFM0xCNIakAIpLaFeG/DEl1x9P9W6qJbHtCUqso/VJMzLJplaz3KSfuVS27XAr67t1cYvpen01lzq4z5CYEaXJMyOJ8qd1Evt1enljqvofvFWBrRyo5jIUuk8ujTLm5vKi5PKpyvumLRnCrkJvH53WNyeo04hUAuMtUTP9ZFKJacCDQNZGmPnObDIx56zknl1J+5WGjCYEh9nkFXTnWRfD6r16RXT5Fkvqhl/xc9J1Uapr9xKRS1iyIdz3zEQDx78FlhOCgrrrAQ8bD3/jzLmhmNmR+zv+2QmlU2zb9L5KCKoc+ciq+hTmSkeYydcti829lmrRLxnBnFTvAvRRa6wKGbN38BvvmkrG/8VS5p5GBRpapIdBwRTxySq82f4dUdx3+pzmkmVJ8bTwfYNeY9fWx3FxMsNaAqPblddkFWokVZ8RvuOVrqoKhAESZBNJKffplIqipPvhKk9W43YKpohDVggOPKURtv/WcxZKNUxABJKiqOYeuPLB7xU27l2bJ6ibM/r/0996FWVV7Jcad7w/+8U+uvR8HBULK3vucD+LVn385PviC92EoR2YfGpO/I6k6uh9wJv+9ou/F0/2f28f97YvAN/68nU+l8qf0ijIAUES8PT3zBTMiVS4Zp0VecIZymzbn1FZopQJUXTu1sjKMWucn7XBBMEmpW43+lFfdimrcx8ZEz8SAIRiWyngcTNtkeLCufaoy96moXQFUejsDtMiqLhIwCUyoK1NCIaoFBwJjTcKGeGlT5F7QFb2v626z96lKt7cdD+f9zlKwboJ61zNOoDLAuefs4sLzq2LmXwHIAO959sORcvj+b3goUhTHjLMmKm3/zdh3cxXX7b4Ljnf6UHdFaqckNXZhaP7XJFWqL5kqUVQJ4HBwX9bNG6zrGiHNXVeqpRz0GOYS3bt+xn6isl6T1eBi4ZVLsq6McmU4URXbbaZjodGVgaCPpDZpr/pcRZr7QnzqmfOuBznymiOjaYL/HKnNbddue0Km/4JOFKJaMDnoKP+cbyrgkvyLjxmQf5AC4wIg1gGZDBv/KABMkFSA4jNFlkNAQBNQJd/X57qwXyT13vOPh2uRFhuQsXj6TIWvPnE2ZpXF+ec+hWpmN6amTiFl2SJ497Medj7byueyyYUJzGZ1FCjTlQc1XSamX1kWzN+1QZ0oqq/63PIvgvdfeMz/F/smpv3S0ARViGejkMq6mOwFouoVxiqJRjdoVGMiCwr3alO9XsqB7uU3mctvmropiNJbmYYMprlq55VzT6hriq5ZVS3vw59WtwL8NVCklIhdSirTvpeoduZ+rgiADQFQTdWqNknsI69RVoWwQzr+HX6qukqWUlWbddPAkMp8WFGIasGhgEzum1BTbztyCpT4REkQGOAjipGvRrVukrouFfXaJy7vTNBeW8LubuXIzxPnrKU/BwVCUAUzrxRWgUzkSaqgiww2ldQUibVCWPfvZTAlMlpNTYOtRLEL5vyqTfrc/6ryklIdu8bEAGADkHVtMDlfaV1z3vVt3Pmn5DnXtzS4Tad90mqhNQbGumXz2gRXGZ0vNDemFm0SmjuHHFmNziX0MZ/CivQ5wrkD5IKh0v7F45WQZRuLEn0qay5lmiaruWwLG8UE3NSmiEJUCyaFXKnUFI3q0kT+90Em7ld+9uV77d5o3LLTnAfBPUhr9lWovPlrVrEy+zuCxuz1BkPhYRWTA3c+EsE/Ndx/4bGIgAPNw+/1X72ilWWgyvjpMROe3q1Ac8ZTT1ftDfYZkr5pW9TUhy5+KPiEHpnVEdnRJu1FyGlU5Shj8o9KVIJa+ywD/bvWEd9dfXTbNeSukqAog8j/NJdqKUfadeAREMf7EBFmsxrWk0EiwJInhJ6wVhli1IWUpOYIqlZ5K2NhKvZ+2828IHNbPTeY1xV251VQuVNXDMsE1AamsoGsjkUwqSvC3IyNU1Ur04yYJP+3PpBqThXquQnbMlNcSSrjspDvR0JcbdO/WD3NZAlIqlulla0KpotCVAu2EuJjlyuZKtAPVAB48HkfWCtZjfvSRCGLSvHmrzdJy+8936WMSifpiBx0RPZuGu+86Fh4SETEk+L8sO+8qCEi13zlSrz565eHVFm5ogebOtdXf/7qKNfo1EHk8qACcOWEhXApH9Qu02/O3D8WLurfEyVr9pSNQZNUIPXLbvdNB0tFOVFVKWVRIoGG3KRVmNKx6VLXDLmAIJvcl4ba1ZG6XRTaabA0Sc2p3kIAhaQaY6OAKGZCPa/AFaFiC2sMiCwwN6EaVOpWwJZcMFOH33xX343MtT5/6qyqUc3q0EdRqdmLB2naLDIIgVW58U2xSLUu7Q7Rh0n7ozJKeqoOFKJaMCno5P5dkAkxSrnS8/vedNQ/wwVJyct7RcD1T18WbfOGx6/w/ptNUFWX2W2T5yNkU5sqNTltpduxbb9hIg55Pncqar1QuPMbr07tF1yE/PRU1Q++4H3hfz3+mozllEJBSk5Tn+4+5Nbv9eH/zouORSbbvnZN+L23E/bHL64x8XP75k3T8n8OKfEU0z+UT7yBNzubbrKaa1+7Hxhl5tfXTohhZawjhJ4Y5s9jBss1jCipNbXIW3DhUGQ116/cOOj/dR9d3/w4GnZzV22i+8+NGwNJ2rS+33hfVoKQV9UfV3w7UyU+d25RyVl/zQqmjUJUCyaLrkAqMe/pCRNoJ+zeFIRo6zyOLMEhYNxwJu8H6hSq5jslas2m8sBKDk4AmPkZIxf0IUgfRCkRzSHkg1QPVxkLe8hVhocudmqpNucDTQCQW9cmXH0Peq1Yj72netMX+ftztza474LjeHrXBVdd99Rl2e3vv/AYXvfYlZHKPiYCO0dQxR9VshrIuOSyGuQJY/fLYI5wEvkXSGpeqnJkNdrPxOppK9AtMfXL3CZKauXVyx3v2uFcOryp29ao5wbVvMasmqG2BtWuxdxUzm81yXEb/tdzjdG/2bYKG/x/Z049lf44VdUG8iwknYhBtcEcgDUGFWr34l0xUI9Ko9pC6iUUmfgNu/RhC8yPwU92MlXoqPiodqAQ1YLJoYugasiDSgdETA3a3C8YClZyJM0F1hppJLTXTMzrwruf9XC2nGbq99elWrlzGX55kNMkYld1qwZg3Lm+/ol8gYL9xBSV1BzREXNsDrmXtvQarPLFp/YvFDZEabe30SZ+7c88hPZ916ioRhGpMCcYTu7P/jESjPGLlf10dTggJj6i0unAqbj/cV9zJFWurxBTMfsbr66m52bZ+dACgK0MDFtUTKiBLImLMqV4hTU9n9RHNiWpxnDWb9WdO8NYt9yy8X6i/eOfQy7tWRqQpefEIVW1YPswmXeJgoKx0GqqYFKRmwqL+Opf+8Tlnet4AyT1Pc9+GFUlVXtEsZKPbX2v5EGqPqJwhZyVHR/ZP7RdNcRDq26HERIoJCqhmIGDz2DHpwuL+P8u8rtK/T+BxQtdALka9/HLUEpSjSJ6Jtl2WXQR+j7/0+i7aZNUo8hzKN9q9At3QlLD+dlIfQ3kVd8H8tuZpX6jvn2Tvyfy1axS1x4buR80ZJnDsTRZbY2Famvo3uwa23Q/bUUzA+e4VbC0+s8BQFFUC7YK733OBwPx0epSCiJnjquVn+cmUlMBjbJ68+6wUmyVQz0TgplxTNnGVeA9z3a+o5LmJzYvZ5TVpBxjS1ElwPmb9r8Vi49Zo1K5BOtk28rVYcLD3/jzqAwi0iIBQqaKr0V4mVGyVRypHxPUoXtJX8uuohOOZAFVxeDoIlNQ0lN0kci+pOzSn8b3tDuyf0wQWXPMfGdyOWPlHs2l4koTzTd9d991P9OgqUA8Vf/dPjYy+VezGrPZHNWsjs7NcKxo1tbdAHNyj3eqK8zrCvDm8b7zzgVyVTMbBU7NKovZztytr+qIIDJT8E8FADYuN7S4BAhy6uoY6Hb0/yE3qz9HXXkqPfZU4e6rTfdimihEtWBr0UVSu/C+579/LWR1jOvCGEjE/LrNWKlpEugmqel+uba68iXGG8pD1weriE+vAa750pXLn8wW45EXPuitBzGhySlLuQfxoj6oGov8riTASF4OmQAYSF543HfBcRhivO6xKxdSOnPbSnBRGkip0zotiy7yqb+3qzZ1t6d/OylJleT9OZIa/FOVeknJ9U/vA1O5VFDOf9nABvXTvexVxroXPl+6NGemT3PKRub+mfeTFdVWZSAQ/9RAGivbBFMpH1xi+Z/AdTM3jL3X+nLDAjFZ5Xr6xLRgPApRLdg6jK204iZcNylvS0AOi+jhHya1Hf9g3CtETe1Sqq1SL4jakcMS3BDyGY4kSKGogTrXWWUPtZJ68fpJnwAAIABJREFU7EUPRmp2ZOZXw9Kloo7LQZp/CRpDHALZ8X6OlQEwc/kxc9HmQL8Lx9B9rf1Pxdyf+qCmUfO9/e8hpal6zLY5H1FTdYBgV4R/Lmgq8qlV11S7dGif1Jm40KiAqoa0yvGdYlj5HKtzmoV+hiDFuVI8qT3e+mVIp8OqqhqznTl2ZjVMZYOi6/rj/WQNA7ZR7G1QnsmRZ2JUVQ22FJRUUTnTl98+pAVRdJUssRgQu1RpprJAbQBCaw5NMamo/y1QfjeBQlQLtgauZvm4bckrByZD9rYJOgJ3P0vBvvtZD7eqGrljNuZOIbCuyEJMVnVfh4K+crkQdZnEygBX/9WPre7kthAh/yc1CltKUgWcmHOH/Ck19EvFMn7ehpq8mOTdPKRqU18C/EVU3uDjmTGr91lVushPV3BZzr1h0ZKWOZKaC/DqIqlaQRWfb61epiQ1Pa4ESEmQkzEuoMpSk4BflzAVRC4ISaaBWWWD20Egq5UFqcwDTOReWnzRklT1ZfbzRO3nDbRVXQDxS9gAgdRtCwHWyf3di74J96VkZhCUgKvtweGVLAq2FkMP1Jz5Tya19z3//fvSp/2AJomb8F2yXjmSj6glUkVrDNhS9AHi89HLBYedpJ78pvdGD/o+hVCTVH2dhkhq2t5Ykhq9XCiCqgma8630Jvqqw1S9ICnucxlI2x0bUKOJvc381ti2Cf+YFHEpedYBXuk1zZHUWSXkUJHUKGCp47g6c0BQcBvymaaaij4hmFEFZ3nf2NnOHLPZPPytKgujzf/qAxUcpsej+b/jpcKg9RImy/o+aZv6PpMXA41Wrt4pqalACabqQFFUC7YOutqRRs7vCtYFJKXlPLcF6wwCYOvKCho0Cqruhyv72szsL/vUjw+2mSanjxTYzCQ6ps2DDE1SI9N28hDPmfq7lMKcT6v8P3R/jb3/dBUoSbFmfBAdkyJ3mQIQKdrKqfrftLdlplAqttmnTVhz45NT/9P7Mg3gCTlTqf07yZVElb6FpP0+GExIaTDt+8CloKj6dY2Pav85hf75EqWzKr4HiCoYy62czNIfKc8q6unOTh0T1J06BFDpFxAXQEVBzYV/mTWVBdUdWSlMu99LoSn355ViWdyoqjqwSsZMKv3lxnBj2EeL2bajENWCrQFbACNLv+vKJYY5TFRTTWOVIpeDFehPYbUXvOZLLwvVogTy4HnV516+dLuHXR1dBmNN/UB/EFWu3XS7IbKqfQnHKIlC3DSZE7Mr4F6EllWxtD9qpFj6l6c0VZcsQ+hLPmK8dRyd/N4mBBUUzifN4RkT5abPUSS9v6ZCCoWICkkVlVIIozb1p+Q7X4wg9tmtmGGtO04lpNy/uBs022pVtxJFV8z/3h+1cUFwfRL/UAKCu0fwWa3ja9aHrhep3Dnm9nVuBQhkteaGoLKwV6X+l8j67UMx/RdsPVJzT7O8WS+wTHjweR9YZ/cWwpu/3k1E94ukCl7zpZfhJ77wsijZ/V5IasHi0ERjP9oTU+8ix+oy4wpMZn1KJof72b88n4IudjlI3SXy5ve8a0C+bKhPC1Z5/9Iqrmkf5fBU/dRjLeZnHaSUmsulupMOmAq5UCsbJdXvHr+2/24u32oVXAvqcGztj1pVTSqsZpkz9ackNYxl8lJFYUyaObl73LtJateyMece3Rcjiz9sHvtg9i+m/4KC9aKp2tSU6dPQtc7DMgIYTQqdbYiqfNPX9peQjkFameme807sO1E+7Dj5Te9totkT/7vIlO/XpXXlg7qUefinvpsS6DRG3BxStdoJ+hvVSkywwLCbQRdZDSRTpaVq1Mk4EX6fEk3K7UBcJUzm/HLjp/OqGsvB1G05zhebpsqqPMmceXO5EESdkzQmhXE0fU5FDdc7XDw3vqLQRuczc/OirRuXAH0+co6i6BJxiOwXf9RqZx6Z+zVJDffbAi89bi7mVh8EadaQtM3cS4tlcgFdYBhv1q/J/8+EmgDyKatqa1y6LphsuduC6aEQ1YKtAluECUljL/kTC4ZRSOr+4sSLH8haAAQ5U7WuK9+Yotv7dgUY6f2GsMi2OdPqsr53OfVXk9VKqY3ia9lFPKjy/RjISKCPl55Dc/4GzAyyFKVR0ySVCJFPavBR9eVHiZAnqSq6vw9sGrKq3TiCqpxkjqDaRAGaoc/Gk+qqcTWofHlU6Yse10XN88tikWwOBgCocU+hCiBjYev4mlXMAFzqO0MMOzaNzLqwBULKJlCIasHW4LVfvgrvftbDIUrXoHkoALEiE/mmlQTQC+Oe8050ln+dguJ7GJAzaba28eSLwJFimO6TU2jFV1Sn9kmPlxKg9EHalYpMByvpQMY0kEcjdiFQ/6tSpI78OVI6E59O4mCSrgbIXdq/1rE6SL0ombU1sNZgPjeQPKFkOeRaJWoi+Yk4UlKFjOrcqE1e0iaSPvWz1f3Vf1lURCZU5PtCdTgPZoJhG/rGM2q1F7lLKIIshFm7HKT3QhhDPw5ybd228RhXhmFt+x5r3V8KXdelme/z1wlwvsXWGmCG6JpVxmBeG1S1S1s4JovDOlGCqfIoRLVgqyAP5RR9ZTwXzYV4mHD/hS4Je5twEHx8RMEEMMo8qSKgw36ZFD7ROpsPMNLqmZAISd5us7/ABilJ1VHWXQ/iXOJ3bb7XwUgpMRWTdFPbftxNG/uzt30Y9XgEUloz5gAqA5+jk0FEoXSn9odMldTU1N8ELykfUEUMI/eFzA9R+udcOAwMbPgemflNf8oyTVaJuJUjNYeutrqO0y5cEpPmlKzqvzlf15y6G7XpS7dKYQrrt5vPHemZAwBMyE5RMG0UolpwoDCqqs4hn5fuv/CYMjMjZEPIq1yFrG4aQz56WkMMEdCZ/XPK2NCxZFm6T85KodvLkVS9Lnc+2rc0p67m8pAKERQlsE9tS5drwqPdCVI3IlEka2tRUxXOlZkBTwildGfjkpAEMlVNKioxrYu5vZUnNee+kLyEpNfPGJsk3W/8gnnEhBdlFTBtNZdVGpL0rhF1PpBUUXDV3yF0KaqNG0Xqh9x9jdnfe9YXOGAmlSarQj13/8/9+8VkhAznlVCQQSGqBVuPrshgbXacOu48+2T4/7qnLtu344iCCqjxIgRXCvnfPQj9dhCFbN+6VZCArfezU0QKyD+cg79lx8uG3j9N09QH/XuS5ycRA9bAgkKZyrTaTy5fpVZZo75LTtGgQnYroiEXqVdTZzMbItZTta09btoNIo6IBxBIrt43UlNrg7quMN+dYdfvu0szZ14GQtCOkFQJTNrxpn0dST+T4CTDQUlNc5O6jspAKhIngXSKiAKIiSK6lc0+c3nfttYaHzRG0QuFPq71JnYhh33HD2qwRSDmQTFPqnBJpgVdpUuT2BzE9B9cNuoKtnZm/7quUM8rzOsqcoE5rCCivwngYQDPh/upP8DM7yCiZwE4DeDFAD4J4EeY+cub6GMhqgWHBgfV/0f7k2piLgRefErvu+A4DDWRyW4blSdT5ZpNE5ozU/FNXSNSszfQ7T+pMZRvsLm2noz5l5BUUU9f+sSPVfqh81XmAkBySmranlZEhaDK366iENr/Mx2PyN8yUd1CpSatdFZNOzpXaXoezEiUVAJzHUiqdgPQ/ag8+dVVpxoFlZNjJy8iuh+KsEbR9dpkXnm/0J6CCv0KZLdrQG451/F6IYWS7H9soJpWj9M8uK4IQpxPNi2CkAYgpj6y0q+qrlHXFUxdoZ5bzI2FmduwzWSwmWfUHMAbmfl3ieh8AB8log8DeDmAX2fmO4noOgDXAfipTXSwENWCA4+pOcyvCvecdwIAsiQ13U5P6oL04ahrgBvEZLVE/e8vLv/kq3Dym97bub7LLw/oD0hJEV5KggkfwU+1XREqIavSRuiHs50aZtQ9v6/IRK3JnCeps8p9dKqpoPpW8f6aBIZlJh6bKIVVpRRTikmjJozI5CoNKrCvF6/JUG0pqLFcEeD9Q90xY9O/ZCZIj62PGZn7u65h+qKiCazcA+FHnnfhCPtFyqsjuELYhgirvs80ye0ivOQLAIQXkExKqMi0H4ogcOTPm8uMMEi+awl6o6Ck1lWFqrbYNRMkqhsAM38GwGf8/48T0ScAvADA9wP4J36zDwL4CApRLShYDk718+ZrakyczID1pknm6boCaLM/M3DHWe779U/nXQDuPf+4/48GSWqKOM9jstKqCkIgb1JGLwkp2DtcaqrG/w7I+1JqdVCD0ASNAOMsB7rcZJcjcjtTgHyvA1lxD3kLwKC2CEpr1E6ioDnzLjuCOnNR8DuzeVT3XmCt/H7F37FR4SqTD/gRM3HwBfWENTW3G3WsNEdoGEdPZOq5wXw+ax2vrp3SWpNJTP/uGDuzuilBOqsxk2NHVafU9e14GUnVWo2s4pm8tOR+72zRmOrdG0tERtO2u44DICKE4iqRvqBY349A8OVlSUiqroo10+VbPVH1LhPVzMLo7AjqvHRZ1EBCxS2h9mR1d4bauwDY2kyKqG7aX5aIXgzg2wH8FoDneRILZv4MET13U/0qRLXgQEErp/KjFzPQFEnqorj3/ONLuzAMBZql6pplwuseu3KpYxWMw7EXPejdMfrLpgpywUIugKoxlfepTN3tZpYlpCmonKpcpvukxFQF6JnGtUDacAojY+Z9N3d2akdUPcHTiqojGE0qqFzeS7YEmDa5DwFKPmgpja7PVVnSRDCog+F7Da4M7MyZkSvDYLYR8YqUQa2ganN1FZPTruC3dOybF5Vk+2zUeqy8ptfS3QvO7zQQ9OSFZSxJDcFTrMasA6KqhuOqZV0kdXZk1/kk79QwVY3ZTg1SLxk5Fbx5sTENIa8MjC98YOoKZpfBM0yHqPoXo33As4noUfX9AWZ+IN2IiM4D8EsAXs/MX01/15tEIaoFW4XaP4jZANYSDJEXdJqgCaAhp7VKyK3f4KeCVE3tgyapewlscoFTrpHWQ0+R1Wu+UkjquhA9bC2aKG+079suFwAAoKonWEZVsiJikKhOGfVM+w22+scEawhkAVv75TOAav9bcwKr2x+KgPtgKMl/KgR158iuW75TR8EyEgRT1xXYEnbnVURco/MLhUBiM/JsZ+7yrmo1zliQyZDFDFF118OgnrfdAoyxoKePuPGUVEi6EpWQL1FU01ypKohIK6mpm4fuW9d1b90H6bZpJoPa+MvklFS5ZEwEWyPeluMAvDZBbZRUUVN1YBXgct+6a9T2ydVm/pSgOiXaoprNUcn9IdewajtAB0VSEeag8vr7h2sJrqpcQYCpENX9wxeY+ZK+DYhoB46kHmfmD/nFnyWii72aejGAz+13R7tQiGrB1iFMiKxJl1ObQsSxjSdVTQK3tX59H0nVZSuHMKSsvuZLL1u0awV7hCh3DQkQguGIpET253MI95uCG7LSKK7aNNy4ezTIp4dqljlS48in5OxkA1Se8uiyopWRZPLik+oIo5DUnVmNHa+aiclc3ApM5YJehEzMa6V2ZsykqTk5UjeDylnHZDAhqW0F2cIYgKsaVUWoqwrGWMx55vpXe0U1Ispo+8IqVdVUakw7FN0cQV2ErCKjvssYBdWalO86udC6VFnV45qDnndyimpTDKGtEIsbiJj9xT2i8uR+dmQeFFT3suFeMsT3uGVZqFQ2AXK+uMb4Ps5qUM2wZEDGlVglY1BNKOx/WWvZXkBOOn0fgE8w8z1q1a8CuBrAnf7vr6y9cx6FqBZsHaQyFbEnpvISbRsTqGwHNOrqFDGUiuruc0+MbkuT1SZlV7NeUlBZNL684vMn+IkvFJK6CTj1v4kcD5fEugCZMYFSgtx2Yf8cK/VIdaUuUiTfK2PBXMGwS6guwVWV8nUUUqYrNQlJne3MA0l1yqdPfu8DjSprUdduTGwtvXOPLGsNLExEVnNBPMZwCFoyFUdKqtumfwwDWZ15FbVyKmltqkDQnQtA4nag0iuJuV+7HJAyW/cpqDmSmqqjff1vvssY+XOCIqvQWSDci4eF6TXb5HxZ9ctDSlhlHPVYpSmnqlmNnZ05qp05dnZ2Ue04M381m4N8YQQhqVlrgn4BM41YEX5TxmnHFfkCAMQwtZ3ss2GN+E4AVwH4QyL6mF/203AE9ReI6McA/CWAH95Q/wpRLdguCNmaz426ey0ANwlClWhsAqimNxHdc96J3kj6RQiqRupWpPJ0BzD76H7viyoqXSGp68eVf/FKAMDJb3ov5j4wxxCjRkNOKrbhXpeHcM6PcRGI8iSBWED3y1wXKbDWeD9BgxnqsJ2on41Z1+UVlSCjqqqjIKOdI46UEDUJ8KU/pq5QeUU1KJTzmYvetjYyL+tzaCmqFcOEnKuZk2T3K9BkMJBEAKRUN2fqnvtsAOxTIDUvxrOEfM1C/lTnYxnnAUVWNc32g9rXY8zcpl0ZwsusYZBXHaniqKqV+KjDaHN+O6q/RVK5vQ2AoH7qvmilW7tnBBXVm/qNLy+ryT56xiGyOJgmuEp6Y4y4HzCMteEFZDLYQDAVM/8HoFXHQfA96+xLFwpRLdgqvP6rV7h8oGCXbJqcEuWCf3w0c+TYH+//6s9fvZF+awyR0LuecaJFOFPESunwMd1kzCH9VOUn+dd++arhnQv2HZf9+avxyAsfBCD5SQEwoTLWvZz5ly/TYf4fQmru136HwQoxwgKaBm0ZZT4OffVEM0rO7/NfpiR15s254rcpifJdHwGg9v6gDONTQlVV7X/bxh+7Xfo1/J8puzlmrNxfPXYA/HFNXcOIolqRJ1zG+wCjXepTp6ESlbXH3UCb7FNymlO3xxKt5h4AgFhVRYWQQkoC15SxyhNcitoBht2N0usRvUBIlP+sBlXW3w/OT9XMbENSTVOMIdeu/s6gOI7McEtZBSSVl/iJTYioTqkvE0IhqgVbCcvkqoxYYDZzaX0Mcys9lairhngSJBVoJve3nnPS99F9bx5KTjUmaquhOQyVOZV1FYnpDyVQaoKYz6vwf3DNqIDKP7wqrwTOgMhHb6xbQEpSW4jS/IxT6sScL+mZjFbSPEElYkdMKxuqMum0QxJgpE3z0k9jnLm9njcqLfkSmFUlVYYMamtahK2eV4EEhz5nUjS1luviAMrMbE3VuBH4z9NPng1bu8rxWkkO5+wDhCQgKCiY2gUhENt4XEOAlckTNB3U1CwcS3QIqKyzqkCa8Sm2GJAUZNa6unREBmSBet4e52Ys42sfHY1id4i0KpeY+HXAlFOclamfxDVCJszkHtYWAoZ3DaOWspre+5NSVAuyKES1YOvw+q9egXvPP97k+rRwUchJ4nEd0TwVknrXMyRJfy4QRJPVeN2i5r4c3vD4FUvtV7BeSO5aIgC1AZEF6ipKcs+WshH+w223A61GK3KaMJkmd6s2vWvlL/ilel/UkNtUpYjS0fipX6bub6NGOqLDhjqPK6hmznQcnb/3yc7Fz2i1TyL0hRgxkyPU7KLHg4l8VqNKcnGKOTun6JpZox67jRuS2kVQu9TU5oBybtQmb+HE22poWnlOju8C+wiovb+qlCLNJOoHGtO/JPNvjWlUsrZ5AZDrXvnUZGFsJOgsY+onw9E5RveKOs+0D80YtYdmrNK+39CiRUGMA5+XoeBgQsz6wcRvEVQVCUyZWjWq1OQ/Pkl/3sy1CEr50+njRz/9CgDNfWyte9GydT49UC7CelEssn+XyiouABEh0+bdpCKTBE2FAKMkyCkyh+s2FXlpkR993K767yHgJzN2cpyqidAn49oiyb8qf6VCkidWVWWjCko60j89v5CayXAnSQ3HVds7gobo0xovE3/ii6QIsHoZyJHppr34GqcFINJ7AHDk2lTuelezOqomVanxEzN/NZsHBbUhqc11j86zh6SmfWjtm+mf/hRMG0VRLdhKOH9UQm2bilRk26mX0gl3SmgUjWX2HVbCCjmdHh7+xp/Hyz71453rf/TTr8B7nv1w+F4ZC66ah6+xjoxZa2BgW1JD30uMvl9aKYT0uh6zv2TWyG0jRSI0aY0Imwou0mRF0kWZKiYiYPLphNilTOqANc4FwChfxDAOlpz6WhPIq7CpQin5TEPWASFYO3NA+gX4Nvy5e0XbPHUkjJ2tvMqqiHhEXmdNRgNNUEOf07KgFJOv9DqAlBsHt+cECZiL9wtNh+2Zfaox+PasV6uNDXlWa39e7MdPSLWR3IBQfQEa8l3FvrmSx9Z4ok/e9A/Draj+QLj1mKD7HpcUb5F6DHVPYLiNjWPDlammikJUC7YWQlYlSMioYCHAPTinlhM0qtqjo3DV+qE8pzmIn2ohp9NGl9qnYWv1oPWpqc6cmWFnVgc3l2oPD9ouwjq2fGPfdlH+VdMoYZEqSrHS6JTSdmCRI+M+Ib01MJWrBOWyDbg2LElCeZ9SqeN8mSlE9gMxSYVSa7VyG/rkXS4MDNg6sl3PK2CXAtGyMwPMKwBamVXnWDEiUqrFXKV2NgvVv5l7Jg2AC4SsI9AumPuFaCeEDiCkqatyLzO+0qpb7zMHmDDsbZU2Ssnlx1L8kUMGBJ9jV98r8EFpOXeQLsg2DHHvaPtiR2M5ObI6zQw1U0AhqgVbiTd97fKWKV1SVwGO8G1LRPuylerSh0khqdOGRPXL36v+8pXR+vsuOA4A2GliqjCfGxeEVNkWwWSmqAqU9jVMkXMbCOt6EudLu3tBy6ScuAGESkNiEvcI+S5RQerQm4pgrI+2twRT2SiISf8NvpPqnFrnEvUNweTfmNzjCkhkpPqUkC6grmaopJyTpSjgKnVh0OfXMvcrc3dY3xU4BDjFuYOw+i/RPdEiq8j7rMIwIO4mqq+6B9JXNsgqlbkXEv1dk1RjkjESJbmPpHaMh+5ry5KW3B8F24NCVAu2GlpVBRAm+SlGtafkeqxymku9I5AHTV9O1oJpoPKkIvWdfudFx7yq7pafmTdP2FnFmNdOQaytgbEu+hrGgkLUN5YjqwP5U4fQt19QUCOzbx2i8MU/cXZk3sqVGdqXUpxzG+q0z3fVeVkCc60qH+XTVIXo9ZqdQpv4wwbCVGk/VPfXqa3+usG6NGG1dw/YmQOYYWZ3o2OKG4P7q8q2akKcU54HSGqOZDdtICLlYFW5ixGlbArXzauqmtinAVbwaqs+vhQ6yJnjXb991L9SVEWdjpXrhqACaEz+KXFPzrUT1ND07O9AqeiTJatFUc2iENWCrcU2Koi6z5q0LhvtWSL5twfhQQ9HVkVZrcxZjoSCUXeY1dP7I6iFHQ/cQbLaKjHczgaQPYcO/9QutEy6ipxIjtUowl6RNSYGalEMOaSrYmNhDKEW83JlYWvTTT68n6rkEm7ORau9KWHMvxTK35wrA7eCj2wgbKmaGtrrOY77EpPULFnNRPQz4LJCeNWd4VM3yX2hKjfljq+V2aCehvNyfkahTybpnx6XKv6uFVStJjf7xued7V9HzAFbtR9TcNlI+5j6vBZMH4WoFhRsCFHSfiweWFVI6nZhZzYPKdOMV/nmc4Ozz5r7nMAGO3DmfiGmWnWXDBfzucFsZn0Z4byqqpGa8RfJGtCQkW5CnCO5jZnXNgUAlJrqcov6vJk78xCNneZRZWtg6xr1bhUpbO64cxfURL5uu21KrYo6Zy2hqjjqrwQSBVITmfqb5ZICTH6Xaaqs2ZE5dplgZhbMdUMa9fl3qKl9Jv/cNYhIVus65683Wzhl1SgfXVGfufF/ZtuMSbiehkGsiCg7ddj5CtfOG0P1rVFCEZ2/fjkhapRWuadigpsoyWEAmn50wZHgaBSi/fW1nSxJ5fF+4ocNhagWFGwI1z5xOe45z6mqorS2/W63UzkuiPGhl/wcTOVfRqw34xsLUxFmkEpOjDNzly81JUUCZorzqfaoqjkIMdlvpAFUOztzlVrKm4JV1aEmZ6ltCImvVEGWUM1qR7Rq7/NYO1WVKucCkUswL+bldLmG3i9dR4ZVAFaj1DmTOGB9gQZN1NJqU2G5aZPU7Lj1vRh4ItinDMaR974yn2VQ6Ld7uZGk+PKCI6TW7dco+NqELhkNdM5VTU5lPONzzpNzPW65PKlD45S7Xum20ViqF4VU2S6YPgpRLSjYIFLfUvFjLeR0O3H6b78HgEsr9UN/8lp86CU/ByA2jTI5s6SkCpLI9dq6wCn2/oZNqqe20i7lg0HdPql9yEZ09z3oB/ZP9yNSuVV1BHilKzvFiqKQHjHZEjkzvztfA+YaxhoYW6OqnNpaWV/W1GcH0H0IPpCJv2NEIJEhPEp9dOePdjJ5ReR0m+HYVZu0tsYp9cNsbZAS50YJjpRHtR2pPopSysadj62pRVgtTFBXbW2ikqlyHCZn7jdJGqpcGdg+girnHI1Xzic3NxSJW0XXWOl1Wh0P/alsPK5T8wmdWn8mgkJUCwomhkJSp4mHLn4o/C+17QE48hUe1A3h+1d/910wFWLSRtp0TahmLmq9qlzg0Lw2sLWJSgDL/gKX3cKpXpZ9dTbviyi5M8cQ167I/tbDvmd/IdQCqUYlOTNns7n7HNn1Zv/dYO6X4KWQazOkckoqcJFLS5VXK3fc+hmhris/DhSXQdUkOUSb68AeROb+kHeVnbtB8H30ZC/r6mAQiJyQ7XD8KP2SbZM1IDL7pyVTRWUORRH8+BhfNCC9ZtH1Db7IgLEmmP7lXEzlXFDY+/gG3+fauF0tg2q/3MT3Sy8xRTOmrfNR55wS7jaxjc+pS0XVamxzHMTjk/Q3GqeJYEp9mRIKUS0oKCjogSaoGo1JFKGcr15nqvYDOlJWlY/pbAZYHzhUE0C1kECoNvL964rA1t8jUmoYnFS7SvcdUrhyvqlGEZOGHPpgqURNzQUvpSTHLQ+RVc51ojYuKt8SjDWoeA4AIZG/tQZsEtO0VzgDeYxytrbHS64LW59T1KBRukRtTQmFVx1134UUhfHsuUZDy0J/Q2Q8osC07IsJk/Nb9n0matR6rg0MOVXawEIyxYo7AKvxQWVBltovNh21JQGwAAAgAElEQVSFC+JsBB1EWpPU5BzzfrjpwGTu0+j3lRkfk6zvGfeCaaEQ1YKCgoIOdJHUHLqUTJM8VANJBQfF0BJjjgozSG16A2YG6jhH6KqQI6ljwAlhsZxX2SqdS7TyFYmqOvimhnVCZLRylpBIC5+Kiwk8c6b+qrLgnXmzizUgqmCYm+pLOqpfJ55X/WrWx+Zgqyowca1WZXx8w3aZcXDfBwZVOHDH/RNM7EIMq24CljYbVFVv7gcTyAJMtQtUA+BKGTiyKu4A8t3ABfYxcWSWziqoQFZFTccqJakpyU39cLNtyDH0vuggqEBEqifro6oU8IIYhagWFBQUKLzv+e8HkJrD421MQkT0d9NS7Rp1MWwjAVOS/7J2282pCdBxiez765A3uS6XQ059BfJEQ6e0yqmp+lylxvtspiL8gytA7XOUoqUGtsgYgKryY+QDsSTHabVboZ7VmO9UgPWmf2siotoK8tHpkTxRbpS85jwlL2nomeqjnH+vGh0pjlopzJBKBnIR/5pshYwIShkOLgXiKtGlqqIhrFauYW3Alr2vtIE1BmQdySdjXKlUw2DrUn+1fCcHCGluTNw/MUkN6bsS/9uojUw1qUA6gZio6+NpcppuV7BVKES1oKCgAMADz/2AJ53x8i5FTB6gMWlNCGqi2HWZf42vPFUZV3XJsrQhpS3zBSK6HrxdBBSI0ywtWoEqp6ZGJLWyqIJ6KYn0WUX7x76mg4iIjoHxijMn/J3ZZQDg2vSaqEMienlpUME8UXupaqoVX86sp8Y3WI7plrdPKaucdpFVRbYjBVOyCMh4dhLGRrUHuTy0sBSM/T6rbwhFI3L3HofjON9brSSPKQPch0hJ7SGpWjF155+MaUJQs+ppZrspY9l82gcdhagWFBQcejzw3A8AQPA3TfOXpoSjmtmIoEkQkVTl0RWZooo7SnVNK1QJWSVizGYW87kcvyGWEflN1KpUrcuR07C8oxa6tKPRVcFKxkifY6g6laqpO3WT3N+XKW2pi4GsiOpm45KjlQUb4wKhZjXsvILdqTCrd0NAUOqa0GVqbhEXpTyG/RU5y6X0MsaiVkFIreuRGVun1sa5bMP24JCYvxU4JmPhSaoxXlFVxL8Log6DfRYA79/LxOCawWRg596d1RLMDEDtyKr4s4r63zqfTPaIaOz1OIgvqzqnvkwGqam+da/oZZEvMNoktisP8IRM7YwSTNWFQlQLCgoKBvCjn35F9P3Yix5sIsrDQ7YhqTqBfKqwCnJkVbaztSPLNllO6ljShqzXbSyLvsT++m9OQa7+f/bePNyepSwPfb/qtfb+/c7hgCEMIjzMyCAiQfTGePUBNDEqolxBQQ7IIEcPoIhKEL3PFaeEaJyYOUeQWSblilzM1RiFGJMYUFAGCSiI6LkCQgAD5/z26v7uH1Vf9VfVVd3Va9h77b3rfZ71rLW6u4buXnvX2+83NS0aVS2qT0OlotVTJHGKaOl9Ta8EenWVXIolYzMoeDN1NEerpIYqXX+CjqCqnKMM9NWd5DBFbKxrxgw4Nw0hq37zRJaGOEuAj/aP2+SUTsmcIHOAkEMCGwbYkjt2vytmtoFhrEigq24Vns9Qlc+fxNg+RVL1PWui38XIA4BvE/uoJtwGoK/DvvqrVgSoRLWiouJcQ9RUweP/7tHZY191+2tAxFhqRVUF7WiSKmmWUiRVIGR0ELlvAG6HhNAokjqm4JWQ1bgc6phfarI9haS0cdWlGp8CqhtG2BuncGrypfJx2ovSK4eBCdcd38FeX3YXgjt7Hp6wRsFU9ou7HwlSHFRtMjYSPias9sDxa1FU0laRVd9WKawphdluh78m/rpoE3rG1YDZXU9FVu1vi1z1Kdsvu88scyC2U0VPYOWpyRNTwoCsxucf/yZjFxhK3A//WwnOXx3jzsd/Vm0GJDX3dyD3Yt+wRwrvPqES1YqKinOJV93+GvfpwG+76qOPTuy3sKqh88Fshmb4lIKqCWqSRETwxxupiRolsS8cN4XUdmrSx2qVLKWmypiimC4aG0BlTIfFcoXl0uZPNU0Ls4gi7EkRrMQ5hHPGwPQrfpbMHWhhTdPwJurInO7OT/xjY3Oy7adP2cSdAbdSutX4fKN9SirjArsY1DEAq0pSIubNHm+PCchcfFxryWvqXngTeSN5WfvrFkb9S4NQNfTZvTS5k7buAluSan9v1EElqzLoWmsl6DrT++lqwiqnmED/kKBIqrrvviiCUfcoFbWfMP2zelgbI6hjDw6x20fF/qIS1YqKinMNTU414kXOqoaWpHqf1ARRlLY9oRz2LSS1y0SPs0+P5LaZuM9xgjeF4uMdVx4qvmKGHiqpg9RPSiEbKmyzpq2IDvlUSx06S8KoV0H7/rtegZSIeSEyQsBd+iY2jK6zfrC8Qn8MWQKL1qVpUvP3uXRHbdvh9ctlC4i39co5AjU1MGnnSKp812M5Qi1Em1vtBuBUVOO6MexdAETZF9cBUeJjJTXpAjDmH6zPPd42QlL19+BvK0dS1UNJEjP/dnYGrj6qOVSiWlFRcS6hF81fu+tzAyLRtQRSLIqIA5Ka8kHVfeZU1DlzAwDThNuEIPuxCpRUOXaqMIBGEFSUyJIlJNWm4lIkNZHgX6uoybEDIpM2BwdjG5dGiRjsiqf6PJ+OdArJMUJ0pAKWJ65ynk4UbC1D80FGxEDbeALcreyFIO6vtZjJbaBRTwIB+OpYfgwa+vfqax1fD32ucZqrOP9o3KYYQgTbXmn1KqscQtYFIFYdA7eRCReAlAk++4CScD/RpFRbIcbSTg1IqnzuJoj1SWMf57QHqES1oqLiXOEVt7vWK52N6Vyp03Cxs6VP+0zvZICFImOagOVIaYpslSyOQkjjbbF6mntPp7ECiKTE57CPeH6di/RmBlpX7UmTEFFSfb5UMfUbRrNc2cj/xcon+O8JFhKR3Qni5eeDXqvUJM0FOZFprbrng6F630Wrojq/VMk0kEjn5BVV70JA6FYNTNfaCl6rBmbRoVsZkGncPBf+OhkYdJ01R8cuALp6mdyHMUW1v89d+GpsDtWkyX8mSfXqKPq0VWg6oDV2u3MFMO78dGCVqKqAu49CzhVZdV335xbfZxXpH85LPujzCy0Swd9YKrI/UmIHOA1ktWKASlQrKirOJXKqXa/G9IuYDpDy0exqEZ1res/OyS3+qfmk1NOAXAeEZ7xtSoXVvqjil9i1Vk6NXRSMuhZN07qXq0IlwVQTSq/OEdp3PHFPgo3KtO3UwMB3USuoUTonnWqJpB9yLhcuowB3fcBWt3K+sY1NkE+dLStqGnttiCxTY4NATY2RSnUWKOPRQ0SvMGOwf1N487+oquJr68irz6WqVFXtAqDnn/JX9Q8nKP/7KD636PomVebC8faHrCZK81YAqES1oqKiwkPInk1+3iuUvVm7dab/8UV4kF9yQsUJVLWGB9tz6u3AxBq18QR7oASHJnZt6u868iS169Sr7dmd9LVYrJya2oIa+W7VVLOw10tUv5zbAZmeKI4hRUZYrheTdQfw11AIaZqkBvescT0xgboOcAFaorDSysCsOnSrFnS08PM0pkN75JbQlaSrYk+WSxAojsYpqVLmddGC3HUNXBeAMjU1RXp0UBXgCT4U0Sb3pERsAl9VK59SH4jEKs2Wz6PWq8iD+zWipqbmGaupfv5A0GfyHCf6rtH1pwuVqFZUVJwrXPlXj/efX3+X5/rPcY5TgSeJmuRlzOfZqk/Kp88ebz8bhOmpcr52ot5qhVTvjwktMEzE75PEq3PR82a2BNV0hK5jdKZD2za+vGtMNJum7X1SXXJ/IyTL+acGqZQy4I76MqBqPpQLJx90EBIvPceUj3CS5IhaaMimpnLzYSZ7GFv3Amo7GGPATYu2XdjryXb+BoqsTuRG7ec3VFPJ3zdRhnuTP4A0SS0lX7ljDIM6R1Yhv9MweEzPW5NVIPX7Do+fisIXlFy3vmP1t7CGmrqXqAQ6iWMhqkTUAHgbgL9h5gcS0U0BvAbA7QF8CMC3MfMnj2MuFRUVFRo632aOKPood2XOTi2MWqHUn6UPAFFFKIJBv5B3TFkTfs4/daC6OpLVJ9y3lZz8d5XbVMiGJ6qtfW/bBsZVXWqpJ6tyLlphJhU8Rc4VgCZM/z65PkVKakeAKMr6s1y3TDqt4B5I8M5YHs1BI06T1Y6sC8iitab+BYHF7L/ogNaRNQZaf18jG7geJlbC/X1wn5v+vngVVd97HeUvmFIQR86ZDGze2Sg7AJiD/KsgR2D1dYpSPA0eRuKHm7kZHmIkLBiDMde4FmeC4J5xHJei+mQA7wVwY/f9hwH8LjM/k4h+2H1/2jHNpaKiogKvu/Pz/KKvE/UD4QIoCqSY/HVJ1BRikjo41oTH6vdFQsnVn4Ntyu/UuByUOjWUMZ0t9Wo6mKZFs+iyBFLM+6yIatc2aFfGfl416Lo4oMoFTrkSqVZhZZs7VRL+R2mJsqS1dWZmcnH8AcnsALKqJbdq34g/n1dTVX7N2Dd12ChFVoU0GxisbD5SORYAGZdflBpr9u46dKsmzJqQnJudj3ElZc3C5pttliv7+2o60ELloNXZClK/u1iJU2Pn8vXG5U5tMJhERSmVUqeq6obELpmTdAvkT0f163nGSqrfXoJ9Viw5fa8qjoGoEtFtAHwjgJ8G8ANu8zcDuJ/7/FIAv49KVCsqKo4RRByoqUBo0vfH+FdIDmW/YNL3NEHUxtqMEVMAnpySU990yVKtbmryaBa92qrnYLizvqmOZFkllUHU9J87Eyz0ZqHIqevbk2Ztuh4z+zM5H0kpLQp0nas7b/NOOfLjSCSsAqjVuUH1rJTSnZrDVOCKS8tFojA6Uzg1vaLKjvBJGrFu1Vgl1qnRufsbKKVNIsLf9CTf+9qmpruumpo9Z+7TVaE3/3uCaAjchapqcJ7bVidjkrou9pmgOjBqHtUcjkNR/UUA/wrAFWrbLZn5OgBg5uuI6BbHMI+KiooKAMCr7/gCEBk06KwYRjxIOwWEvqFSiWnM7J/yscupoSlokhoQUUdWdH8xKfWBU6KiLlqnALe9Cqz8VAXcGVs+lMkGUDn1tD1aeFXV7nNKocTzOAJsTf0IxgxcC3JgR3oMgdvGXT/brmP2rgHUGUvguPcRZnUtwgvovutrlQuiGoEnXwZA59TFRetTyi6aDp1hm7KKgK4x6FbWr9cq0/aaWp9VFUyn/FGtmmpVU7Noh0qqu55ZJTVHUsfU1FQwlQEAu90WmnDX15n/iWHTVwFAZ3qyCvTBa4qs5vLFpq5xalv896XdJPy23LnHGRdOAUGtmMZOiSoRPRDAR5n57UR0vzXaXwXgKgC47W1vu+XZVVRUnGcYpajGC2OcemoqNVS8OAdlPIVYxmVEE/DKrSKngUuCI6gAAoIqZn3xGSVCT1CVj2pPTHpwy32NewZoyaBVA2DlyGaDbmX68zTkzcJ2PBdYtWjDuUfXLVe8SRRSFvXUEVYjBBOWTANwhEkCfxBE2If30B47RVKnVHC/TVI5OeLLq8aSuKYDcRt6FKysrzEAGOqcGEz+GtiHidaRaO6V1EXrXQBknGzglMYcMpY5VnLJEllf1MBdgqgnvORCrZwbwJQLRhIx4cz9PUR5UoM20bYAp5mcVkU1iV0rql8J4EFE9A0ALgC4MRG9AsDfEdGtnJp6KwAfTTVm5msAXAMA973vfav3RkVFxU7RE0L12QzJZUo1jX3+AnIZqbXJ9FJy/KD8qKhwQpqjYKlIQfVR4+JP64iQ1FbXY7HLAdo5c69ZuCT2i77YgZ9f27fx59hwQI6LlFQNn79UbTNi4ieI/d2SNfIVpFhITOvq2ScUtrH7NTqlHFkgURgJMB3ISP5US0yJATIE41ZVIf/c2QwGQRlRrYRrX9SmV4DlmsYq8fjkx31Tc5BqX2AK8qrGnQRWA5dnOOUKMDke9dfDQwfBBQePK6kbuQRUnArslKgy89MBPB0AnKL6Q8x8JRH9LIDvBPBM9/4bu5xHRUXF2cQ1t3gJAOCqjz56J/2XJMoHhml1vOuACmwyJkrZFJHGXnnV5DQirQbhNpceSsipENSYnIo6mZq3jdi25lzmDrQyzgTMoMagM+yqNEm1Kgrm64Om5FwUwc8hIIMxMWR2/LXxFZIYTtwTss09qZGPaCKiLC+RO+XcU0RUiHIu2Mor0Z0rnUpoGlFZG0swXb5Vbg26Re9OIVkVvMpMvelfm/rNovV5VP18t+2Dqk+JVOS+i9r3uWgbAK2bQ9PZ6lsujyrQ9b7FwMAVIH5gC1R8df59kF1/rH6Q06r8cPJnkZzS0N+6AsDJ5VF9JoDXEtHjAHwYwENPaB4VFRWnFEJStwHtX5dUOUdIqj5Of/cprRRJ1WrpoF+lmHrSajpfwWlAlptuoKBKUBUc4e3THw3nbQmCq1lvAGYhLI6IGAax618RFTG7936g6Wtgg6PGyapWdqUPIUHsfFSlH2aylZN0iqqRKlDhyXL4OaeadhjNDCCBVWzQV3OSdGALx3fJZkRAR+ikPKtcC3/v2AdODUjqHILapQn/7OjxFFklGviqym8FHaJyqvCuAEJWU38Terzge0pdPW/gGkyVw7ERVWb+fdjofjDz3wP4muMau6Ki4uxBCNLj/+7ROx5n3qLpFTNfFSokqbHPaeAnS32QlBDU+HhdtUcT4tA3NJzLcI763ZFVr0C6LABMIGahqDAwsFx2TRLBgJfhvC9quDDHBMf7rXbwSqMnsii4N9o3tTgpPnqyql0ShOAKGXPR/0RdL8gu7PURv18jmRIaOUA9iDhTf0BSo0C3+NpsG4HLSkzgJZDKq9P2qsdk1RNTIatQ11z9vrWaqpXUwBd15kNHNfufD9TKVBUVFXuPZ3/eKwAA3/s/rwQAXHvLl6zVzytud63LmTp9bJxLdUxR1W20ihqqn4qomqhfraIqJdSTVLWYezO76XpCrJS9fjJ59wRdc17Iqo/sZusbKmZ30VPZsA+6iV0AwoGUsqdInydFQmYy90B6o+Ab3Lici8lyfTo10mRMxrJN5iBdGwpJaXQp+wHkIcCRXpdCy7iUVNw6v1TnJoGOAnXT53Y1ykVDCKrJDBqpzf0ct6OmBg8GgC9JC+UjrMehzqYQC8iqKLINovONCKrLZBHkt5Xj5O9FFz0Y81ctJaljGQL2DVVRTaIS1YqKir2GkNRN8fLbXturOEBAOnOLXuliqEuahkFTjDg4ajB+5AaAxLF9m3Beo/OLE7GvoQz3Siu8O4A3DcfDRYuskBd2aqiURWUXVT7lGlA639EHhzlKXcTJRufF/dzlenDTgXzyVQaJyV9fF0XYfES/D3gbzpG73od0KyR1QlXWfqtk0D/RqIcYhhm6AWhf14SJXx6iiNAHi0X3JlBZt4Wx+34e3QtOKTYtalZRUVFxbBDSuo65vzHsK1A1StWMy6Lq7wCGxNOELx0w1TQ28r6RQJnI3J8y9Qf7o//IKVO/3ZFQm4SwqFynzGGAxpT5OPCh1aoWqeswllJIT0eN1bUmuY+7dABJkohH48m1sZ/ThFVXTQoeFkR5jccxKFsV9fWR++xSTNFBC3O4gjlYoTlcwRwe+VfjttOig1m2oOXKmv4ljZZ6cOlPIro+myqBSnVOvXyeXX1uDQdVsmymCe1n2wYZJvpgvj4bRbNs7fVRabikH9s391W4tqWmnjKIpWKbr7OAqqhWVFTsJUqV1Gtv+ZIi4koJwtLE/qJCCJUJP9hn0oulbhtH9seLaqzkju0X2AWHRwkZIUwPNAhoKVFVE6rooPpQYv9wrtH1Mf1xBA4k2YCQZK7HcGB97RO7SxRn3Vd8bjFZTSmt2o/VPWR4dVXSPKmcr7aNmpci/QHGyMVIqdStwjBIAqbI+eSq/Krsj3F+q1qFFXg1VT2USYYIM7zPo2mozigxjcEliv45RFVUKyoqTg3ERzXGlM/qr97hhZ54xon+vUoaqanxS5D7Lj6pMUnNkqUJAgbA+zkG34EkQeGUOXgbRMaruBFhLyAPPhhqnWF1Mv8ow4Df7pVQpTQXDJd2qxgzEydeep+MHaRdCtXbWK0edXsAZinh24B9CFIbTHSvxVXBb+/dF2IVPiapXnn1/sOhgkw+rdq4kmrnWUhaq2n/zKAqqhUVFXuD59/sZWDn82aor/CTI6gaQlZjdVVIaiNJ1uWzpHWi3h3AmD45f2iuH/qzBgqsX5iH6aeCY6OcniFZ7udckjidJZhHjQO2ZTuN6ZxvqJDdhEqlkEpVRYZ6p0fDLnDGKrd2Gwb+qsn0XiPnERPegPAAybYDchoF5vQHRt99IFWkcG4jqEb8W/19dKp2l0jTFCnIHkEQmnLjkO07UlOH5F8NYRjk0yB0ABGMIZs/VpR20/vhDopeODKrCWrvr5r+XYyR8k1M/rkHmNmpvHYFRg2myqAqqhUVFXsHWZAMcZakpsz9hhgv+vxfwYtv9WIAwKvv+IKBj2kTk1BNOE0iGCoiqV6ZjdUkpaTqc8gtrmOLbumCnHMd2Aa88qcUQPs5oaxG1yc3j6B9IqvCAMqXFbCkIkdk9H0axa6UtriwgMwpeg0Qqc6apO4NBmoxgt98788c+qgKSSUVMCYPdEkfWYz8FnZ1ant0mSvSqIpqRUXFXsH7+hUuViZB1BrDeOmtX4TDwz5YyjQhSTVK/fTHFJDUWEWNCaocu/F1GFMTKUN6HEpLWY6N7XNjtu47oFIS2f6JGUwucEP515GbI6DN9mlXhylC788l4WObJBlj120EJxJ4kiKoavuu5zRF0oicqippqCRXqvZPNbAqe8IXV5TUONtBamxmBAr3Rn9DpuB3smdgnJ3gp21jlKgS0RsL+vgEMz96O9OpqKg4z7j644/CC2/+UqDpzf7Pv9nLcPXHH5U83gREJ/y+XLYDc3/TtGFZU0U6m0UbmPzlONt3T1BzwVJjRDXel3QJoEyfcdR/rF6OBBOlCGsfHJUy+ypCig7ojE1W33GfZqnpo5O14tn7z/bjDM5fq6k0JPiaZFpCRKospzU9U1Q9Sit6QTS/u6ajCuq2cmmuGQST9CuWr7l0VLuGvh9MAVmVxP9kGNya/t6kKoRp9TR4qIvGkGElc27KRWMOTiFJFVSimsaUonp3AN81sp8APHd706moqDjv8Gb/gmMf9/89Br/yBdbM7wOhIhOiNtfrKk6apGp1NWeW1iR1UC0qMf/BeZn8vinE0f6xmhqY4WOw8yqVJO3Eo2Q17JgtfTBWPQN6tTvwSyRHM3Q6rJSAOnb+EUGyY7Eb224jl/0gZxb3eWaPM5AmJqkx4SwhXEEu1Oj4k0xM75RsIat6LtR01gcXABrOPJjwkKSWYgv+w6eJpJ4UiOjFAB4I4KPMfE+37RkAHg/gY+6wH2HmN5/MDKeJ6o8y81vGDiCiH9/ifCoqKs45GsO2fKcjUlMqQyMppNxCKCmnFk3r1dSFU1KbpvWuAQPzvy9dOiSi3s8u4R6gkUvhFG4ICW6Zmtr7AhodjJJQKJNQZBWgPl2UJ6shMRdVlcA9GfEXPOpanzMrNwAVCJQsBuDPIZqzbtcZUCfnZdz0GU00B1+Zi7jPw6muX0pVJbJma21qnq1oaZKaM+PnMKag+v5H+qE8Yd8qFFlFw9ZG7xR0X8UKCWF/8DsOtw+C2zQpltu1wQPHqSSpJ6OovgTAcwC8LNr+C8z8745/OkOMElVmfu1UByXHVFRUVJSCiG2MsVu0SlVIbfqXhP5CUjXBTJFUraSGZnmoz+MkVY4DEtHvUXT+lF9mbPK3G0O1OCapAzB5RVJ8PP1Ruowp8WC+Mp6uwOS3xXNV4wHODcBQQFrjqPBAcYvm7D8614J+zgyivh8Sc7MmuxKwpMj/YO7bIAMZFXWUoI6MO5uknjTEFQBJ4RyAusdjJLXixMHMbyWi25/0PMZQFExFRF8I4KkAbqfbMPMDdjSvioqKcwpJlVSakuRRH7HeSa+6/TVDc39EQOPvYy87F73YxqR2OBcJKBojsYO+U2MnTPvyHnxWJFWPGST+F19PpcBpwpoiq15dTPTtSUeKbHTkfFitGhqTVnTReZnwusncg/yrjqwmzf4qkl778AbXsDDnazFKSWohIT4VJFX9drziKdc9558bB02l7sGIj+65Axcq8ceHJxHRowC8DcAPMvMnT2oipVH/rwPwAgDXAmh3N52KiorzDuPUwo7n5zjUCf0leIoMo2naQZ5UUUgBDFwA4tyo+vicr6mPktfR70pJ1SQqRXZjlVbU1N5FQIgt+u8ZZVfm43NdtiEPIPH7JLY5Ux3p5cS4g2pKSu2121NjA9waS1bZ5d1ET16DOQJKKYVfYSbN8Co1EjUd4Mp9Bmpqk49yyhZTGMOUqX8m2dqmP+rcv5XZpnGlSAdtm4mB49/nMaipp9LsvzvcjIjepr5fw8zXTLR5PoCfhH2m/UkAPwfgsTua3yRKieqKmZ+/05lUVFScC0iO08del/6/p30FZcGZagMA3/Ghq/C6Oz9vYMrvzfVIKqkyZv8KSWpAYBVJjRXMwXlkSGrQNpoHgKKFfMwdIg5q6UuXqmO6tCIcIEVQAXdNEBJFNWfubNATNwxuO0tY3WDcAmwUQY2yBhAs17PvIWkfuxZJNTUIiBshcnMJatQmR1Ln+7vOPP6kFMhSF4opFbvgfJMprM4wdhT1/3Fmvu+8efDfyWciuhbAm7Y+qxmYSk91U/fxN4noCQDeAOAG2c/Mn9jh3CoqKs4hyDDI1UhvO1O8OL3mTs/3AeJBf0kymnYBkDKoycApVXbVdqjNoZpo0mDseHx7ntPnZM/d9ddJ8AqQSklljx8GNvmvbs7eBYAZTIBpMDTxm5BcCzntA5a4L6EpVYdi4t7ZDADcGjuXtldX/X7xQxXC2hJMZ9C1NohqoE5HqvRk+in0ZGdAVrvevaCv/jTalb+u/mOCpK5FNvbJ5IR2BU0AACAASURBVKtcPkYxx50idY9GovpziujoA8dZwJ6cGxHdipmvc18fDOBdJzmfKUX17Qj/LT5V7WMAd9zFpCoqKs4mRBkF4NNKPeZvQ5VU+0AuTIujoyjEO4Nv/4urAQC/frfn9CVSXWlUIgxKo8bBVJqkBqb+mKTqBVqR1X7+kRKYIshNmjyn+vDHRab/GH0e0yGRSqWzshkEOCCeXimV884QVJJ2Ym6P5ytpqjpjyUVryQ8xgckootoHRtn524oCBlZRFf9WuYZm0cIsOpjlCmbZwixa0MLNddHaeak5BeVA2V0bTZ7XJKj62u6EpAZ+GttjL0Um8S2OByD/ILGGf+qZJqknBCL6VQD3g3UR+AiAHwNwPyK6NyzP+xCA7z6xCWI66v8OAEBEF5j5er2PiC7scmIVFRVnF4+97rGeqOYg6smYuT/Gr931ucnFOEn8Sl85kuo7Y+8LCoSBTEmSGmUASCGOwhdiR1P+gLqPLiSsA7Kq5yHmcyF4QuIb7ktfxgqqq9supBVAr5KJf2zLYNMBjbFR+kxg0/VKqmxr7WS6rgMbA+64V17Rz9PPp2E/dq+s9tfbHl94oYSkziCZqaCXrZlt437ku/69DNwMxrs8EZ/NGtk/EydTmYqZH57Y/KJjn8gISn1U/xDAfQq2VVRUVIyCyKqpcelTDb/P/d9+2W1+2e+TKP98/6FZH+h9U0VRNYFpX0hQrLjatsb0imGWXGo1NDUXIagBkZroMwFmsmVLQZDETSWLmwReybmIkmoWbVCLPajNLvXZRaWUfLVNqKj6Epkpf8K2V0+9gtkqghrsA5qObMBVGwZh2esEO79Fa+e16KyKahhoeuI8FeXvSbL0LYQ5d93i9lurZpUhpDmsQWKOhaDmKkmlqlXpfRUVhZjyUf18ALcGcJGI/gn6/8E3BnDZjudWUVFxDiAkVAioJPBnJnRMePltr0XW3h0h5Y9qMrXmB4FTmVfcd2q8sXkAQJzUP26rfUPD9tPjDZTXeL/ODqAIs3WF6EmqWXShotp0PpG+N+8b9MqqNq8nyCExwReJbyUPFdlUWY6kkhQG6NQ2p8IyE7Cg0H1B5mb6d4iq6l0j1JxS5En5xgIR8YzUS72PDJ8cST0urGP2H7smY2RVsC/nfsJg7CyY6tRjSlH9OgCPBnAb2PQEchU/DeBHdjetioqKswhtxn/prUPrkiWkwMK5pPqgnwgvu80vJ1VVMfsbRQiNUlZzAVQ6eCo2z9uJ8IAg5ghs8Fn6SJDn+NgxgqrnbTfk1Vgi9vEYenzbvksrqfJ50QYmf3hFtesJKhCqqE1PDoeEhAEiT1iZhbwq307lJgAA1NLQVUCGoH6cwbxUBaqA3OcCdiRZfS6tVCKgKElS9zhwau30U9tGTFarmpoGb1GtP2OY8lF9KRG9HMDDmfmVxzSnioqKc4Dv/JvHeTVVJ23X/pmGGB2mVRlLUnvzfk9GoUz8HARUxWVRdeCUmMhH1U/32UejI00gA2V2JP/ooG3ktuBJdmTGt8egLzYABMqg97E1nTWbEyw5dYFJnqAuOu+P6lVKd30C875SLoPPch5aeZQSm42blyKG+rv3sdTZALR7QHydPCnNKKkC3T8rJVX5x9r9CSV6sCH6DRaltSo4Zgcq2t7lET1GArZ3516xMSZ9VJm5I6LvBlCJakVFxVbxqI98V+B/Oua3KogXol+763OD9mVBUkOTP4BsMn87boKgAoFJP6eWanKadSdQxFTvs8QMA+VXk1AAIKdEW9KlyLEj6GLe94qqI6marBYTVHdeMUHVnz1ZDa6FfNAyqSbXTgF1xFKnkNKgxBwGJDWDmJTmzK2Dcq8jhLKabNdEvW4h6vVIojSY6neI6IcAvAbA/5KNNY9qRUXFJnjNnZ6Pw8M+tZSUQdXwqqr6/qrbX4Pv+NBV+PW7PccTV5+SqrEVqRZNr6wa06FZtPbd+VyOpaDyZu4EkdVKq7SFUnClnX73qZ2yJDVqp/xKB6RUuwIQD65XWAoV3lQeq6l00Kd38sRUJfNPmvMnHiQmTZcRGUeUecz7oyqSGiixKZRGlzv/1Oy+TN8DwqrnO0YsTpuKOIck6Wsx1S73m5lJykpSU1U19WyilKiKY9kT1TZGzaNaUVGxIQwxXnfn5+GhH3gCvuNDV+FX7/BCv4/IEgVDjM69y3Z9jLzHvqlN06JpWhXlH6qfUkI1lYLKk1CEBDUgrybs0x48VEZFFQ3mqwkWxcdGCm+CnAbVoRQG6bF00JQy8/scpIvW5R5VCulE5HwqsGht/zrtj+uuCXfo3QY66st0bkNx6hBmHShE8bFzrsMW8oeeCDmbcx9SBQSqcphEVebTKCKqkk+1oqKiYtd4+Ae/OyCrgpRbgPZlFR/U2LQfpqLS6ueQ5A3IaGTe9+qrJMIPFM+YsPZzpMBEnXAPUGMVE1NFloNT0NdM5Tz16qmkeIpJaqN9XgtVSo2SRXZCkYWz/nsiTKzcBTCemD8efxuKZknU+jbHS+BMJLnfkICdDzX1ZPKongYUEVUiWgK4GsBXu02/D+CFzHy0o3lVVFScA3z7X1yN1935eSBivP4uva/pwz/4RLz6ji9IthGi9oa7PzvwSRXT/qKxZn5RU4mssiqqYh9M1QXkkGJXgEaRU6dK9nlIO0/mTNMFBFeroX6+WjGNfD0HZnpFVAOXgjjNlu5rcJHEb9WZ8htLVMUHlZTJH3Iuskam8mJqS28cKV9SYcgrtdKH22y475vC90Bdlb5zOTtH4CtSjc1vDDJWfK2PwbS/LZIa91NC6uaQw9Sx2yCOped/+klqxRhKTf/PB7AE8Dz3/ZFu23jm7YqKiooJPPQDTwhIagwhZr4evDNtexU1iPKPFdEwqb8noZHrwMB9oHGZABatdxmQz2Q4JKeO8AYEE0gSUorIYEodlfFtH13fV6zEqkwJ6QvXq6mkVFPxRYVXWx1JjYlYlNopmW9UBzuN+pG69059Jw4rZjF6sropQYuzCWBDs+opJam5Ppjzv5s5444dG6QVq5gGnxH1fAcoJapfxsxfor7/RyJ65y4mVFFRcf7wkPc/cUBWY4Kqv1+8cMlv0yS1MeF3n4bKmet9Gwoj5nX/kp7KLFobeCWVrEwfPe9zkgJ9SidtogdCMpolmUM1lRQJDvKCarN5poiBPs6T21SSfm3q18FTGl6FxHB7RFCDBTZRp568Kum2dwjU1YCs6q72Ia/kOm4QpSDemb/mFOlJEcl9IkpVTa0QlBLVlojuxMx/AQBEdEcA7e6mVVFRcd4gZJWZ8Lo7Pw8ir2kyZojx0A88AW/8ol/y/qeiki6aPuJfR/kbXxq0C0iqQCuhzaJDs1ihWbZolis0LvjINDaNkyeqqsY8Kb9Ybbr3/WdM/faEFFHVCmiQqzRBSBN9xPD+q9p1QG/TSmqK8Lo0UT7faIqc6rynGRAxOCKiZBPm+vPjNhFwIyghcvqYTG7WoCKVDqQaifjPIlVIIKpqVYQNSWqKpM0lm7smp2Pq7aY4SySVUYOpciglqk8F8HtE9Jew/9puB+AxO5tVRUXFuUcup+ob7v5sNDqV1OgLQ5IamfmDQCmnpJqmtX6uy5V1A2hcKidVU96XZtVlR5ViGiyiGWI58DfVxFRIJRJENZExQGNQnUkRVADTJFWXF9UkNUdQR5RPNrClUoHe5M9OZTVw6uqOlEWd0J+pj/gX7EKxTUW57wgxCUySTn2Ou1SHR7BLsjpnDhWnE6VR/79LRHcBcFfYf29/zsw37HRmFRUV5wK/cY9n+c8Pef/3AYBTVC1ik7zOl9p/D6tOeTXV+5hKm2HUvGw3jSWmi4MVFodHWBysQKZDc7jyiqrUve/LdsL7fQphHSigOdKSIqxxlaVoW6ptLul+gJgkpPoEerLYuspNrbHqYyvbTV81Sh2fU4KI2PYlY3Hv0sDgnqyOKarxnMcQVaLy80ypqSmf25E5xK4o2fKshf1ti5hnCViydGwmMAxlRHJdsjfqRx0M0B8oovvsPhM4NSR1H1xd9hCliioAfCmA27s2X0JEYOaX7WRWFRUV5wbf/J7v82T1DXd/NrrOQEqpCrSp3n4Xn1Tng2pSaql9F1cA04QKaq+iwiupjXuJgto4smokOb7p841qJdWT00hV7SdctlJmyWmCWPbuAaqDOYpZiiQI0esUqWu1mhq6APSKanoINsp9QxRNUVgNFFnlaXI3RQozyKqpqbZaDZ2TmmouJue8Yf8zCU8p6Zsij7P6LvibSI03V5k9NSQV1fSfQ2l6qpcDuBOAd6D3TWUAlahWVFTsHEL+DMVmfCAX8a/TUBlnsh/4qarjGpfWyixaNMsWZtnaKk4+72hrx3KqKnQwlUTRa39QP/mZqto65HQTU3MQwa+2tSYy+ReQ1JhsCiHVRQji4cUNQM4lEYw1OXeZfwGG5+GGkuYTZJWIywnFGUx2vw5ZLe986AKyicvA5DyrgnkqUKqo3hfAPZhP07NJRUXFvuM37/mLAABjgK4zMMRgYsAQ0PUmf6AvkSoppxpl/gd6n1MjOU8XUpWKbYDUovO5UsVULxkBvJp6cITF4QrNgX1R08EsV6ADp6YuuyExlYpOTTetcnqTuXsbMT+Hlasy/aXU2xipxTj2LeXIH7U1dpHXpn5NUFPkNNU/4O8jGymHGqqq4rMKKMIq51RC6uIKWbEPbWT2l3NhDtuyjAmAoO7FmLI6Zv73HZeToeNWUoEEERzxWY7b5OY7SS6PwYd30l9338BVUc2hlKi+C8DnA7huh3OpqKg4xzCm88qbT0mlS5siDqDq26bUVEtaLUn1gVJR8n4JgDJNh2a56iP7nYJqDlZWRY1Jqi456tM+YVxJTSSsp4YVaXXNcgQVmf7nmKdjBTImqDpgKiKpAwU1WlRTqaRIyCaxI6h5sgpEQTcj/pTBfj2HrL+mnV+fizfdXkipn4dSRLUqPEtVPS4kr4dyvShB7riE0mn7XcM0X0lqxUyUEtWbAXgPEf0RAB9ExcwP2smsKioqziU0EYDpFxZfgUoU0IiYDvowHJFT66vqVdQoN6oESzXLFYwQVikzSpwmqeKjOhVB7ycmjDQirARI2dBRxPs9ASz0pZxSUbdMUmV7QFbH5pYiq3q+uaZjp65TaumxfNtYKZxxPfccJUQ6m5liBk46mr8Iud/nXj1s1BKqOZQS1WfschIVFRXnE9/0ru/3n9/0xb8AZkLjTPltZ23+MSmNfVMBpajqZP+OnDZL63e6cP6nphFVtfPppszCEdWDI5ilVVLFR5Ua7kuOGmfijxVUR44n0dGQsCqyOtlWI1ArE+qjjsyPyaneLmb+hC/qFEEF8iRV7/dkteOMqhoqdjx1McZ8e3OLvSbiOrVWMK7rqoPP/UqgPoVWCv4eFroqbBPrELB1SfjU9Z1qN+f4Na/j4KFlRGXeR+zz3DYFEX0lM//nqW0plKanesvEBP4LM39FSV8VFRUVOegUQIYYnTJdBmprQT9xdSohqRK9bxq7DcRWQY2V1KYLyKl/Jx6S1OxEokU359OY6yK1fWAaV2Nly5y6TXHJ0w1JKmAfGLLR9KUkJVYx11mwx9qMkdf4+3FE/a+LtXxQC85hV+b4KX/XXboBnDKSeg7wbAD3Kdg2wJz0VGO4sKV+Kioqzike+GdPwZu++BdClTRIUTU086cgpkiSQCfAVplatjCu6pR3AZA8q4suVFEPRE11AVLLdtzMnyM08cIY5R8dBAIVEJGBi4BvE5Mu1WdAWvvP3K1PUIvgiJ9XVVOHiO/npj6EKTV5TYxlKRDswk81G1E/43xK1dS1TfabKMcjbhjB31Pu2mfGnVJSs9dk34jrvs1nCyCirwDwzwDcnIh+QO26MYCmpA8zfUgR9uyxs6Ki4jTigX/2lOR2o/OTRtDbU/6qi4OVcwvofNJ+T1Ibt82prGj6z97cn/JFnYuO8iRVE8oCsCOYrNsnXv4YIaExSZVxY5Lawb6YihfOSf/aLYLdPJkjn75tBcvMIAvJnLm6K57wod0ykj63gmwxiMR2M+HKso4Sug0SVjLuaSWpZxcHAG4EK4xeoV6fBvCQkg62pahWVFRUbAVCVn/znr+IB737yQCAN9/75wBgEEglSJJYOcb7r3Y+dVVAUl2qKhKzf8OgZZsPmHJ9ByglSVMktWTxVGNnye0guj8cN6jcFJPU0nlsESUKphw32jZnrj+GSHM/TnKOuw86mqPuHlsAlLhSlMxtKuAu12wsRi817p4SVGb4zB9nCc519C1E9BJm/isAICID4EbM/OmSPralqO7nna+oqDi10IFW3/COH/QppzTiICu9Xd67tnG+p46oOjcAm9R/BXN4BHNo32nZgtw7xPTfsE3u7/1Tx1ZGSr9a0yfQb221J3ZlStmVKfX7U685Y6RenRtPgqnEJ1WXSG37vrRqG6i3wcUPr0WYVmsdwjG+jIztn6OsTka6T81dzjv2mZ5QlUvVVVtRbfq46X7Sauo2Iv1nYYfEcMzkP/i9zLAQnBRia8E2XnuEf0NENyaiywG8B8D7iOipJQ2LiCoRXe4YMIjoC4noQUS0VIc8cvaUKyoqKgrx7+/zs/5zXI3Kb0+WUWUsDy/16qrpX1JhyudJjZRUT1C1P6pqP0BMlvRLzPGtMsdzTxgnFdkcgY3JbNynM/H7BT0w/SslVXbnSGmMjD/hgKzKvdiCa0BxLtBsB+q+aX/nxLlsnHdUdm+LJ0yS4EIXjTnzmfodHJdKXXFWcA+noH4LgDcDuC0KuWOp6f+tAL6KiP4RgN8F8DYA3w7gEQDAzO+aO+OKioqKUugSqin1VHxYZXvXGXRtg7Zt0K4aLA6PrKnf5UslIy92if1b0MHKKqmGe7M/MO2TWuJzOjgm+h4jHrMkuESb9VP7g2OoJ6vOHzXpflCqOG6YmqmUGMbHTboMGHappQjkGDs3Hag1YMM2NRb6IItYhSSCJ7jZcYhtdjGmfjzAX4+pKk45DAKrSqpg+bYl0u3IMdvy990xisu55oKw9uw890wB3TaWTuD8FgDPYeYjKvzDLzX9EzN/FsD/AeDZzPxgAPdYb64VFRUVm8O4ZP6mCUuoEjEWixUWyyMsD4+wvHAUKKqSN5UkiEqS+IvSKgFUWjmNzL0DRHlKs6ppZOIXtXNgFo5VVo4+azNmrJxm9gsxDUqiapKaMo2usXBm1VNiwFUa0+rmJkrpxiqrmkOSpA4GdLl63Wt0LgM3lfkK61YUWX+O844/dmzZP3Wy7Z6R1HOAFwL4EIDLAbyViG4HG1A1iVJFlVyKgUcAeNzMthUVFRU7xZBk2IT/PpjKANSwq0plFVNv+m8UiU0R1BRS6qP2/9TH6ONUtP2gPama96k1NEUaYxV1xFczVmu2ot4Y9ApiRlU9zowAORCxnZrMkRgEdy8S8/PXX6upid+CzyGrz10rnxsqzetgY/J+DrCfJHXvfEq3CmZ+FoBnqU1/RUT3L2lbqqh+P4CnA3gDM7+biO4I4PfmTbOioqJi9yBiNM68bxYtwGRN/o3LjRq8Op83FYs2HTSl/0vGymYQHBUFMKkAJx08FW63L0m+L/17dTTnv6q2Bypq5LM6CKoQZbUzQzV1Lkz0DgQ+qYHqmCFPg4Cfua+ieYqCC+eT3AUqOjn11L/kePfQoklqcD6JbV6ZTanxY9CKfRykpm/NxHkPSOq6KalKr+8cX96UVWLKUjHVbaxSB0Fj0TgVJwoierILpiIiehER/TGAB5S0nVOZ6i0uWgvM/JcAvm/tGVdUVFQU4P/90p8BAHzd2/+V/yxIqQ924bILn7gGiH8qNHmiXlUNUlDFSD3K69ykWkXV736OesJaVR2qm32deQwXVkm7NFBJE/NLXZ+kAhySVH38TlS5hNm/37fmeDOS/BMxGORUUFi/Urm/cVqghFtCknQ7xTRWVn0xAGkj+4BpH+CTQO76z/CLTWLEr3ejPscerDad8wniLCuqAB7LzL9ERF8H4OYAHgPgVwD89lTD0qj/ryCi9wB4r/v+JUT0vA0mXFFRUVEMTVK1Qhi/A/BlU3VEvzFi9u96E7+oagSnuiFcQGMSExO/DEkNfE4T/qKxuhkEOEUY+K2m9kWuBlOJ8IN8qceBEjU1hak0XSVD62wNTlXt8+ImFFDxU9Y+qzShDKfU1vj8UtkQSlRWfx7RvoR/7M5M/lMPEbsgozOR87/NFgnZA3eUAeL/F9t67Q9kMt8A4FeY+Z1q2yhK/Ux/EcDXAXgjADDzO4noq+fOsqKiomJb8CS168tzGtOhaVo0iw6LRduXTl2uYA5WNqn/ctWXSHWBUz7KX6ei0mQuJqOtM9UD1oTP6piJ+Q7UTa+kqsWTewUuThafU2mDMRLjxAn9hWTPVnFkbh1C83/KVzXlPpFCKQmV45Lqd1pJ0+omoQOI3DXt50kY+i0myak+D/37SCmrCFdhDtoWnq+eI0X3fko5zOVOXQfx9Y7HPW5lOKFOB9dHXRt//yMl1t+riuPC24notwHcAcDTiegKFD4yFwdEMfNfU/hrb2dNsaKioiKD935b70l099c+C//pq34Cbdtg0TToOkLHBJNYDPsodngSQQbeD1EHTVlzf+dN0D5fqlbTShZcrXxIhH/CnD/eR2iCnxp3dnRzjqQqcr9TtaUgiKikGlW2JGhM7Evh0kdZsz8BnTbtR8cO/D3jvtx7RNADAhQQTe7PJzf3SfeFNX4Lu8CemtdzZDV7/B6RVcaZN/0/DsC9AfwlM3+WiP4xrPkfAEBEX8TM7041LCWqf01E/wwAE9EBrH/qezecdEVFRQUARzg7g3Zl8N//xY+iWSzstoZgGtkfmvd1WzF9mkWLZrFCs1xhcbByBzPMsoU5tEqqKKpYtJak6gCqlM+iD5oy1tx/1PQqamvs4uLUVVakRMZOIqU6Di7KCIFNKKeBYptRUQFk/VL91DJjauW6Hxuhmhp0xMPj9JwNTy/MsduCPIykVOgRyDn1fqMMEn9gFcC2FhJqsr5OrK5//Lsd9qWvWfT7UMqqn6/2gU31oY7fOkr9g8dIeenDRq7/QmU1p6oCe+oGcAbBzB2AP1bf/x7A36tDXg7gPqm2pUT1ewD8EoBbA/gIrPPrE9eZbEVFRcUAijhJqVQJhrp06QBN04INoeuGNmRdiUraNC65//KyG7C4cGTzprok/0HwVKP8BVPmaVnUZH5ScjQiqT1JBGCUWpgjm6XKSSGRm0VSR7C2n2OOrOr9c5CbpyK4c8kqkFA1M2b6HIoUr5yaHJueNXneFCdNtlLq5dSc5sx5XQU31aZA7T8pnHFFdQrZky/698HMH2fmRzDzLZn5Fsx8pWPDFRUVFTvFA/7r07FYrNA0rSexMSTFkDEdzMKmpTKLrk9JFeVNtYFU7AOqRv8TqmT+/jv3ifM9IRSiJtWOIpIbTnhEcS1ZkFNBWGpeoyQ1sxgmSWqRojs93WTbibRb2cCQDU21QeBRKo3UCFnPEvmR38+grGxpn4MD5yulO1NTU1gnddjc/nPI3pdTpJayVd+3/TpFyN6sIkWViL4QwPMB3JKZ70lE9wLwIGb+qS1NsKKi4hzjHq//xdH9l13xWQDApz5xk1AVQ6+kirn/4MIlHFy8waqpl12yhPXCJW/6p4OVIqkRYYx9RwXii9oaW3lK8qBGvp/98U4tMyPKai4q3I2XQy5gKlB11fyTpVyjfkpJatL8r8fMIac0x+eZmZ+fkuqPJd3VmsQ1MMPHbgn63NdRuWJzfey3GvWbVFdTKmI0r1x51tkEdSxIbZ8wpqzmAs9i878cW3FqUGqQuRY24f8RADDznwJ42K4mVVFRUaGxWKywWKxwvz/80WA7ORO+RPsvljbS3yz7pP7mwiWX2L8bJvUHhouWJl1iSmf0vqpu+yAXakeTquW6CBL363RNTGuRVI1ZSuo2kVFMB+m1dJP4mp9mU+kWr7EQ03XKtAbYk8CiXWG/q3ZR8He+rdcpwqXcjlIf1cuY+Y+iqP/VRlOqqKioKMC7v/UpME1+v3F5UhdLF0glaakOHGE9aPtKRLFP6pRpO1ZVGeFinlJT466m/FVTx6rvevx4TjmCCpSR1GNFrKomEJ5v4gCRVkTJ3pICmPRd3QcUKojADII6RdbWzahwShBbZCp2CyJKBkgJmPmP3fs/zR1TSlQ/TkR3gvMhIKKHALiusG1FRUXF2iBirI4aNIsOb/nKnwKz8eb+xdKa+pfLIxxedj0u3OhzOLziczi44nosLr8BzeU3gA5XlqQuu7S5XxCb8b1q2QdRefVS+4AiJIWBeTyOdk8hIgXFuVD1vBPzmCKnGyupBcR7AEVWs/vjMfTcusidoovM9hnMUtJK3S788bmDS5xIhwFWgzFSkf1zsI6KeIyuAEUPLRozyHuuzb4qq2eUQP+ce78A4L4AJNH/vQD8NwD/+1QHpUT1iQCuAXA3IvobAB8E8Ii5s62oqKgYw/se9iT/+a6vfg6A3n/1D776xwH0wTDG2KT+i4VN6r84OEJzsEJzeARzeGR9UhcdaNnmfVIFAx/T3uTP2tQe50wdW1gUkZujqvrxVT+BcpoYcxDNv4lf5RxsQFYH2+J+R8YKVNkCBXCQNiyzf2wOa+fJ3RZyPqtjY+0pIROsn2ViWvWeXSDhhME4m0SVme8PAET0agBXMfOfue/3BPBDJX1MElUiagBczcxfS0SXAzDM/Jn1p11RUVFh8ddXPRZdZ9CtDO7wkmvQrty/pGgB+y8P+L9AZHzUf7NosVyucHjxeiwOVrh4xWdx8cafxYWbfBYHN/ksFldcD3PZJdCFVU9QJ02e6P1QmYC2D6DyQVTKl1IQ+KUKkRJVlckGVo2lrEotnlpBVXNLppcq9OcUbKqkDgKqYtUz3p7MbJDquGCRjq+nbG8nCLNJBCsN5pR++NiGippNCzaXmGyqruaQe+DYoRvAFEmdNNGvpt4gjwAAIABJREFUS1YFe0xazyjuJiQVAJj5XUR075KGk0SVmVsi+lL3+X+tP8eKioqKENbhH1itFnjfw56ErjvA6qhBe7TA277uR9B1hLZt/IJlTAfTWCV1eXgJy8MjXLzic/bzxUtYXLxkS6Ue9En90fAgUj1rIheSqqL8fd5UnTop55uaWvAVuSq7KBMkdWTxXkuRWUPVykb/l16TqTZjYwBpf9e4n/hhYIxwjfn/xuPmsCU17MR8KMceLPYVKeJemid1D/1wz6KiqvBeIvplAK+AFZCvRGHhqFLT/58Q0RsBvA6AJ6vM/OszJ1pRUVExBNtk/u3KoG0bq7JGkfV9dH+HxcERlodH1j/1wiVr9j88QnPhCObikfVLdSZ/arpgnHhcAEPiKVH+SmHlmEBOnVKCaE2WDZ1JUnexsI2S+mh7cVWfFAkqUB/lczYlVuTvSrn+x4oDlJDUqfRbYw8Pu1Du9tyMvU/Ym7KzFY8BcDWAJ7vvb4VNezqJUqJ6U9hSVw9Q2xhAJaoVFRVr47bXvggA8P5H2EJ3q9UC3aoJSGpfqYrRLFc4cAT14OINOLzR53Dhis/BHB7h4Mafw+LGn4O50Q3AxRVo0SZLog5IX8rk78z9oqyy+xwHXGVN8SMuAPExQTtgkKx/quTpHAxIsvqeI52yPXWuQVnbEtI6Mf8iUqyvXUQg2YTtA7U1l3M1dW1PmJjOUlXHFMRSH+KZ1Zpy80s9hMXHzfFLLb4OsbI6khFhb0krn21FlZmvJ6IXAHgzM79vTtsiosrMj1lnYkR0AZY1H7qxXs/MP0ZEzwDweAAfc4f+CDO/eZ0xKioqTj/u8srnAgDe/i+f7heSPmiKbaUp02F5sMLy4BKWF26wSf0vOHP/oVNSD1pgYStQDUztU6ZcMfmLT2qrFNVIVZ1EiqxOHY81SOoYKZoas4CkzsEshTXRdl6DnE+le3f3fuAaMPZwoNvnxpya1hZVzq25AMwhqwXQJYvnHL8u1i41myHfx1qt6xSAiF4M4IEAPsrM93TbbgrgNQBuD+BDAL6NmT+54TgPAvCzAA4A3MH5p/4EMz9oqm1pZapnJTZ/CsDbmPk3RpreAOABzPwPRLQE8AdE9Ftu3y8w878rGb+iouL8wC4kdnESkrpcHsE0bEnqxUvW5O98UhtXdcocHtmqU0sVPKWJ3xi8yoowmX4isf/WMEYgxkz8W6jEFGxPkcvEIh9UV8pgE7I6G2PXT2UWSJLV0sCt0qmsc09Og3qm7uVJp3QqIu6n2iXixBL0vwTAcwC8TG37YQC/y8zPJKIfdt+ftuE4PwbgywH8PgAw8zuI6PYlDUtN/xcA3A3WRxUAvhXAuwE8jojuz8zfn2rEzAzgH9zXpXvtq/BeUVFxzPjgo68CANzhJdfgnQ/6IcAsQGxVVGo6W5HKlUVtmtaSVFcedXnZJSxudL3NlXqwgrnsCLjggqhikhqb6iMTvjf5HzVhmdRYSY1Ib7I05lzEamrkk7oNkjqAqGJjdegT/p7bJqsbK5BjAVT6sETQVdLUP8P/+DiQLf4AzCNlpzFQKoGYLCeJnb4uU2no9g0nQLKZ+a0JwvjNAO7nPr8UllxuSlRXzPwpWkPSLo1DvTOsMvpsZn42gK8FcHcADwbwL8YaElFDRO8A8FEAv8PM/83tehIR/SkRvZiI/lGm7VVE9DYietvHPvax1CEVFRWnGMyE1dES7/7Wp3hTPzXWdC8lUZeHR1gcHGFx6F4XbNCUVVKtikoLqTzlGMecBUlyo3pSinSqoplkZuvY5SI2x2+wgIRum8htW6WdQ1KlNK5+bT6B+X2cpKJ50mpqDtl55X4vUpVuT89nR7iZ8Cj3uqqgzS2Z+ToAcO+32MI83kVE3wGgIaK7ENGzAfxhScNSonprAJer75cD+AJmbmHN+1kwc8vM9wZwGwBf7pK8Ph/AnQDcG7bC1c9l2l7DzPdl5vve/OY3L5xqRUXFaQJ3AJnOKqeHRwCAwwuXcHjxBly4/HO4cPnncHDxEi7exOZJPbzJZ13g1PVoLr9kfVMvHgGipAKWfJSoqSqxP2IFtbX/HpPVoBTIDNNfxfvzJz9DTS2F4cFC7Rd0tUj7ecWLtoleUTtpO0UeNyV1Msa2SOqg/nniNwIMienWcQwPOsz9a+2xS3ycp15zsUY7ecAdQP4OThFp1b/Rbb0AfFx4lHtdc0Kn970AvgiWM/4qgE8DSFrjY5Sa/n8GwDuI6PcBEICvBvCvXQGA/1DSATP/T9f+X2rfVCK6FsCbCudRUVFxhnDHl74QAPCeh9qMJff89Z/335tl6ypOrbC87AY0yxUWUnXqwEX1L23wFJouLFsqmFqYNYnVamqXCG4S5II0EmbxLBmcwrpkJrEoz1LDUtKFQX8N4mjqDV0BtqqUzjnPjIq6c5P+hiR14wCr0ms05Zta2k8ux+1Uf6XtdJOxa7OrQglnF39HRLdi5uuI6FawFvGNwMyfBfCjAH7UFZK6nJmvL2lbGvX/IiJ6M6wjLMFG6f+t2/3UXDsiujmAI0dSL8K6DPxbuQDusAcDeFfJPCoqKs4o3ALznod8P0Bszf6LFZrlCs3BERYHK5jlCuZgBbNsQcvWlkdtOqeabDC2iqwPpjSmpI6QVeCYg4oEm443dg0nyCpwfH6bA8x9CDgJkrrvvpFzsK5SChT7FE+2Wxd7mORfYBXwvfmdvBHAdwJ4pnsfC5ovAhG9CsD3AGgBvB3ATYjo55n5Z6falkb9E4CvAXBHZv4JIrotEX05M//RRNNbAXipY88GwGuZ+U1E9HKXmoBhUx98d8k8Kioqzgbef+UTACZ0rU30LzljyJHU5eGRD5w6uMz6oi4vuwHGJfQ3h7b6lFVTebigjUXTa7N/R314pzb7lywYI8nrkyQ1QwSTZv85yKmVJTlTR4jCQKHSOWkzgVbAlgjfpubY1LXOmPl3iuMiHiN5Q0cRlxSdkdJsLazbvpCwjgafnQKcRI5XIvpV2MCpmxHRR2Cj858J4LVE9DgAHwbw0C0MdQ9m/jQRPQLAm2GDs94Om7JqFKWm/+fB/pk/AMBPAPgMgF8D8GVjjZj5TwH8k8T2RxaOW1FRcRYRLKr9f2djOpiFfTWLFmbZwiyt6Z8WHcxBa03+TWdtO9tSSDYlLGMpj9Y0+2+y0I6R1Dntk+ZUra5K3yPuAMXK8rZ8BcdI6lnDnMj/gS/yxHfsbxBVCU6sFO0pAzM/PLPra7Y81NKlKf0WAM9h5iMq/IGVEtX/jZnvQ0R/AgDM/EkiOlhzshUVFecQUn3KBjDYj6YBAHYBVYBpnE+qy5PaLFeOnHZoLrsEOrRJ/WnRWf/UKf+5HIFMlOkMov2JQYCtdFRKclJjFVTqGZRvLcUaSiow3y80mXA9rviVcQeY7nzLRGiKpMaBdacQWQI2pjpOkdTTgtIcuHL4KSPaZ5xYvxDWgv5OAG8lotvBBlRNopSoHjnzPQPe9/SsPqNWVFRsGe+/8gmenAJhFDozwSxcFapFC9O09n25srlSL16yJHXRghqbvsoqqs43dd1AJYn2zxzjF41YQdwRRqtQaWK1AcnYut/sOtdm6n7FZHOTaz8nsO6UYJLMjF3fYyKoJRkhKs4dnsvMvngUEX0YwP1LGpaGIDwLwBsA3IKIfhrAHwD413NnWVFRcb5hS6J2/t0Ymy+1ceS0aTof7d8sWxvdv1xZYtp0wKK1Pqlx+qXS6HpNXFKLpeonUGNSKZu2gbkkbC7RWFNRKq3jPnusuSRVtpVc823el23hOBS90t/EnpBUOebYgw33HttPTbVnCu0HiOhniOjuAMAWq5KGpVH/rySit8P6LBCAb2Hm96493YqKinOB9z/iiZ706YT+gOQ/dO+mg3EkdSHlUS+7Ac1Flyd10YIOV6DlUE0lM50LkePI/igtFZhANAxmyAZnpJTE1KLA1M9NlfWMlb6smhqT6ZKAlwy2QQyybgDaBQCYDmqLsQsiui82v5nm6rWQS790zGRwtluJOv7YVNaRIMiTxp4Ry23jXgAeBuBFRGQAvBjAq5l50vw/SlSJ6Kbq60dhk7T6fcz8ifXmW1FRcZ4gCioMhwTVEVfjXs2BpKSyqajIBU/R4Qok0f1jJDUmkGP+qZk1lYjB0k8U9LXxQpIgt3qBLiqXKtt3TEKCsqNzsWnu1lOEIrK17TRLOZSomamHjZHjtoaJa1CSk3drc8h9r9gZmPkzAK4FcC0RfTUsn/wFIno9gJ9k5g/k2k4pqm+H/XdOAG4L4JPu8+fBpiy4w+bTr6ioOIv4Hw+3wVPUuEVPkVRjrCoqBNUsWpDp0BwceZIqSf1tvlRWlWbQk1SNXPonWfw08UyVSE0hWlwDslrqn6lV1Xh76rOe3xi2TVi14nvWcExK1STZ2gJhXfeBKSae246Kz6qpY+QwkdZtY7KausangJDuWR7VrcPFOX0jgMcAuD1sRdJXAvgq2HRVX5hrO0pUmfkOboAXAHgjM7/Zff962OT9FRUVFQO872FPArOxhFTBGGvmbxatTUPV2BRUzXJlU1JdOEJz4VJv8j9c2Qh/8VFNKak5chWZ1AEEyf17AhstaAagDlZV9e3UIdI903pkNc7jGZv85y7UG7gDTGEjVRU4OeI7cU+2QYimqm0VEdYYhUQlRzLn3qttkdVikjq2X+XjXevarXtcxXHh/QB+D8DPMvMfqu2vdwprFqVR/1/GzN8jX5j5t4joJ+fPs6Ki4jyAFfkiuIh+p6imSGpz4IjqwZEy+Xd9hH8pSc1UHRqoqSVxP9pEWlKCccoXcaQS0tokVaDI6sbkch2kCPueq7ObkNXSgKHZ/c/wZz32ezx3vEoUZ+OMZ0O4FzP/Q2oHM3/fWMNSovpxIvo/AbwC9l/8lQD+ftYUKyoqzgXe85DvB9BASqFqs7+QUu2L2hyurJ/qBVtxyhw6JfXAJfZvVCT+DJLq1Updiao1ACeCq2LoWueKgLEiZORIBRvlWlBINDjlerDpIpUiqzm3g2wfWJ9g7gsxnRFENeZfmlNG5wQMrZWmaRvBPjMJ70Ypr4CyksFjvw9d7YypTJWuOBUgomejT2062D9FUoFyovpw2LJab3ADvtVtq6ioqAjQdcYHSgHwauri4Ahk2FWeclWnDlqYQ6eiNh3McgVatlZJlcAp7Y86Ze53SJLUXGCV7BfEi7xSU/tAq0SQlZDYCZIQL77H5Zc2IBMp8rEDsnlaylpOmfJ3OeZkEBaQ/03lSOQYuTzu+zD1uzqmXMX7jn3++9gAb9u0g9L0VJ8A8ORNB6uoqDg7eM9D1b+ETN4+IazGdI6kOlP/skVzuLKmfkdY0XTKH5V7c7/vbGThTZn8NUkFvMmfNTmdWvxjwhqTVUdKk2Q1br8OthEQMldVLUCpb+OuA3gGOEmys8E938ivdR0cR8qsuUg86B1LJoC9wd7lPd0KmPmlm/YxlZ7qGcz8jE2PqaioODt477eJpSYfzEGSyH9pS6IuDo/QLFdYXLxkP1+wL+NKopqlI6rLFlBkNZl+KkbO5K9Jamzy1yRVl1AdnFA6swB1ABohXY7AyjSMui7diCI2d1GKj08Rl019VbcU+T827s7Iao6kHsfir883p4IWKJwp9XYT14NJ4pvKZpE6rnCs5NwSv6fJ/MQRWS0Z5/wQ2tMJV9H0aQDuAeCCbGfmB0y1nVJUv4uIxpKxEmwC12dMT7OiouK048+//XtdYvyIBEWLnjGdN/FbBdWS1EbM/T79VAdatH3AlE9DlRh8qo47IpO/oB1hXmMkFYC4VPn9cp5aXfXfEaqrMucuaovM97nYgVI6h6RuEnm+c2U1GGzH6uHY+c6NUE9dzw1L5paS1eNCscqemduYi8apJqt8Zk3/glcCeA1siqrvAfCdAD5W0nCKqF4L4IqCYyoqKs44/vzbv9d/1v6nKWJiFlZRXSxcKVQpibpcuZeL6l+2Nkdq0/XqqVdlRwKnYoz5nwJpNXViUdN+/wFh1WQVVl0NyCrsE3wu3+qpX1AVYpJx7JHogrPi37gucZwgunN/b8d9H4sf7qb6OUN/W2cQ/5iZX0RET2bmtwB4CxG9paThVB7VH9/K9CoqKk413vewJ3myZkueWvO+MTaFlCTyB+C3mabD4uAIiwtHWFy4hMVll0ALp6YerkAHfY7UVEJ/jxxJnYry96Q0TVJzKuoYPGFFOD9y5n/vDtD1WQEA5w6QCbQKVFlgGNilznEujiNV1br9b01VPSmSus55Tz1waf/mdZBxO0iZzwdNdTq2E8CuyeqJlGudAcaZV1SP3Pt1RPSNAP4WwG1KGpZG/VdUVJxz9P6nvQ+qWcRklQGCjep3Pqq20pT2Q5XjYdNWCUGNF+gZC3aw8Gi1tISkyuIwYzzr/qDmGbsDRMFWAILF1y+mcTAW4PsJB9xDN4EtYGOyWkpSNyH8c67bpv69xxT9flLK40YleTcgqzFR31fl9YwT1Z8iopsA+EEAzwZwYwBPKWlYiWpFRcUo/sfDnwgiS1AlN6pZtGicWV+qSpFxZLXp+oT+i86mnzpcWQX20KWfWuj0U7ZfKNO/X1hidTURkBTkJNUqa6f2xSQ1tSBEhFWIaJD6L0hVpZqKwto44gkGSKJ4GeTGt8pqT/gBgJW7gB13RF0tWcjWrVS1L3lQS7EOodslWd/W9cvlBz4mbEWBL3XZGUNM2tcgq5vsr9gumPlN7uOnANx/TttKVCsqKpL4i0dJMbrGvkmaKWI0TedJqq0qZUmpdQvoerK6tOZ9eSfxRQV6NVVDFjbKBFTJYhUv3nHOVADeOr9OdP3UYh0RyZzCGvuvEoZuALPU1ZLF+pQtwMcaWLUrrEnIis59XeK6jymoNsVZPCeFU/93MAIX9f94ALeH4p7M/NiptkVElYi+EMDzAdySme9JRPcC8CBm/qm1ZlxRUbH3CIJkTB/Nb0moU1W1orpobZnUxhHShVVOzaIPnAqUU0Fk+p9MSl8CTe5yaqo+JiZ3paZyRSRnk1UgUFdjsgrodgm/1QJ4dWwPzf4bYZ+Cp9YgqVq1nE3U9Xj7dB0qKsbxGwD+E4D/AKCd07BUUb0WwFMBvBAAmPlPiehVACpRrag4o+DOgLve5G9MBxjGwpVAXRzaQCmftH+hI/iFrNp3KJ/U0MyP3gXAJD6PTpBGK1DFZVKzJDX+LqTVkVXmyPwfIyi3qsYTSVcFW7Gxe/xx4h7Qsb12TN4VAFDuAEJOpvzqdqSmrpuGaus4I8TspJWzU+2feWZV1bOZ8F/hMmZ+2joNS58FL2PmP4q2rdYZsKKi4vRBfE8Xy5XNkWo6HzBllGoKp7bSUpFUwz1JnRonmTB8DUIkTVKpqDZZpGcQRU9uvb+eSuWlSsKSdnMgHleUx65FHDCypSCgrS6emTlNzrXDyZFUo16pfRUAEn+70bWJ77GuZJf9jeWu71mzEAA+8HPbrz3Cm4joG9ZpWPpn9nEiuhPcv38iegiA69YZsKKi4nTgLq98rv1AUgaVYRophdqFZv6GvUuArSjVDUz60pf/6NNRRQpq8Dlhkh9D4KOaUU+nkDh+ViqrArJKoiq7fSmySkE/CVeJ+KWOHRRj2AGKCKwPmFO/A+LTQzTiFfKME9N1H0qm3HVSDyL6d3pi+XcrjhNPhiWrnyOiTxPRZyYKSnmUmv6fCOAaAHcjor8B8EEAV64314qKin3F+x/xRAAqEt3YvKi+utThkU3mf2DLnzaHLnn/cmVVVInad0qqJWEICWts9nckF4CNms+RVIEz8w+qUMUpqbQbgJj9S0mrRM6P+aqOLa6K0PRmfutGkMwMIHlXlSsAIJkBbLCVzss6ipxquQ3f31KU9B+ljBr11TymtE2DMeds3zKyZUbjuYxdl8xvJptrNHXfJvy1k78r/fsv/K3NzuN6xlwAGCfvErJLMPMVRHRTAHeBKqFagiKiysx/CeBriehyAIaZPzN/mhUVFfuM91/5BIhXpKROkqT+jUvgH6SdcimpoCP5gUBJHZj8ZbtWAlMBP3PN/bl/8Gsm9h/0XeKrqqEX0VTAVRxsJXlX4QibDraKMwPInPRYuWmcRAaADUjwmcgAsCFy6uPa12UbhC5DVidTQG3jgWiMjJ8xsnqWQUTfBauq3gbAOwD8UwB/COBrptqOElUi+oHMdgAAM//8zLlWVFTsIT7wyKv7iB3qzdNmYcugSuCUaVoXQLXqU09F5n6vqmaUVDJWRYW0a7re3J9a+GJT/hg6pbTq4yM1tSg4aE4+0vi4LlrYxxRWg56suqArr542Op+rJqmJeY2RgjWKGkwhSULW6T+hrAKJe3ScquoJmfjHiN1G1yXud+rhJ4WIrHqSmvudr/lbm03KzxBZ3fiher/xZABfBuC/MvP9iehuAH68pOGUonqFe7+rG+CN7vs3AXjrGhOtqKjYI/S5UvtFyJNUUVJdKiohqTbtVOv9U3sfy8j3coykOnJK2j/VL3xuSvqftvc3RTFhBaJIf+kq054jolSMsQCwLiKIuXRTQlb1frcAe4ISpbQKx4u+x8TlOHwANx0jIhznTV3dyEQ+l8TLb0u7AEwRvqn5bYGkro0zRFbPMK5n5uuJCER0yMx/TkR3LWk4SlSZ+ccBgIh+G8B9xORPRM8A8LoNJ11RUbEHiAmakFSJ5m+WOrLfJfbXqacc0fQkVdRUgWxrlAITv2KSOjXnuGSqfhckIv3XJj6leVVjdSpFWFXlKYpcEzw58+368QeEFWE7P1WmmmtzE5yAmroOsRsQ+W2RVWDStWSgpm5KUrfxkHIGyGp3yuc/gY8Q0ecB+L8B/A4RfRLA35Y0LA2mui2AS+r7JdjqAhUVFaccoqBKCioiwDSuRKrkTD1YoblwCdQwmoMj0EFrTf+SN9Urq7AkS74btuRT1FVRUpuuV1bH/jfrXKixmpqsUBV/p9kklRUp7C9S5nvK/Jn6niOOxpFVOGW5i8ZuZMFWJtexyev2Ekhm1PXbEiavz9odD90AjlVVPSUkNW7bVzKb2UFUzlfAid/KWNDU2uQ09X2T+637PG2kj898MNWD3cdnENHvAbgJgH9f0raUqL4cwB8R0Rtg/2M+GMDL5k60oqJifyBmf01SjbG+ps2idUn8nenfVZ8yh0cuPVVbTlJVBoCApBL3rEsvgh0NCadaOCdzA8b+qbtCgqTqxZxj877MLTb9x31G++aQgKAwgHId8CrrLtTV4zbz7gozSF5RRP7MfjbB2oTe/16iB4Qx3+wxkpo6n9S8xs77DCijFeNg5rfMOb406v+niei3AHyV2/QYZv6TuZOrqKg4OXzgkVf7z7GK2jhy2SyEnK5cedQWxgVSkelsKqoD5aOqI/e1iV8RVu8a4FVVORbpICT9WVedgiJ/Y2Z+DRl/Ri7VHHlIFi0Qd4nEwh5vCwJXPEFAqKpqs39inCyEYLhgLK/Exip0AVndFgnbCIqsBCTsJNJUyZSyv4voPm9LEZyDlBVgTnPvThK5nMSIyekcd5hkf4l97u/Ez2jdh6xTRnj57FemWhtFRJWIbgvg4wDeoLcx84d3NbGKiorN8OHHPw4AcOn6A/cPkAZJtoWk2mAp54dqup6kLi1hpUULc7CCOWi9ikpCRmMfVK2gNoqg6qCpFOkTMMpIasnCNSd3aowxs35cyKAAudyVg76BpE9sLjWWT3cl7VLdkiKuM5BS6o47UOZYFu+5JvP4Gpx0ENiGpGzUxzl3bOz+olHyN7fr1GmV9J0ZlJr+/x/0xriLAO4A4H0AvmgXk6qoqNgcXWax8ES16atLCUltli1A3Jv7nS+qTerfgRatje535VIDBVUTuFhFNbDHA+MkNYOskrplpEqc2u0jbWacS5ASKFA6OQys0u4EcWCaIM7Nqo+R62W4PFMC0iT0pKPvk0FDgFejB5irvBWQ1EkFMeFbC4yT7K37+c4hqyMm+skHEb1/XbKZqbqWynrRt8GZDwysimoapab/L9bfieg+AL57JzOqqKjYCrpVg67rV2GJ5rf5UTsfMGWcetoIIXWKqlVQ7YtcBSo0LsG/TzE1Qkw16Yt8UX3K1kRVqVhNTZLUqWo8xICk3FJBSpPqYCJghPTctYtDcOzIfATCdTRZlcXXJ/9PdJRTdhO5WVkG0emu4jZrLPZ7R1aBPMHURHYMEwQ1SySzFdOUCj5BWDdSpUvGF0xE7/v+Um0Lxs66PUz5YSfa6m2+AEbKBSBG6j6fUsJXiWoapYpqAGb+YyL6sm1PpqKiYnvoOpNcIM3CVpsKKk01zvTfON9TR2Bp0YLcO5atVVLF5N8owqZ9L0cIKqACfuZg03/gbuEUwpMkClMkdVMQhmTVzw15/1Q1n8G21HXZ0WJ36uqx50j5XIIKJEnqMOJekbPo3sxSKccw9jtMkcOpfs3wvEow5q87SlbnjJPLJ5x7YNH3+pT5p1aMo9RHVVeoMgDuA+BjO5lRRUXF1iFqKoxTVcXc3yRypDp/VHKmfzpYuQCqDnCuAUnfU2CYD3UOQR1TU4tPVH02DLTD9iUqqj0ubsiZQKfoe3wIRZ/1fr2g5hbXMbIhbcYULDl0QhXdOyKaIHuzFaeYxGR+g9lzT5i542MDAhWTVWB7hKmE5BX8Dmb1l8Bav5MxJTYRUJlSVu2G8CFzozyy+wYuyGhyTlGqqF6hPq9gfVZ/bfvTqaio2BZ0In+bwL9F4wKhmoU19TcHKx/ZL+9k2L4ftDCHK9DBCjhogYUEUHGY/3QNtbTE5N93mjKHI8pH6lRJuATmbEkqUWgODxbxMQU1dYw6lmJC7uc6PHzY3h43cAEA8gvtnIAVRV59aVZ9TQfXLtFeY4+UqRLfzySicyzyD834UebuRUCu1PbJ3J5rPiCMmt31+ClMmPC3hlQ2jCkXCn3dO9j/N5DzC4k4qYeZQXaAqqqeGZQS1fcwc1CJiogeilqdqqJiL/H+K58AAGEaKoKG2t4zAAAgAElEQVQnqeT8TKUMqjFszfzyvrCpqLBoe5K67HqCang9Ez4USRVk1qtJdWFKQREC2GbIqRwjH0tI6pYxCK6KFbHZJlmVBWCdRXqOi8FxIDN2iliVktfRvJ9TBG6KXMW+0PH9XJcQ5khzNNehWXx6vLVJqjrnyXmUjJV6QEpd15iIy0MmTj9ZrT6qaZQS1adjSEpT2yoqKk4YH3jk1Z50+QAqMfMbq4qaximqS1t9yhweWfXUdDAX3efDFeDM/lhan1ROmfmBtHKjzbYxodRKqnwvVVM1DPpk5QaWpWmVsiUb+KXzlPpJRSrqrogpY6i8Ur8vSVY3wCALQLCPk0EpWUI2ZcY+DneBQrIxls80SU7HyN8cX2FAqdUcqqup+7mBeXeKVM7JgbsxQY2/R0rnaABZxt0mbKC2N/Y3QPqp1uULBuBTr/k/K11muIv631MyWPOo5jFKVIno6wF8A4BbE9Gz1K4bw7oAVFRU7Bn0gkDOr9JWnGJPUk1jK1CRI7E2L6olqeQi+9GIimrN/SxpqFKIlaMSkpr7jgk1dcz3jywrJMPgloYkZ+BfmB/mRLCJAuTuQY6kFo0t/UR9ro0SM3QJ1rguJUFRkyZ93aZ0fuqaJV0VMkrkWhjpa8xNYpSkrjO/kWPXIcT67zKVsi2ptioXl0GRCCBUWaWPilOBKUX1bwG8DcCDALxdbf8MgKfsalIVFRXz8cFHX+UT+wtC078jqxKt70z4kryflo6wLjoXOJUgqTN9MgOSGi9muu06+R+9Aomhv6qQVPTkgcZI3DGY+ZOI/VV3OhYPF/EYqeuQi2YvITupbeue55SvZ2n7mKSWqHul/WdM/qNm+U0LUkz0VUQUx+5X6Vw2KP0bthv/PihwocdWGTRG8+/uKaqimsYoUWXmdwJ4JxG9kpmrglpRsaf44GMf35u6SS3EoqY2vckfgE/ob6tPtc70fwQ6XFmSesGZ/A/aPEnViHKdDoKlBPHaFZRMBbJm/1gJdYso+2husiY+Ia2NcMAOvjqVK1UaIEVSgnytagEU1wRjx52T6H+nGETHh6b/Xm1KE6exfJbASDR7DlPXZRsq6waR5/J3kepnjsI+qVxH55mPVp8grGPEemzMsT5zxx8H5o4Z+w2rcwryBrtAK+s7z+E1V9fbuwXELgEVe4sp0/9rmfnbAPwJJf6bMfO9djazioqKecioKfIyrpJUs1z15FUl8LeBVJ0vkYqms//0p0iqYIykzlgTBspihqTK5z5yXpHVlsrmnBnjVEEWYUn6P3YqitTmgopS6ZcGZDWHdUjILpXklB/qFkhqFjkXhVKFdXY6tgkz9hgJ3pcHrTFMKPNyz7T/efL3qq5T4Ke9Z+pqVxXVJKZM/0927w/c9UQqKio2QEfD4BHjzPuOqIK4900VcrpofQ5VSOUpZfIP0lDFkDVEL8CptFMjc7bHlP9zLlYxY19VcQeIzYRj2CaBUl4Ig+045vyJY2RqCjkytQnpOQYyNUZSj81PuYSslvThO5iwBoyMvROSuuuHjqnxJIAylSEgcl3ZZ7JaMcSU6f869/EJzPw0vY+I/i2Apw1bVVRUnCS06V+UVF+BylWcEtO/lEf1rwsrS1APWvByhKQKFNkMSConjhntJ3UiI4upJhrO94w7hKoqOqA1/bFN510ARsdJEbmONl/cM80DkrqhojJQU1UUuk8nNlIuM2leTqVc2gVG+t1aydGTIKjxXOaQuVTQV+HfxeC3NHXfxvot+V2Wnlf8t8SZ32M83/gYRUSDEsI6Q4DMqVG/39iHdc00e1sHVx/VHEpv0T9PbPv6bU6koqJiPXzwsY/PBmoIWU2qqY2K+Bc11amoNg3VyKB6zUj5dOa+bwBKqGGD/aKqKMI1UGGnFv2TWizi67grdWrNwJm5ZHEQyCe/xTXaz4bh/gXY+7xFkpp1r9hGZgJBLg1Uceczjj+Nri96zv7/XbRP/QaChzCKtu0BGJaobvt1FjDlo3o1gCcAuCMR/anadQWA/7zLiVVUVBQiVrwc4iAqUVOJGM3BEczBSuVLbW3w1KIDL5zJH0hHyuZM/qncqFvCqMlf+58Z7pVVUVQbF2DUwpsGd7Yw2wguO53S8y8h+nPdFBLBOjoDQ6pYQ3bRnkq3NNV+zeM2Um6TAWIz2qfGnrqfa5CCkuwLY2pqMiI+OGDCJSDR5+gxuX6OI2PF2Hatrsp8iPvr4X7v8jfAyuR/NqjcZiCiD8Fmc2oBrJj5vic7oxBTPqqvAvBbAP4NgB9W2z/DzJ/Y2awqKipmQysGgfnfMMjAq6nN4coqqq7SlA2gsiYzXji1gZC2t5Ryh02SmkepmgKSWkpynI+q9031/aInqzvEVkiqRmwuTfj3BiQl5b4Q5Z20bRKBVTtQV2chNf6U8p11ZdjS+FPYpnK1QaqobLGH1O9h7j08KXVuHSLtXV7c5qiMcpAJY59U1ZP1l70/M3/8RGeQwZSP6qcAfArAwwGAiG4B4AKAGxHRjZj5w7ufYkVFRQ4ffOzjEWsCsY9qn9iffalUuAT/YZS/mM653Clox4vXOimgPNE1sPqACrKwB/A0Wd02kZ26TkV+vDPnlPNXTCikwb5todQfs0Qtn7sPEyQ1F8A1lfrpOIOFMP5AkDu/UbK6j0i5ZEy4+Uz2FUX9B6WFY7JasfcoKqFKRN8E4OcBfAGAjwK4HYD3Avii3U2toqKiCFEkO5EjqWL2X3Rh8BQBZrkC6fKo3uSfMnm6d70rFekfHzPrHNw4EpU7FUgxAa+eNq5ta1yuRTtHr6wCURqtHRCRsT7HTPaC3LlHaalGEffRJBS2MUyRtBzBW4f4Tpi3gTQRKyKmpdvnYM511DlAS9X0NZCs7PT/s/fuUddtZ13Y75n7fb8TwEvQoETBlrbRGKGEjogNVqmCShlYCkqbACECQoTAUExRBtJqCjiEwaV4gcHhUhBQixVasZEUvNMyqFGRIhyEqiWSQAKKAZJwvnevp3/My3rms555Wbe99/t++3fGPt+7115rzrnmWmvO3/o9l7kGc+7hFnrz7K56iQr362EkrplLQBxnFg9Ye+CsPqUM4P8IaUi/mpmfPldDLHQRVQBfAOA/BfDdzPwBRPQ7EFTWK6644vT48U/55HEVKpXyJvscBh/57+IyqoNP7H/jFdZMTdV+qRKW3+leg6o0U04mK/H3HDOZcAEwf9tLKZtDRkr9aUVFzw7aCYe13AOWYCsVdoZf6Wp/0zntKajRa3BKQlJUWC8BPQFuS6+fzqMqVFYi4Q5wKeDd8qg+j4jeIL4/bRDR38rMbwpW8+8iomeY+e/v0Zgl6BW+HzPzzwBwROSY+e8AePGO7briiisq+HVf83UAyqZBOgw+LdXhKMz5YvnUR15Rxe1QVytLS6BuqbAk31qMI5KK0s5+02Ay2zPJAnAYfD8cxn5oKbXdE3wWYW64LKwlN/Ec9bk2kvx7dX36PW0ntj8WrCh0S/nu6NfJvmuDnyxY7euBbo9uY8xPPBele2DLTBk620GAvu5nSc1VwWqTfypI3VOyP8KCJ5CLnBwWXsv7hZ9m5peIz0QtZeY3hX/fAuDbAXzgqRtZQ6+i+rNE9EsA/H0A30JEbwFwXVL1iisuAVmEMLzvaVBT3YFx8+gON0899pH+Tz2Ge5fHQU0Ng/ntMOZMLampheT8xdypq84HOUG22pTcEcqzTBbQJP1VudHWjhWePAmulJF27FQtlygpHSS1BVNpBcrtnuNPWjv3Nf6lPdjA5WCCOa4WGiWTv4UlbW8FYK0hv3taTlpYq9YXgqzSb3JRgDODcZ48qkT0bgAcM/9c+Pt3A/gfTt6QCnqJ6kcCeCeAzwLwcQB+OS7sRK644knHGDwlTP9O5EoN0f0k1IVk9rcCqLRp/ZSD6Mwgh64o+6iuhuVVdXaBxTj1RLekzQ2Fd7V5uJY+qDPafDNla698o0tdJU4cgGXCCB67FJeAyXUXyvW8ghovUSWyesWvBvDt5C/EDYC/xMzfed4m5egiqsz8C+LrN+7UliuuuGIhPDH1aqoLZv/D7dF/Ht15JfXRHdytN4TQzQCEQCo+VNTBqKaWlFRgm4l4DgkQaqq5qpOl7AFIq1bJyN+5KatEsvDi7zHSWBLhLXwbjeO7iEZNbVPEJSuz95q0Jvs9zPoWtiaopWsm/RxlEecipD3pvCyS1oOtX05bWRX2hM4IcIE4h6LKzP8CwPufvOIZqOoWRPRzRPQ24/NzRPS2UzXyiiuumOLf+9qvTRH+AHI11Y2KaYz+jwFT9JzHIT1VIKhSTW0M4DQoknpqWCZ/7bfZY1rtUFIyX77OY8aD+3ftwkySejK/OxUM0+MDefE+gdLHs/I8LFEjTSKyNWmy7tOrcjjigvviujKVjVYe1V96qoZcccUV8/Djn/LJAMak1pNI/5grNZHVYfRNTYFGYtDOfNowUVNNgqpXo1qKngFV1T8x28ffHexIeY2ojGWqKvrV1Ua53dgix6rA7Ij4pefa4WeqyVzWthpBiwsc9LZtK7JXUp+1X+Olotfv81zqr1644ly49Ot4RYZeH9Urrjgb/uUf+FQAwPt8w0Wldjs7KFOz2OdKDZH+7maAuz3CPQrLpj46+ij/m6M/4Gawzf6FCaxKUlvbJBb5+E2PZ+mOoNuWCKvhCuDgzf+KlJpkVYJGcp8FUukoZe0iEcutpZ6qYa2SumTBBEkwSxN6R67T2vasXVYdNUVzTpL+EixCNyfZv2PQQGMS+Y77uqpunYI8Gu3cxE91r7b3Lh8MlP2ew7GmL/rFKau0V3qqe4/rugxX3BtEwnrFCK2ipuVSYyCVC6lYkg8rAzfHPH2SQ3ky6Fnbu3e8X0tSYzGybk1irTr2GvzXpNIptbUD3aRwoXLVJC5rJ3jZb6T+7klt1Wma3xzG9e5Rrx+SCfYsqJHgyv0ix7glK9xdcTm4KqpXXD46Bpm3fvbLMoXxeV/8P+/ZoovAez/99fiJT38lgNE/1R28YupujtmHbo7A7XE8WLoAaEizPxqBU3uO/yUlNX43fs/+HiKZwZQUpoAqpFWaCBArVoVjpalSqqklkipT3pRSdnUHjZX3W7QK01psEa1v9ZsR2NVcjUseNxdz1VS9X1wfvsNFZBZBPQWZ0imZBsqu3yJ1da/lhuV10i4DLbcToy83y/KxE5gvIwvDJeJKVK+4aPi17HMztwWiAnEI+Dd/4vcBAPjojQi/8s/81Y1aeF6M542U4P5wezcms465UqNP6s0AuvUMjx26zP6b/L5GUdLHtr7PQeZ/KEz1sVyLpEbU7sm1eWW3SEEFlKO/52ALE6lFMnR7Gym00rFrrvfccym4dBRzzF4aESq9BBSyAExcAbb25ZxDxrWf+aX4t15xclyJ6hUXDRcGphJR/ek//l/7P2RAkRrM/u3nfbQfgAeXfvs3n/v78Sv+9P+yT6NPCXHenkxhTPifVmdBTg5q5tVTR/Rb/qCFdsxWQ+JEJ4OsJDL1E8pfNZ8kc1cJ1X9WYnXH9pKtp0j3cym+d2tTEVn9CvSTpzX9UFLK57ZhJ8zOnFAj0ZdIsFegZua/eFX1gtt2TlyJ6hWr8c9f/urs+6//y3/B3O9fvPJVAOBXTApmaid8KyM45MdkJriDf3Djfm/+zFfg+X/um/Azn/Mxviw5dzhOke3/7rUfmba7G18W0RDMKw9nMEipqZxI8k8wo/2TusoEuMrSqdHsz1RPRTWHB1gT+6D+NeswTP6tY/Tx8TytY0pk9VAwD7eSkcdymPxLxFKuZClh+reIWWmzDIVwa6JS6hvddz3tlsof0B99P6dPevtTu3WEl0AayK8bb7SHiBePN1Tor2LmhNLLk96mXsJKrgBZQF3cz8JWwWyWYtqTvUMW29GWSyarD2lu2hJXonrF5vjnL3+1SVaHwXkiNfE3EgMMMYgJAxyIGUwUlEFPVg+P7vDWz34ZDrfTycUHFXFSFOOEwoiKIwFHFyaP0R1guDv4MsIgcZ/8W5//574JP/mHPx4AhIJaMak6hKVTxXdgG6KykzKz+6RikVVgGnXcIlp7TDJGtHmGjdXTiY9caRGFObAIVG95FqFq3Q97KsqSIHde7zVkNasXnSS1hRrpF/1rugEAp1WSW+Rb7np1C3iw2DXqn4ieQ0T/NxH9UyL6Z0T02rD9VxDRdxHRj4Z/333PdlyxH37047yaqiNbtcoa99OI+T4RotRdiFR3ITLdhcT0/rsnoIfbu9F8nY4TJDUoic6xT9N0cxTK4uBTy5BQIy/FVLoG+hy0iV8S2KXn22uu7Q5MafzeOyFucf3ImPSd0We1PtzrPortqJFUuc+ca7ASTRP0GpJawpbXYAt1ulZe3HVmuyZqKmaY++cEhqXCbULYWrzBRM21SNW1aPEHo+yHQFIZwMC0+echYG9F9RcB/E5m/nkiugXwPUT0NwF8NIC/xcx/hog+B8DnAPjjO7flih1hDcSarMZRKRJab6oPRPNmGBVBAIgrawRzrQtm65TEPimCoy9mJKeRqEalICpyPDjwcfDlHh0wOPCd90nEEKy0D+DB1teCNAk7UjnivwUVfFQ0bVvK1xy/Pm3yF9t8+chN+VuoPdGf1xdUjzQu+dXGMgbAmwqMOmQ755i/rf1bfqBbLW9bAHNB5asQ1KWkYhLkpk3YGnPrKfkkp/rFNYsR/5b5vxAUFp9D+UJfJbDC1SRbIa3Q5kUKq7yPh8J2hNs4jqMNf5bkOrA2JUiHmtp1Lxnj1CWb/6+YYleiyswM4OfD19vwYQAfCeA/D9u/EcDfxZWoLsYbP/WT8N5Pf/3Z6icnJpElx0dV9DBkEzkPBHYk9gmElJATVIp5ROH/vTlmpn9yghyTJ6nDMB6rzXI//cf+m1nm/5/49FemMuLg995f/T8t75CV4JBqqYjboTyJX6owMVdd7SWCFuHVfpG6nJISrMuqEcW1yp1uX9yv1k97v4TV/CItkqqbc857r0FS4/YmubGugTK1N9VVVX8c70rtXYWC2d90awltoEhY5aU0umXi67oUheewSVJJ/X3pZJWv6alK2D3hPxEdiOj7AbwFwHcx8/cB+NXM/GYACP/+qr3b8RDwxld9It74qk+cbGemsJzmGZAmoPEDIJjhx+8AkkqaDo0qaDDPu8OAw+0Rh0d3ODz1GIen7nDzyH8Ot2HVpRsRIBRcBNyjsBLTozu42zu/T/w88qsy+VWa7jyJvfH7xyCj6F6QmsmEt372y7pO/02f8QljhD3GwbN0rXaBmlSGu/yxnvjHPS489gOm5GEpupe+NLZZamrvsREt86M83soGoD9xvzkjprwn4otTicy1Pta+1rmWzrtFUiMJKSnAcyDPNb5EOpHeizAq+vITf7M+gCgjXo8Faqp1bcV1apEf6UsvzzG6E1XrsK6/da2TS9P4Um7ej7oMWbc4n9YnK/fgFwiZtCluF+eRpcCr3LerzPuV86ofX9imjTw9ZZ0Q0YVuy89DwO5ElZmPzPxiAO8F4AOJ6H17jyWiTyWiNxDRG9761rfu18j7ggu86V7wzV+JF3xLHjiVAqmSSd6TVtO3KOyTTPbSx/TgSWWKXg+/T1RUN2TR7ePEMX4QB+ZISt24z+q32ODvSsYE8a8/7Q+sLHw+3M2QovbNe+a2In+v6YuBxk8JLeLTMvlrnGptvbkE1XE9StoinNX6Z+y7ApsqOiRIgCQJpfOo9UmJQNdUXL2/donRhE3Xp4iyPK6E6NOpP5M2W+cpyZjsK20CL90/C1VW+/wL5Nix2ZfF/ddAqfGxrVc8eThZ1D8z/ywR/V0AHwbgp4jo+cz8ZiJ6Przaah3zNICnAeAlL3nJE32HvvFTP8n/oSa/sympCpqsAuiOdk1EMpjsk8komqWMtb1TGqak1gxK3RCDJfvMAewAYgILAstCiZoTnfuTf+TjQrnRb4tAguWNrgaMn/j0V+LXfuU3dpW7FFVzYiStLTgAx8Y+paVTz2lCS1H6K8soHb+GDDu286luhdJ1b7kBlIqjlWQ1knRNUoE6qWqYy1M5jKnJ1vGsl6Mi2al1l2E6nqDSjonfZsHveOLv26MeW/UtIHS1Y7K8wtI/V0Ier1bvWn1fNdo3ryBcqIvTwwl+2hp7R/2/BxE9N/z9LgA+FMAzAP46gFeG3V4J4H/bsx2Xjjd+6ieNRHQF5pLWH3vFp+HHXvFp+NGP//TVdWu84Ju/EkCuNGpk69Q7zxK82f4YzPhHb/KPpn31iWZ8r7pKxVTlCI3KblJ4o0Lrt6VALgEegLe8Jjf//9RnfSze8kdfjrf80ZfDOa/45kuVDmOWgpDBICIudboXMmI+xEC0YPqJZD9OoiXTP1CerGtK6VyS2lBbspypcwbuXtN8aT+9fa6pPx4TYalOLZTMxhWTdTrUUsYMVWoXSFIVSao08UezsTaDK3O3qeBlpu3xXItKY4RlBo+p2fSnYb5OdWd+j0pl1O2I5nJhTk8qq1RzpfKq+yQ794pa2bq+NbeKjk8aX2O7pHuAdAuQ11c3gfK/Jy4B8jzFPZHd1wW3kMm5tlA69oqLxN6K6vMBfCMRHeCH8G9l5r9BRN8L4FuJ6JMB/DiAj9m5HQ8KktT6N9XxifvxT/lk/Lqv+brisf/ykz4FfHThmJHI/OjHvRogTgRzC/xH3/RV+LFXfJr5W8yNOpq6BJGMikxYg92/necKxLhPyABgDI5xcNPqi1RV4Rh8pDR5ZJHFAj/1WR87ktlMAQntj/5AIVcrg7z6szdBAPCe/+O34C1/9OXTHyw1Gqib/i1YZexxWlupCTV1tPf4pZD1WuezUOlswVSbdF3xu7A0bA5JKCySXDP7A/UVqKJiKRWxjv6cKLu1dpTa1vMyZj3r8ryiwhi/W/uVyim99PRcw40vc2vlNs7UVIwKLAxyClTPvRp8J7cvHY8uiKwyrsFUJewd9f8DAD7A2P4zAD5kz7rvA0YFlNJ3i2T6oJwoJag7OZi1s/0DkW1lAmCtWO1kdmAxOWqFlRwSYXQ3YZYX+3DYZxqyOSWpUlWUA1w2sAqTfHIBcAMYDgiZANJkzpQIoPQzS22O5xZbOjAwOK8uRLIqmv6mV38Cfs1f+ItrurKM0C7fJk+c/ZfoVB+6ZotrLC/FUpN/i2CsbWeJrJ7Kp1X1S2auXkAUzZcu9ZtZF5ATLW1pWNnPVmoqsohHLzHUpHBlG4sK81yodlljSrWeRFjjd6uxBUJfe9nd60VYm/GBjBDG87dekLqj6S2/2Ljdch2pQQzD9xkPJfhpa1xXpjoTpJle+jNGsjqJGBcP7sRMXYiSfuOrPjEd815f9Q0AgPf5+q9JS5mm48WEXlpVqoXYXp2WKSOlwtQfzeVpeU/isGSqWFUKyPw+83KRE1RADW7iOB7Xbydi8GEA2Pl2sFdTh7uxb4e7A9gReHCqzrCggBpgo4mdiMBuAB+9YsuD878FdfWUiLlimeF9JLcmqFsgTvJrFdASekjpluqipcYP9rOZ1R2PMUiHRUJ7MCFSlmIp25Bl4+hTdiYBP5nJX6RA6yVTOi2YRa6Tf2SDLFpER7sLzGlTC8a5mrlYKT6L/eTTGm92QY/aLQhhjUgm65RUVSc7GS8xpetWwuR+Lu96xf3FqfSFKzpBxBlJzX2Z7I8LKza5w5DvLx7wN77qE/Hjn/LJ+Fef/AdVhbkySG5cRUoT2h5ogm23V7WZvJ+WuzkK8onqR6uoKZpfnFN2jsJdwLcLowLrOMsaEFNlucMxpcEaP7EskYHgMOaAlbldZ6sCK/CrvvSvTFReZowD+TAufGCaHVsmtnMqFXuQWGCqLurPKbFFfYTs2pnPg+V7KX9rVSGfwXhMfIYiSe1VAyeFd6qfrXaScS8vVVJ72q/umUkqLvGZpIMq3HfFbATof1lJ2ONWlucFGD7H4lxL5+ymvzUD8Kx7ZOm1vTTwdWWqEq6K6gUgW8pTDlRyO4CUBkk/vEJRTaYDKdYwgQ4cXmwd+DCkpM3D4LzJeMjL/H8/4Q+ByJPV/+Abv7rvPEK7fuLTXyna/hy/ShTgU1CRXwI1BUrFBP1hnxT1XzEZThTUtO90v8yUMkTz+OBdCojggkmPBwd3M4TFAIIaObhixoEIDn6gzAxHDD46ODgMx1C/bAf5vKsA8Gv+/A4uACTalgKqXPJJJiZP+u6cDx6xkBQQ7otW7/Xfk/tHaDXMUsYG9a9sp4RWJ2voJU96v1K52i+1N8tCB0rm1Qy6KoOsmgtyHER/DxiV1xClPUHJpE+KpKZ8m5U2l14+9D1Qul9iO7WqKsbPrIzKeJLKngnT/K0JlnFfLsormsoY6wbK6mrXfTMXlipv3ROT64P8XtPXqERKS7Ce9bnj0BX3CldF9UzQvqi536YiqTRu04oeyb+DskeUv9HLY6Oi6ZcbDZHpFPwuQ65TWXckkC1Ek/8YFOXrfp9veDooqEFFdSIqPuZI1W/ZEcLVIcuJCuQkNURnW/tlx7jxOJlb1f87ZIsBeFXVzuOaqalCAY7XTvqxyn6XiIR1Vwwi8n8QBOqmcE2XTmw9x+2pfFgKeu++W2JCsrdx+Vhl6hX3panSaVUZsP0rtSomtmUktbd/l8w8JYuJbn/6DnM82RKTaHTdVzC2afWx9plUWKi/hS1P3WqfdR/Fr/K6kbgHS31WsgBsMYZcuALLw/afh4ArUT0jIlnV5CsjW0JFjUTJaYLqxPYsYf5IXEHwvyeCmpNVSXxj+QgE8//7g3+weA5vevVIuN7rq75h4pMqkdokV4aKPqrx/JRZP4u01yaiQFJr+42m/imZyRYCCCteZamm4ipY0Zc2Kr+R3B40WeX0XbsAnBrJx1AqfCLAanOUJpLaxJCRiJn1tQZgq8/XXoee42NfC5K6hU8hS9eNGkwSMd0tT/kj9tfkSu+jSMWEpMqXx8Kz2ETtmA6SMSFvez9/lopqXQeLkLXaZj0/JStEMBIAACAASURBVBePc6H0rMV7A/mLUpGg9pJSfV8uwZbkdyMwcF2ZqoCr6f9MeOOrPjFE7GMkU65AUN2oOsqIc03CWBCRMcBq/M5McDxgODrvDxPMwsPgJsETUSGUuUAlEkEl4M2f+Yqx/Y7S3yDGT33Wx+I5v9Tv+uzbnwpLlh5x89Rjv9zpoyPc7d1IUg/yXAuDUVymVasWFkQaFQLAjgCEPmYaYwOG8Hfsu6MDHwkuBERJcpf6eSAwHdP+gPMJ8x2D2fcFDyORxZBHdb7pMz5hUxeA533Rt+LffO7vz9qZ8qkeA3k6OvCzh7pSHhP/E8NkOS20Bn5/CcZ9o9l5CeSLUah3El1fOlTv31tf5k4S/t3Y5F9C1aRrvSQ0kMzQzHmgT+wT8Qxm6qFFbJXlwq5Q9F/vQg2yrGRWDseX+kMrvLq9a65TvH9LBFW3WeOg7iEtd+r7UQbDyd/Fc9QVaS+r6T39boXc2K8URBXLXUI2tVuI4Q4yq41X3AtcieoZ4JfVpMkk201ShYKYpWHCOPESMEais//NmwIcXHywj/ArMx05I7cAMrJIxNPUSjTup1NB+T+UsujyjAD/7rUfOaqqYllTGbAEYDLQZcqoGOysfKVsDF7JX1T65TIJ0hLG/8MAig6baQJHyhwAJrBD5sfpz1XkaCUGHAUSYJO+SPKf/+e+afLbIkh1WZn8mQEaCHTTWn5qJ5D6W18yuTKWJoStoo17sDZxm+nLtsJGJv8S+vxWG4RMT+4U+yH87sR+iC+eaBNU+RsKfauv7ZysDz33hf7ZIkQz769mHaYqbRw3IN/HakMsR75wzWzrJirrGpIatxdXe1tAUuP+D0QlnOLhBD9tjStRPTHi2u/ZRGkQVFAwwR/YJqeJCIZCjDfuqJLKfKkcAoeYCS4Q15jKaNw3Nky0z7FfNjRWdzOSw0lwkTivSFLd4Yh/+3kfjcOjO8Axbp4z+oOCWJjVgbhKVesNmORkqRFTUWWTMSPLO3uI7eVJmcQ+1RTdhL4RRC9lSGACU1Cl4QOx4DjMu+EcBudjPIhTflXZTxza8+bPfMV2ZBWjUsaMdH2Hdz7yiyjcHkGHx75PdFCVIC4A/LKzA2xiOatBld+kqhrul0RuVuRDPZlJVKqpipRtQoBVEEoG6/nXhEwj7RvJwmiJGQN9eLp/MufytP8NZdv6Xswl2+P6oe+D2A6rjyWBVu3Ltq0NxtEuD0D9XORvg9EuSzEE8v6SRFapqpthYsXqfDHSmKjHxv41Ql+qS1+3lqp6VVPvNa5E9cyYkNSD9D+FCJgaB0KLoGaK4iGfBGgAmD1pi1HvBHiSJfN+xsjwSSOVv6j+LSaaH/J2pICiEDjlbo+Ifq/RjxbBLxQHqUIKc7mGFXFaG+z1MeqNfOI2EYmRUEDp4EkoIRA75kTs0yQVlVbiMdF/6h8a3xoMhYkleV6JX/GFfw0/+999dN538T64OQI3Rx9M1fPm7tgrxvFfoBzxC5TJbKuqmsm8NWFBTNA0PeddUWrb1nNir4qUTf6dxEK/yJXyXWqCatyvPUSp6J7RdT+iT3l1M/pBH9cyHdfuf6CPcMt9W+dTa5N8qVx7z9X6aY76qYl4PI7VGGztr8vR6r7sq1jmkoUFLhU8ThNX5LgS1RNjEmBUIKnuwCNBFKmb/L/ICWpB2Rx9WT0RiIQ1slxyjOHognsAJX/WePykvYqE6t/pMD1uDO6KwVucouvpRpDUsB+AqRoiod/QlxA8Y3LMCGu0+AtTKB2GFD1PwW1DKtWkCKr0SwWxFwvhXS0olC/V572c3pOPqlU+k3d/6EqMj77JcItJU8KazEV7q7lzO/t0kepZWGp3N1QUy1m+qVY/AWV/0UxNHfdfq95NXAJaL5saLVLZUlPnlGvdS5bKvAVa9+1a0/fcQ3tJqjWGyGfXVPZbdVfKqx4nruF9IalXVHElqieEzC9aM/MncheVU0s1leTU+F2OR8zk86ZGIinIqDsMyTwMHiOLS8SJShOmQcCJMGYquBmj5t3NALq9A90GH9XbozifUEBNTU2kUuyfzjU/7+7JDDDcAsT5xrLIm9HpAHg2yymQiplBcSQ9upGUYvD5axlwGETu2pzYb2X+f+7nfxt+9k9+VE7IQyAVjg54xy1w+MVyAS6oya2AqoHs67SErNYm4ILKVySpssyIrQilLEcE1XWrOw20/GuLuSe1BaJGLEyCUOhLi5xuQcp46mc7Ia6916zmI9mCpehqH9Hu+lS5W91zNZ/VOapqqTkTy0jle41cmmR0pxe5nheZewYGrj6qBVzTU50Ib3r1J0xJakhvlEiqyC3qzeNjSqqYtxORyBJPSGp5JSdOaZUiEU7lBLXTOVW/Sm+V/hZm+zw1FqeUTofb40hMb8a/nfg7HR9IalrtxnF94sl8e1dcEKseoU7HPo05WhMx0oTAUGWz7+maj/9uZeav4bmv/facPMlguUd3nabkhZXr01t6uj0E1CJWeyERU7FtEqEt/lxBXKsrElkkNe3UUPc0mdKfeL+L+z7VLcuW+yyB0c6T+BTPMs1bxKvjZeAEz/cudehrMlHqO4/Tv10SrHv+gtroRaNtPw8BV0V1Z8g8o3GCkcttehIZzf0xlynyHJ1Akbxl7gCF/ShNmAwcgi9qTEET385JZAoY/L5RaSURcGPVlwV7aeIsSa3MS3rjSSqViOlcU+AcaB+2iqkvBWSlNoUgrTipc1BNg7zLLowOwq+ThAuAzgKQlb8x+OhAbghpqjAGLEnf5ey8YZLKFFB1QhQj8WumZyf+tQJv1vSzPtZSVjdGMe1S9l2MDyXlS/v6yeOg+rpEHmuqWk+aqZLZds51qb0g6DLnwlJWgbaLQavMrcetrVdfWvNy0NvPW/fDUlwQIb1iHq5EdQF+8o98HMCE9/yKb85WGIo5MbNVh+L4b5n5ozJ6GBPwg0ZfVX9cKKfhyG8ltBc/yqbkxMjKEBC2azeBrB5BTLO2u5G0UvSzjWT1RpzfzTDPt8sydyl0vT3WVJKCzxwByW2CQnS/96d1IPLBaONhTrypRyLKSDO1ygKQgrJ2ADPCEqrDmLngSN70fzOIF5gKdEBVbbKs9b/n5e19Y9qwQqR7F3FK5VTa04vsWVHbhulzNKs8YN7kWVJS5XNkBTu56X2t+5FKS+qmMnRbDGI3x+fQCoyRmAREGttnB5ipf0vE2Spft1H3/ZLH2Kr/lISupA5b2ytBdEBdDU9L3GYbF5yn7q+5+Y/vAR5Kgv6tcSWqSxB8Od/8ma/IHjiZBF+iRFJdMv2PJv5I/KrR/CUUTWm5OpX5XSaFNfw2xJ84mY51VLpciSkR7uA6AMdjTtRASrNgKfH7xIwOLFIMlpg3JtH+QNk3TU1SKchKkjceXywyVVUoVeQgFgJAptrGcrfGcOfgbjH6HzOBHh07fbwo91Pt8YPbEF39cQpTvwXhUlHC3PysxfOVRVgkNf0Ge0LuIfs1VFJRFZXInjJ7XyQudRnIHktQCZd0TjuS1GqdS5R0wD7uSvAeNK5EdSGyfKMSQkEFkBFUEMNJX9RoGk/BU0jKZDoWKA9+jeh3nSqqei6qvEhqpMKaIM39Qi3NiGlQDBOpdWJitQiqKHtSn4b4rUZSidgn5Te2679NwirrIh5XthrC4gvu6An9MUZGBeIZVVU3LhZAAzAM3u1jYIK7GTDcAXu7iRN5F4CYPxcDgd9x61NVMYIHPwkChPy+jreGzKe61ATZms/k5GVNZC0VVUOTocLk2EUoe6P8Vf8tXkzAOqREUqOi1/vCowlIV3s6y9yCMFi+wNn2TktA9t3aR/xdc0tIAUsGoav1S6kvimnNZvTd2n6uvfDI7cb3ucS0GCBYI6utPpJlPSCSOszr2icG12CqBXjPr/jmIklNfqdCJdUkNZHSuIa8Iqnx2GhCptJHBDNZv6eAoahwHqYfFIKj4jYn2yjXvT+MgVcUV5iSqaZiAn+x6hTiOfUEJGjMVmxmDqad7SBFCuL5ZEvhRjIXfpcKdNyWcs7KcjY2T8XrCyBz4aAYTNVLoORLBqtteyK5UGzfN5Oq1p5Pdk8jI5qT7BjGOZE+XpddIkY1tbT0Aab+qqX+ndv3pzKxlsaDres3lWtN8gp1b92W1vO6FV+rvBCueU5OtgDHPcUegVQPJZjqSlRn4if/8MdPN4aJyV45iickNZn6BckxfTwLhLP1SUSUMH6ikhmUTggSmT43gyCxOSlNuU8lqT3wSFJjrtS0wlQoM5I2a8CXJG0hdIaDrDxJDtP+5brM3wySoMlqyqIQ+9dy2whtTddW5qHdcXLP2hD9kQdBUs2ApVqB4u+9Jp7Wyj47jVqLTZgRE1Wqr+wmSW3VpU3+tftJ9p++90qkdi4WlpEpbmvUVNkOoF99b+5TeWFYi3OqgsV7LN/W9Xzs+WJ5Nfk/sbia/mfgJ//wx4++qTFAqUBO9dKnGUGVxC7uI44fiU6o2CJ5HSgn6y+XEycLApLp3xoKsnYfhH9qIMJaVWy2n1gFZvD8PIax3UDIUQrAYcxwUCtjGK+n6dCuzH/RDYDckEXTE3sXAOc48/ONmRUcHAZm0MDAAcCxTp7X4Lmv/Xb83Bd+xPgiFM/52RtgqZ9q7Ietmly8xh3HWv02idqO9YhjGn6lgAoAYRLlGORHkiq1Kpz/nbKy7YplmyukU/+mFz9okbM195rV/h7iaPW57LNagJTRj7NyaFqZDuaSG/MFtvG7/G1O0Fdt3x6XG/lz61LXFOAWSe25j4xzMhd66Okf6z54gLjmUbVxJaozYAUkWeqpXDo0BhlN/FEjuQOyKP9kRgYmBK9JaAq/m4n5CxNZVkcgqZaP3ZhTFBiVYZ5NpvNCOwct6zgNB9BAYHDuZwbYbRS/d6WMIk7pvFIbwj3AsR+OlPxkaZju68nrwnPuhJnq7NHd8gL1vXCuFWBKz0JPf1r76Pu+RljlGu3x3pKYHBNfclD1a59FUFXbqUTO1H7FMmXbLex8fbv9eDVhKfVLjYSV7pGuJU0LZW4FXWbNxaGRBWUzVwCr7kvAldQ9MbgS1YXIFFAgkNJRacxypWa+qXmkvKmiKhOf9G1MdTcbWFYBqoT3MP4Zc2+aqWss07VUdLaGnlxUH03gs0eNZBVoq3QtshrrMQKsiNlH+weXh3zZrBDUJTIBjG4CBI4q3Q4D74SkanBgTz2ihs6nei5lY8k9ZgVWtcovEdaY7kkSVl0XkBNWh5Gsmu0rkKyakmVF4/cSqdIYYpGerUlqSU3Vv9dUtB5C3VpFqUVW567C1FvXnIwHWpUskVI9NtVgXc/KfVVbgXATWNdC9tEToqYCD8endGtciWoFMV/qCMoVVDfAHQRRFcuepnRTQKagZmmcKqb9LF9pyXlf75s2LJigDNBA9cG65otpobTkZneDVD9ViDvTaG6nmGYLxoA4UZnGtpoZAWT9gCfyiFV5wsdRXT0M4/K14KSkOscY4lvAEJdjBZ73xX9lVnf0YPQ1zvPzxraXD8So/vXMDSVldeTqfWipnb1lRJTyfPaQkdho+bLGY8dw6UZP/aaOifdkq80tYmCZZSVJLfVX77PXsj6U9p2L7vREyuRfWQhi8rf1XW4vkdXS/kthkdVeWAq+Vu1TuaqNrZeOhjvWpsvmoqKc72VZuhT1txNXomrjSlRrUA+ORVIt834kKXp1pnE7wsSiCd50sNV+Z01S2phYev0h2TJp1sqbq6YuHUAskmrNWy7mOkXKdZqpq7V2KVeBpitAUEal+R+hfq+4BmU3Kq0BLE3/Ow2o7/rffife+Wc/NEt75iufng+HPlqFtS8jwLZ90UNaW3XKhPkifwwd7MmVEwmm/Jgu03KFGBhqKfU8d6XrUXJFqB2zA1gTUYna/dhDolp900uQjHLkC3KX64JFLHsg/ayN8alabvHal15m5jVtU2xNVu8ZSb2ijCtRbSAFF7mohnl11B2OYy7UGA0viGkkpUBUV3k048s31Ro0Qa0prxGtchtkJe3WY5ra2yRUqScR1NJEzeRfCOJypUc3ugIYu2fiGPnlYyGISFoIgZXSKk35jn02BSZ4GS4oaEeHmFoVFFwEBu8ewgMlrvBvP++jAQDv/gXftrCjbKQXpTgJPXsD3D5r7lskq8Hnlm8YdKd+1y4Zkqy2bos1itxc9CiNVlPkDTNRUaeTKynikNT9qKq3XnpSu+q/T4Knai4DWRnG32se3znXsNfkXQuqqrlJFKxOVdSIXoOgym3dfraLX9KNFx9gSlg1ShaKmqWupKbqft164YKSRaV0bTqv2X0A4xpMVcI1PVUF7/kV35x9H0nmGBDlbu/gbo5wNwPczZjGKeYY9dtkSqdRXTU/QP63JKmC7KbgLSBtTwN17ZOdUEWNkWWWPgayJV+tMudA11MjqbptWrEW+2quYVlwS1Zda7GAbMAno26jXl2Oiy81O4xTT736b+fX+faYMhFYLyRcUWEorsjVwhzyuad613sfE5AFNVm/kVEeMH2+Ygoo+VKa7gug+tyldpd/iunkivv2ktRzYusJ2Tpn1cddCyEYVq1eyPKztH/i01NG8ZiSNa0yHqf9SnPAHLQWTWhg9sIXvZk/tjq/Ky4WV0VV4S2veZlfHz0NpC4z+buDJxXuZgiqak4+ZW5URPIhAqeqD5/0RSrk2ZyQI4kCESshCUWWoiC3FRTLyb5r0aE0ZSQ1wlJVU3Q2jW4AIr0SkYp3iuXIKnUglpX9gHg04TvyqZwcg8I2BnzOVGYwogtC+NuCY7ztC34vAOCXfd53lPtjIZLPLPuJo3mrOAZASTlprlAl75c5bgBOHLMVuqwWjf3lNh0Mxdbv4rkRGQLIiYAsR1O/Q6D9HJWISs+xwOWQ1K1QGwv1rm4cP5qEacV41iKjS3L1TtpsuQIA03uxhprbxNz7ak5wWA9qquopLTBnwJVm27gSVQ2V00+a/N3NAHd7h8Pt0Supt145RXz7DcQ0U1GAqem+UCcLX7gs0t8p9bRQTo10mfvrpUgtoqvqmpDbUv1bIjNDIVdMNflPg5zop+AGwBiSC0AkqwkFM1fsI0bhJWMQKaiY08uJp3fOE9SjGwOr2Adb+Tyz0Yk2VE3hum/h52lh8O3lxwef6zbmeC1B+zA6BsBgCgQ3trMWxT33XLYirC1zvt4HMJfblSA9jdQCVWKfHJDuRwr3Jg9iu5U5YI6da46aWoO+1qdGb0qxSV8ZpKqxmlJxSc9zozI/jG0et5mp0iK6XtLysa6K3t+3dgWwSPCasdEKEry0++CKCa6m/xaiSkohgMqFf29G8z9Fk/9BmfaDCXDiX1oyaWuTvkbF3F4lqSXTiDRVkVFOT10trFVba8dLkirPrXSOst+1IiuP0+4DUSHvUbwcwopc4Z6J5BPx+iLPNyvK9EveEXjY/rF89Kq/FyoJk16W8mW6fzL/J3M3MsLHLmzX6rbVR0smgq2Iun4urOevE+wUmZ08x6U2CAKVvXQVXn7m4h6rqbPIYomkWiKAtMCUilt4jy0iuJaJutdkLS1qk7GqUkerPRGlIL0l2JNRbGG5s579PUSBJWDvfrz1pwUi+jAi+hEi+jEi+pz9T3Q+rkRV4Vd92V8evwji6OKyooeRpCafVGnaPwSycsgXAQBgPyA1E4wFoXp2kcaSaafVJutTq2ammjvHR62opqYdDL+uSAJI7W+9NEi0XAo0EpEV/8o65b8Z8bUn1og9zP5JuY9VLVU/wvlMyGrtPpHLtu6NlgnfwERNrUz4JmFt1Vciq3Gb9fdclM6xt9vnXJ54PU95XSVK4+YlzWi9pLG3rNK2WjotXf9ErGjUUSu/hFO9fD0wMGiXTw1EdADwFwD8FwBeBODlRPSiE5zuLFzSY30x+NVf/pc8OXVDUk/dzXE0+T/yZv8YOEW3IWAqrnvvVLBUi+hZg644liTZQYOcltQtqw2Wylt74xdlbGLmt/yQ1Kdq8hcvD+Zxkaw69ib5Q9heCmbT54+8zqSqWhNAvE5RZZfBc25sZ6bK3x7hNBkeCL/8T/2vG3TuFI/+0N9t75SpptbkGP6NZPXA4Bt/LXAIpPXA+T2lzWy95GaJ0iHvF1LbFCLhNEmq/m4QjparwKQP0n2G/B4FkvVlU8g+2ApLiGktgn8JOknqJBBJX7+FBLu+FO5Mcuo6PrLsUH+mrKZxrnHsXFK/MVlcrNJmhTTmqK1eDJ4cfCCAH2Pmf8HMzwL4KwA+8sxtmuDqo1rAuMJUJD6ReISE/SLlT1U1nV3xRg9Z8e2Y84mGuO37VRjQTbLaMgNr9OQQtczLE9888bcMYDlSfo4xuCrKitKH0iIok9RDebaidIwOLourVYUo+RhcBTeuYIU7F34by94dPdek5q9obSf2q3PJjAApN2bYR993cZ/W82IdV9u3Y1uVYDbvxek90Q3j2fNBVtg+Cn5pcbVrvzrH7px28LzgmZoyeCriMoecblGdE0FW1jgk65r4eerCxrZvQii3DLDaOljrgtFjqt8YvxbAG8X3fw3gt5y8FQ1ciaqBt7zmZQDBL4nqRjN/DKaKyikODdN+A1ki+cKxvQn6J2VIAlgyb+tBrtR+PVnMIQ8rMBkwo+oZ/jZX5JFBBukY8iOAg/8hBDcBSKsLmatbpSjtUJ4IwprkYg370RAi4zGA4cacq4APrsIAcgR344OqhruDL/hE5lMZ8Jf6rTBxxuwAGMhnMzi6sF2RvfAMyGBAOB5TX8Vy1pDVXjRcUJoqaFcdBbLa00zH4V4Kxx8bZco6a9+z3zraUcOWgVVpNSnjpzW+y5k1o7L/JZHUHe69SWCYbEfvSli1tpcI7anzfc4lq2teKB8enkdEbxDfn2bmp8PfViddnCR9JaoKb/3slyWVgwIZiitRpSUopeklQnzX5FKvamTm4jT2s8ruxtwBuuQWsPRhrym0PYdbJv9UFqZ/k5jA1EDOx0hePV2UhCk3D4pyWSkW8jx6yCpiNgCvrKaFB1wgi+z9h9Lfp3LCOQygR0e/qpIk/jUM8OT+biSuMk1YRlAFUiqr2N8lsroVGsVu1sdqEYhV55NUVcrv3cLzt4naFaFfWO8jWm4bl4KaHymwmlSZY9WWZK31otRZz6yFETRqz+8DUVx3unt/mplfUvjtXwN4b/H9vQC8aZ9mLMeVqCpElZMEASJBlkioqFbKKUsB7VVFZ6mnW6AYfHHewb7pA6b/LrVXmvylcj0gW3UqQ1ImMI4aUlWVJNgiqxGO/dKtsi3CBSClqEL4G8hWvdoVxstWMcn/QMCRPEm9c9NzOvhnwhPW6eGJrAJjn25NVlsuKJeC7Pxh33+nMlufq3+WEKcd2rqpf2rrGlkEq3SdVxDLVSRwUtjMPp/R/u70YHOI9gNwD2CcxfT/DwG8gIjeB8BPAHgZgI89eSsauAZTCfzM53xMviGQUTqEABi5NOrantOBFrVPaAuAff0Y93JE32qi0Wb/6r7jn5mLwIFDYJXxofCbUHPNejL1fPzEtsno/+QiooKt3M0R7tFd+lsG4f271+7ny37ziu/1xDKcb27CNw4YAHrswO+4Af/CLfgXHmF421Pgn38E/vmnwG+/Bb/9FnjnAfSLDvTYk1oakD4AxnuZ1PfVPt3Gtq1VR6OdEzV1SZVL/QKTq86COq0+7637Ush/6fy39rPcC1W3jQts99o2FY7vWrXrEvvjAYGZ7wB8BoDXA/hhAN/KzP/svK2a4qqoaoS3uDGnadgeiYYVLDRnUNzLjH8pQVxbwvI3XPiCkFanij6swPT1VQYeBH/UaUHlt/yJwiqVw0hcgeQCgAGenA4HcPDpLLp/zMTbv+TDkmLxbn/sb6btw197yUjKe/qS4VXUo1dU+dkbv2gAEBYNAHAzeB9cHsYXgVpi7S19IGdg4lvbwqnIzqn86TYJkpmhhq89J6tf5o5ThWDNTdXHGrZ2TZjTp+fw0VxxLxevybn8Ys+Ac8zCzPw6AK87Q9XduCqqAr/yz/xVALkJfhjygS4z+wNl39SaOpoO4L5PKt9odEuVapnRRR3N9aWt82uhtY92naipPaKdiWhZA79UXMQ5yjRR0WydPlFtjS8j6V9ZX/v8Uwor6c8cfVNFOXqRCBfKS37QW4EJv/BFH55vczyeqzwvq9qB/ARxdwAPBL5zGN556z9vf4Th55/yyurbngL/wiOvvL7jFnjWeVeBx24kurJ+wvjZGhUCMlF6sx/7+32Rv6tVvFb+Kyj+Pkn/NK9ZdmUrjy+RipLqmY0tan89FsrUS8Y4CSw37V88LlFQKKEnR6tCU10tzI2T+vT+V9xrXImqwvO+6Fuz706TE2AkQDWSWsOCh2dCUmtEsVW2UX9pmcGsPuvYipvCXBQDmxKhapRtqt1GOTAGxK0HM52uKvybXABCQFZ0LUmENpzH277g9y6u+u1f8mHF39zvewPcf/lP8lW6UjuNv+U+z96AHx/86llHv4IWH50nBRyCpR4fgCOB7w4jQbVIw95q5ZZLsBqgYYM6lix6UcPW5Kz0IlEjzPGzqL6Z90Tv/udS4lpq6hauLwKLyfkFKpXdrhu998A9IavnWJnqPuBKVBV+5nM+pnxTGwNBdcnTjWCS1MWFGSrgUneEmpoJzFJTi76gWsmMx03yqHL+ryy/kvx6kjy7RYZVu6uqKsYXGJJtlucUzlEur7rmnnr7l/6e/p2bUfKFlxPAT26CrGIgT1qP5MnqYwd+HH47kk9tpU9J+ALfC3RPnuqjUVN8DUVp0QvVnNunGdTSqms5OS2OPaWZSWf5WIFd/Vh7FoOw/u7BKUjXBZDXqrqa7Sj7snO/+P3CFFfe4fMQcPVRVSDHwKAuMNuqkGX+36wdS4NESg/dAoI6RmeGDWakPE/7ZmZ/mEpqZn4fCWRx0pb5OLP6efz9ANV+TpGiKUWQPAeZOzX6uFq+q/p8tX8m+7IoVE8xnyuxJ3ADe79OIOUqWwkhiAAAIABJREFUBYCf/9MfAffU4/T9XV/zesxG4X6gD/sB8N97kRFYI88Dvs8ODNwOwO3Rn/7jAxgHX44k1YP3/+UjgOMB5BxwYHBcFexAIphNXKuBsIvfak+O1og5L1hyP+l3Wywb7XOj/NlaFF0O5OfMql1z+mNSN+xzWEJoCufK0s1K+pIbx5fGrqKqWPIrF+Xs6i4w9wVe50DVriqyn+Im7eOpy1mKnkVZdNtKGS0WtEdf66Ifa8rsgnIGgAsipVf040pUNSgf3ZnHb8zkUwjJ/ZcM/D1paTSWmPkrbZsm0xd/15piKWtLFVndDmsM0yRVKpOlAdTg0iMhUgN8HNRIrBLkaEzEjnDsURXaGHSJAAanwLy05rLI55ot9sCCmAdCQcTguwPo5liqplB5qFdPXEvg/BKpdBh80NTjw7howBDywMqPAIflNmkgAEcwhfRbFIjp2he8nlObS87O6ZLQO5E/BDuYca6TlZYWjJNr7vlFx1rtWRJAJV964jFWwn6LsM5ZKAI4rVq6Q9qorut0D9NVMe5dk0+GhzDkbY7kRxjgCarYYY+7qTZ4lNSVhf45VZJqHe64+DEd3K1Ps43ib8Pkv8hMJ03LkRjVzNlZe4Saq9vXW28sJ24T6mO6xxzb6jlCBoA4EXVOLkl1tV4EdPk9Tz9hVEBvj8CjO9Dt0QeC3R59UNij8Pft4D8hHZd3DxDuAEfvHpD8Wa26ejFn3yXr0zeQ+q7nvpxz686wiMyG1dY1/bJFVL/eVOtPfU9fmNkWwDyT/1blKxeq5lip++3S+rADXRaHK7t5MLgqqgrOMYZhNAUzU0ob5P3tHHDT8aa/ZBAPxIQ0abPKr2Gpkqq36WKs064RoZJC0FKBDZN/dlw0wQPTMgMh1UQiy3t54PHconmblYqanaRXQCfm/5qa4Rg0hBccx2NqJLFKFh38cq5MnFaoAtuJ8+fgXV/zeu+rGvrk3f7Ydy4ryHlVmG4Bfs7Rm/kfHcGPHejOm/6RzPpDqo+PPuKfngV4OPggrMPgFw54dBQW6WE/cmqhpK7u6MJTRbx/tFpWfT6MMvaA5c6izf9zTLklhatWhjFmkDUeKivJGt/TmlpnLuks0RM8Nasx+XkV6xmm+3apjnsS1JIpfit3hFq9QF53hHX/XRiZvX+vDKfBlagaiGQ1zozMSGl6mD0Bo+QGsOOtVSOpLb/IiC0Go5b/HWA+YabPVA2Wv6Q0+UsMaj+zbeOgNVnOU066YjLMzP8Dj6TUMv/XzilOGNEFAGLCDb+ZSx7qgZxLzoF1dPmzSiVmIPCB85eA9COAmyGtpkR09PsCPgVVxCPv3E0OwGEIL3bsXwCS7+3R9+MBCG6ufdhqblvjpxkxMctyWZmcU9Vcc+WpSGpWJ7afTQ2f1eq4kV4ssIt1yyJ5JyeptbIs4moQwe4VoE6NjcjqbFcNfb9cGEm9oozrpVJ47ud/W8plGc2XzD66ebhz4LuD/4S0O3wsdOGSSUQeo0lqNFtL87WEtb1l8gca/qiYEgTdDm1ep/y42eqGVFOpw4wVIfw9WaYPc5z8J/ngf+ObWAfG4J6ayTW1B3ZO1dpxEcKdJOVVTYn3x4j/9Ls8taDezoro70HsMz3Yq8mfHQM3DH40gN/tMfBoAD3nDvhlzwLPewfw7u8E//Jnwc85+s+73Pngq6fuQDdDFijGv3jjc7KGTAEXA+0rre5jC5ny3XufWs9o9tyLz1pYlhmrPfG30thi/abN7z3uPrXz6nB5yF5Yk8VE/N0ac2e4IpmrJlnHVzKK+N87xoq5KLVD/i6/ntpSYKHHErClK0epnC2frx0w7PB5CLgqqgUQwa8gFNWvRFgp8xncOjVVZva3TJK9LgZ7qC21SayRcmf2W30rWfTE5K/6KBLRSTsxKqwxY0HcL5rkM1V1XrOn5yFcAAz4lyH291p0L7CU27mRt0vgm+AxCdoAcOP7i5+jfCQmgz4ndwA+DIBzSB0wkHcdeGrrxi/ERK1r7K/u9aTUG78VXwKt50WrTKeeYYxnOxLxyXKxvSgpZ6XAoF5sQuLD+fYqez3+j1uqqL3oNLGfbCWuOWi9nFxAiqxTgoHiPPGk40LfK84MrYbF9FTS/B+DQvShFtHsrTMiUw7U23ztuMK27nx0W6NjnDFNfL39JvcPxJQdRpLq1IeQ9W3al9Ewd4pr0aNS1VA7RijJEawCqbZUVSerM1XVQx77T/frpGB414CgViflWExA7sP/6el9Qlsonb+1XV6jokpYKbOltG05Mi/oZ3lOk8AxEt97LAvFds1uVl6upSjOfZmrKcI9CqosR8L0hW605ZKeB/3if8UVZ8RVUTXg0wmFf5OiinElnqMD3wxe+Tr4YCscxiAoTVZbb0kkB/5wjDb9V/P9VQaSLoIqlTQLPWXEfXre2q2gKml+7EEwn2ck9YaDGR9hQgnkKhaZBUEFddCRUFYZMTXVGDgVVNWoxsqgKp2aq5V6SPipEgAOfrAp3RMfxvMJN026/wYK+Vd3gOMxuX8L0V2CUT5fB9/+2wHEIXjqwKOPbzxsjmDSukf3RnYfifsFmPpAR9RyrOqygKkCudQHM/rhxj7r9MutBfFVfbxLZQ/Gc17zryyguiBHr7/jUrJVe+ZM94YGQW35+MpxtNWvsh2NPjDVVGMczuaLNeNNSUlf4oNdSwN4iUrxCjwUU/3WuBLVArLcl0BGWEsLAACYDi5hqcwmOkmq/N56QM+iomrC2hqY4z5ZGUDTP1WqPEopzUiqLD8jrGGfUoDUhDCEWV8eM9mP62RVHZvIarSkx4k45lQNOVgnbTslllYXVFWfZzX4UsQH4TCAX/9+wCP7uFmpq7jxew+WKuOKYE5M5bWXGHlP1u4bOblv/KJSzS5huBhVyaqFkouDKHPyW2/kvhxn4nGxr+RzOfd5mUtM98LeY3eLpF4SGkT8oZHVK6a4mv4N/LL//q+b21k/LBN1QBBMaS7u+cRjGiRVYulv050rv200eHW1R5LN4j7IzXyBpPIh9iMgSSpLtTD+ljVMKgiWGmL8TpXzqfkTAyl3avZdXPu0jKrhBnASFEybVJsIal77Bwbd+sUCxoUBeFyZag248PdaVFwa8v3sa83OIIH6eS/BVOkK7dkDc++5mnsD0OlS09kmraZaZeljetAKsOkta4m5/xJRM/t3WehOf9IXS7Jngnf4PARcFdUCuOeNXJBROgiiaagRTRh+pf4P3bB2UUA0FXfsXPOhm+w747xa6mIsUhHzcnmqDdLcH/v9ILbL/uPxO8U8qg7AnVdIOeyGozD/p6Cq3CUgTZhyWVXdF1ptc75eRvw7EhkOqzsBken5tgRpyEf0YY/hhv/2b5qmh9ITNYf+itW3TMiarMa+fXRMOWMB5C9kFpbMc73HRGuElYILyPvAysE4Ued5uk/cRfavDGyRLgI6rZx0KVDH5e1t3BNzzf+t8oRqnKmq6XfjGKuPJu2M+4QCBk2MVPvUcz191mI5Rl1zyH7NrL9Wvdv6kV5CDIvzTeHlIXMJ2Kgf5mBPN4AL8cFlXE3/JVwV1QqkyT5b0xxADCoh+bYdSGrv6k0UAk1ILD2Zp0OxGqW+FiaBxSS1pPhYD/NWD3gvWZX7WyQVmJLU+K9QWMdywr/ppWRaVb7E64yJvuq2IO6leH84jKtVJXVVvfSEe/AdX/a7y2UvRc20PpAn9QPCv8L1pTayRrU7BrJFRVUq32uUEAKail71+Bl1l4httg+XVVOluGbHyPL0sVs8d/JFw4J171auTfeqXNa1IfWxCFIWAKnHV1Gm1WelcrYiqbo+63eJUhddkNJaJKlN8eAMBE/Po/pn/ez0fK64eFwV1QbG3JYI5JL98pFuADk/S1MW3RwOzMy7qlD9gA/ky9gLc0xzcx/c2ptuj6oa+jW1wwqWiANnCpTSpn7kSmqpSkFWKSpMA3mfSTihFCGpqgDydFUcf0dSVQGhvFrKqlZVw3nGIC6fKiu0ITI/R16BjEFfW5vTorIs+kWDjoGg3rksQ0CWp9Y8UP19GMBBHZ5kGgBOp9BY7Z0z2WqFVTbXKkaugBaPAab+rOk+EWVVlNpuSBWVQ3tLC4PUtumgqFLwmK47QvZTzTxuRZ3Wxk6rz1SQ2yy0COqc3yRi30/q6zs8K2djdJHUVh8sCO7aDIaVr6SsVgOSLwRXRdXGVVEt4Lmv/XYACD6DSAqX/4Sb3rFPaJ7ezlB+266pFHOVpS2eMUu5WfN2ufYNtcf0CIwKnUFSJ+i9u2uBLKHubheFSRn5gJ9eWqTbiFZQaaxL33snA8P3y5FAdwQ8dv4Tv8uUbdaxpWJd/smwVmE9JSyFVX8AmCStRYi0ErmmT2r5jXtnxZayWjrG+ohjzbRXluJaGjt1n8l6gT4lrTZuTV7igU3G3gtB09y/qvDzPsfaqmkFJJd+u+LycCWqFTz3878t3+DEmuYpotmbMmnOAFkaNBuD+yaoEdRS/Tu1aTJAuNpvHBTT2GZMlNRMTXXq36xiobymMjrOS/vJhbKy9lqTnsv7OL38WGZ+6QIQjotkVZb3zq/4XXjnV/yuensL4Ne/X5/iMURV1Y2fx/5fekz+N0lYa8nuYx+ovjHJzs6EtUqw5qC3nEpXT9wALPIVf1uLrbq05MbQ2wyX/51ePJeMMyWC33NsjUxZJNWq5x6gpS4CyO/lXjV1zj57Qbt11MSSe2Dm5x0+DwFX038L4SEkN8A59v8+uvPm/xDJTM4TV5PI9KBlrorlzTBXpGAqPXBbg9CcB1gsVZpBJ+5vESFNjsV2M29iJGvhJWFi7gdG4qkRtxXNzgTA58yl+GinPKnqOIc8qCqeu+5C2acx36pKMxQj6WOQFZhzF4DBM1o+OhAo869l9mT3nX/2QwHHeM5n/C3j5Gzw0Xm3ldL9NGAMonrswM8ePEGNq2M5Bm4G0G10d6FR6T5S+TlwbAYLZas76f2B0wVt1AJILAxUv7ck/C2W90FMedeT1opRb081K4NyARDbfGBfaE8t4Cq2O53POF5J4llTablEhqACzyYHGkQreyYLY5F2vZC/lVAjqJNGqO/3gBVMCKocx6wX7FWVdcwDSzF5VsXfMUVZqU0XCsbV9F/ClahW8LN/8qPS30Qx+CmoXEFZTb6lPYpcCXISqD3c2X6oDox54mZFSLWiCtTVIfn0lAi1nsjmYmJKVe13wuTf65NaQziWZBJ6CqQ1kmJJVuWqoXE/IDvnYtRpvKaapKg+I/LnSMyeEybfWNEWCzP7nSRprmGIiimCvyw8KY2LESD0wsGTXkK4RpHQWsTHIjw1snou9CpJyecTq2eZCWGVdTSe9yY6k/53+bBW7jetsMZzWaViG2NiqbxJRoJ4WDwd6xxK/aJPs3X+uq4aeueKnme7QQjjuGSS1LXtk/uf64Vy7u+XNM5c0YUrUa0grkw18Q2MKl+KYF5BUlOZYhC0BhCtZIpAgq4FACRJrTnOwyBcB+QDoX5jlW3rIdyVt93qyijVgbXwt1ZD5TaCT0ovlFgO+9GdUEED8UrEEeI3paqW/J1SGivdBhcu4wAwMYgp8EECD26892Ij5UppDBB829755z+kW1Xlo/PncwzX64jJ/cuOQbcMPA4J++NxSa3yiiofj6Bb8nlSgaRIV1U6rRi2lJeNldUxPRjy9snr2QvZtpa6qslm4aVvQvbQOH+pts5RVrWqKttUI3LWWFW4fvEFJOvzuH+vBarnHhH1xTIzwq/dUuaSU2vbUsK6h6k8vfzCvP92JanyuFZglWWhAsrPzKSOZU3bvIxdwGOw7RUZLvaSXQISSSWGuxngbu/gnnoM99RjnxvydsjJ6oWYFbL0VpJIp78hTOqcjpGO5RMn80zhrFTuxMRVC+SISqgVzKD/JjEBpXMSamqJpLbaOvNycVQYNdYQqMo9Q+LaAMheMpKfq8A7//yHNKsbvuPFY0q0W5F8X88vAwGPKfmm8pFGhbWB5Efci1I2gJ1gpocCxnulNlGT+JRQuudKxZZ81iflbvBCnOrs3G9lfcXrOoekViso913xOlPlg8Ixa3AiobEL+v7SYkWNwPfc+73QvqU9TGQJW+l5rq64eFyJagWRpGZmf2X69zsWSNYSFAeKiioVd5Hk0hpMDH+k/JjpQz35PdVfaNsc0qYm3omaOlep7r2bJenV2zNS2Ftepc9jVS33CzdmBCB5X1mq9xb3W9fEUBnceSSuRQIfy5iDUiaBJWUVsAsp3lolE89gMzvCJRChjvtwUb9XXxraY2WRrLbq7HX9qGEt+V36AlzyObUsg3K71batiKlVb+/2JSgR0wsnq8MOn4eAq+lf4ee+8CPATME8CtDBB1G52zvQ7Z3/99ExBPTs9JamTaMR2szWMkFJNTWSHq3SWeQzmcbH+kb3AoxtsMxMFV8l0pOr5R9r9WemCofqZxFJ8bc0wYdcmMW8qmDh4R7y8x1Vpdq0VWoTY9qHB3FsMDtH6zBhCMFdoS3CBYDjalVLJjIXAu1uhuDzW9iHGXSgpLjSgcExh6w4JxzddDnU2guGNIsGgktD/Fvsd6RRPc/atvC8gT4/zTlEQpt4e31WS+dgPfeJrE73z1wC4o1TGjt0+bqsaJrvWZGvWAiXX1g0pOk/Ha/3Mcqf05ZQzyRn7UyYvsOnhmx26f6R/Z/Gt4K4AP3bhb34SGwtp825T6+4CFyJKoB3fNnvBg8u+GX68NNIDJwb1dRo6k9qqlS8gH1eX7r8ftQ+koTOJanyb0lY9YPd87DHdk1881QbZZt0W1rjiVP/tiAJhPg7BVaJAZ4djZMbUx5QFWH551oQpCbzAU6+ZZwIcbxeNAAMCkFWBGK/ZCvBu6XoSZeI8Ytf+Tvw1Kf/nWoX0O3QpwYFZYkOQ76iVzyVISxUIV7dU8CbPOdw3tm/EpGkWsSqNwjoFNhybushzHMzadTKKNW3Zf+umfxNCxBG8r305UT0W2/AXnfg19w2bdXPvfVa51GzzM05HT2mV/ddQQx7zsGam3radIG4zFadH1fTPzCu+mNFsrsxXyq5GPWP80+eE18jHj/xd0lS42FWu3tMMRahtFALMJBmJFJtlf/q32eCicG1gWiiLIh/pek//itPae0AF/lp0aWCc99TqdrTuCRvaQEAOgx49qs/uFI/238XMOat5a79ExFozUvhPkn7R/eB+Knh3M/eUsydq/V5lnwwa64nM/xaVyuGlftjssDD3OdozTUvuQIIFBehuEQscYfQv+3lPrL22Wz1/1xzvp4XLxiMq+m/hPvwWO6PYOof7lwirXQYxgCq22Mw+d8BN8ewlCeXe2/rt7XWwKQ/WTYCvw/FfK+adMxJ9dFDVi1fTP2R7TuM5KvUnkylA6aDqjhGEtQmWZUfEu4EN+yF9cMw1i19kiVKLwu1T3zZIUFYSdQhvqdVq9zoI01C1bcyUtCB8fhrf/ukqcN3vHi8doexPZlaKvqEw9LAiEsEy2uXCqX0/HTJAdEHlcOCAVFNlS4QMdNCSWmNfT0XNXeE4rMsPiXoF4satiAE4hnuIqutNpiri2mVqrNsXYxF/rRPZOV5zuqtPVMtKLJaXSHtUlAd82bOCaT6S97XwnqyqG970PmiCyAfl3UZa3BPCOsVU+xq+iei9wbwFwG8J/z08zQzfwUR/SkAnwLgrWHXz2Xm1+3ZlhastdRjEBWi6T8Qi3wA4cvxd5mQROQPd8mZXv6+57nICapG9IvHb94iJFN/+NfKrTq6AMCb30tuAJP2qv623DWEwsrJTxY+PRWH/bRfLOQxSK4A3qc1ZKtwA+6+4bf6/d7FZ6nATWhT9E+dS2pK+0eiM9DUX1XvF18EtV9qcoHA7jJANzHZ61GwzKbCNSSD5f7QjIQvlFU7LEtV1Si7Nte3xpAW2ZCuPPI+aNXb4x6wYnxbrTbvQZDmuEQUXwpWtKt0TWrtWnoNWvdNLLfkd1tr3wWR16q4srjQ7Ys8Nfb2Ub0D8Bpm/sdE9EsB/CMi+q7w25cz85fsXH8X+JiPzNEv1d3e+UV3opr66G5cgSoecm6SqkkzMLaNOiL29bEiCCHbv+avWoL10Gmlt6GmJtRI0JL8l1mbkJPVmFs15ks9MjC4oAqEY+I56ByPvaY3QAVTUSKe/lwG0NGFFaiCchZIKQ7wJFYRWCIeV4YKSjDdCH/qg7pXLLJq9aUL+x4GELsxGAwY1dCQwopun52ed1RFY+DUcTzn3NUi/H0Qv4n2VVdwSu3vVF8t15I5qmQPtK93Vv+ccgrtDGVnvtSACMSaUcccRIJSIiRNMmoohYWgPgBi7An/lorX52/BGt+WYg5RNFBaHKFYR4usl6Dv61MQs9q1mHsNesnbHJJ3QeT0ijZ2NXow85uZ+R+Hv38OwA8D+LV71rkW2RrrB/Y5Uw+cm2g3r3RBmZayC4wqqkVSS1Hec+qf+PEW2tZq7+T3Rr1rju1B6TzMIKEC8Zko1tw2p2UqM8ZrVhnEWZDilPdW1E2KkFI03YfcqRyDqeYO1kdnLyohzfkf/EOFRtN0/9RGjPlco1uEzO3qOJvUq4pfw3Q5NUMjkfr0/ZJRaN/Fmq8jzHs//jazrEu6RgsJz9mul/E8rHKBaF2LtYRw6Xyr613ounJqXH1UbZzscSGifx/ABwD4vrDpM4joB4jo64no3QvHfCoRvYGI3vDWt77V2mUTJL9Uih+RJzX66Sl1ZxNIcjPLh0c/hIqkAjZJndu2rWARs7nQ6YsMaLMJLVFNtL9qVB1JfO8qZ4aqVIPRXxO/1II/GmWEDUEV5exeNtN8LRnd5AIPJavfHXk1VQdNBSLKB/afm5xobj6pk+iDrcqW5zxRQDeqh8S/Uh3rfUGqYS6hkPVXXyKN3+eSBvPlesbxK9E0+2+kzs2+z3vU3MoLmFWf2Ya91MeW9WmLOUjfaxdMVhlXolrCSYgqEf0SAH8NwB9h5rcB+CoA/yGAFwN4M4AvtY5j5qeZ+SXM/JL3eI/32LeRIo1LCqR6FPKm3hx9EJWc9CfHq+89PjWl7SWTuRz0M1KCcSECV1BS10K4ExTbXWuvbo82+2uIYBpzotiSZKQ2i38jWU0kL/wdlcn4UmBNxNaLhP5AlDkJLhnJ5qTcqJYnpXQMrqLbAXQzgG6PcLdH4PbofVMfhX9vBh8gRfABY72DtpgQZSBdWl0sojdaX46gFIK2bkLQ1i0DjwbwI6/88sHuOysgpqQOZds0SXXi+96TmA7gMwNGjOMyYio+iqy2+sF8JsX3bH9zDFJt1oS5ajnAtI/1+ddIdYmsWtftHGbdFlkXqBHSWWR1xcvHpi9/a1RVa2xcQ1CzObJUp/G54qKxO1Elolt4kvotzPxtAMDMP8XMR2YeAHwNgA/cux1VyIlYPixBfYqm/+pDNKcnex7EWl3a39RSUbckqSXs4QZxaSAkIjNGWKOfmM/1r7IGTSei+9U1joTV36PDmN3h4ElrItaHwSuVB04ktWvRhNh89bJQy/zgXvqM2jm0N1tv3XAhkcQxEjGL+HT26eqUSGuwB1ma+A6jrqwGmGZdda9W+8m8J9XvpUm/RASs9tS+tzCXbOxxL5gE+0xj5Ip6d1FVT9EP5+rrDcE7/PcQsHfUPwH4OgA/zMxfJrY/n5nfHL5+FIAf3LMd3XBy8vepgUaCuqA8GWSzFC1iXDL1PykI/bBZtKQMHNMgRkxySi5E/w8cGzDdt4bOe4MoBE7Bv0RNE/1z+i2Z+2+PiZwmpVIHAbYwwK/WZbVpzoQg+9MFsuow9lvcHv/NAj5oPJZVGa3+rS3pWvBLlWm6SudeBYl2zkHtnptTr2O7nEbC+6KK2lTsMD9QbA0JWttPCzA72r9xLpu7scTnoVb/KRTDpff+VrDcS654MNg76v+3AngFgP+HiL4/bPtcAC8nohfD39r/CsCrdm5HFXQIy1VGghrNqTFnavRRLZn9I6yBNA7+tajwlivBxDwoJlSLoJ7AoSNbXWlvJHKDevqjrSCijcflVeEZY1ArAQfC4CPwU77PpfUJ8uUCh8UQ7hnn54D4QoLElXOFMb5kHTxRBYWV1G5EANUBqf+6l6AVKaUmiIpnbM5H/aPC+QFAyNd6dCAefBYFA5EspiVtHUT6K9jR5tbkXIqg7iCpm0GWufZZSWq+bqfoG/N3AGK5XT4gv55aqdeQLgepLaL/a2NNKxvHqRUwfd+sxJylVRcT1MwKUdinde1a+xkwzy257lTGA2B+VobedvUed49J6kPxKd0auxJVZv4e2LfNWXOmWkgmfyAz+yeVSptxS4pYUWVoKKO927WCqsteMiBa625fYSKpUlFlZ5lWyrgflow8hLHMwwAQ5YFh0n81qf4YX6huovnff5JfavJFXGghUG2swb30GQzf+0KxAT73bFSl433KMFOPpRcEuTk+W5GsVhvQoSztSVI1dB2lyX5uUzKVGtNzlEp0rLeknPbcE1L9jiidy1qSuiWxlO3WyxcvgPaBLpHVs0X3zzmtSj+Y59a6Lj2EdcnSvUue0xa5viAw8GBM9Vtjb0X14vELX/Th6W9yIjDFDem7Vo4yQgvY/nYSq8x6+Y1rEtRzDYZzoQgxDwSK/p4N9YWGoAbF/Tqe55o7QDMjgFZVI6GS5vM44LJY8z6aWZPipOqR94L5gsGje4GMpGdM/RHTvwhqqgjyitHzh6CkOkFYjXOctJEx7eNMScufAfdf/WNouJc+g+H7XihIAoA7gJlBRw45X/0KVQwAt6NazJI8ZROU4Q4Q92tBXre5JFX2fw29JtAlE2iprbJ/S+XFPjuw3W89Y0ir/kmd1ot8RQXr6jfMG09rfqM6B7IBS1nsjpaXWOqqkpWBsY+24l2tuQz5uc3KYSy/WmOJtV9p/15k4xvnf98DsnqFjSeeqCZotRSw1YPSsbWBpjS41ga3HoLaKuPSINttqbgVsrq1MsHEbbIqEU3GYWUqiubWre5tAAAgAElEQVRUFxjdQIGUesJKLpBVfW+UyKHsi7QQwEhax+MVOVXfoyUgRbhHomcRVPl9kfI7Ph/DX/8AgBju935/YV8EJRQjyY6pqqKiGq8/IfcR1SSmpB6WoM3WS5XUXrJ6KljKVUm5lfdd7V4oYY2aVQOpv5cSFHncDoRk1fjTGzzb8CX2+y1sQ+/16yDuxbbVXr5KKmupqiX3wiU9mwtxNf3buBJV+WBSYZnUiF5iWXIJAPruxF6SuhV6ykwqllIMz4mWD9xWmJiMA2OZKIyCsA7s1WJgXMnJIqxFsO2TK9XT+F2o/omgIhwbiF+WF9bCxA/aOO90nqKOygQ4fM9vDGqu8WMsO6m35H2AjRWp0v6Mqam7dg6ltuNE5v4t0KviAvbErslD8fpXFLLmi7r6filduxE5W4U547VFVtcqgUvu88Zc1vTNbRHWPV74LmA6umI/PPFElQ5Dehhlaqrxb6Rt/YUa+3Jjoigct5uSWjqfvQdsK8JYBpol01L4N1uDPJAZCU1WZ6iDKUBJnHO2zTL/h5E2tUKbxQ6c8r8mt4CCWc0i+9n1PsSNou8y/1R4877apk3cTZKq+1xH6h8G4OA84y6Y/lNR3/Fin9v1dgA9oowQ8oH9fBKDmRy8qnp0IPIBVhwlP9n22A0T4mSozSWIXReR1DjB9kyya5TBNai1S5v8W8fFl4Le8kv71fqhVV4vQevta92uPc3Btfmi5q9skWbdzh6z+1YvYp0uAdkhlnuAtpDA2EdioL7nqHT57suLqMIu0+/97IoMTzxRnSBOoFFVnQzWC6/6zLf2SQqgLZVUXVarXZYiuKS+FrnW7gClIK+BfNqmjTMAFH1aUyAQhKIXVQNxfPBHnbgFUDRxa6XcqGsS6KK2hyCpLKWQJqKSyPaS1BL0Je9V9wdkk1MKjrKU2qiqxqVVo2JdCrCaqKuFdqh65hDUVFelvHsHTdRq50Od+50arftVXjN9b9TOZUtVdQ5JldvU/ZaZ2Vv37t7ErHZO+gW8lDFgy5RvtaLuKUm9ooz75OG4C971Na+3zdglFVU+lHopyBZqD/upou6XktSt6itt2xJ73NVS3Qvm9ERc4yfcM+wwJteP+xxEPlMXyrBWXYq/yd9jNH+M4k/+qLHMeMxYJx+4Hd3fuLYyoGmyiljt5SPeUwzQO70srEnf6EOrJmmmcWJi6zhN5A3VT5Fhdnx/TP1zYA1P4Vzlx8QSdbTVHKuuIjHsL7de6cr993arKtVVgww4vQ8ztBy/BFqLTPT3R+O7ruOeggEM4M0/DwFXRVXChdV93DD6qhJPb36L3FVSPEV1NAXXVI4xk6mXVLYl6CXVksRI03htdSHl75tgmPuLSeNjn2iT/uADmJhoJHQrn0EdTBW/M/EYbKVcCfjg/Zgz14SxgLBTuN5EIjAKoKio9uRGVOax4vKfYd+MJGTHqnKtiPl4jOzzeN43PnsA3bFXleM5aHcLBT464OiA5/5iCpbKctIeBuAWSFkRZJt1dgVdtqV2qt8n59YL+Xg26jkZOp/3EildQtLnnnesI8uDmwqbXf1UfTMXMphRTklZZfFbz0ISQHkMXUt0peooTO4tslpdxOHUUK4CxfRWArqtpm9u6x66xwRV4hpMZeNKVCNCIFXCkhu/QTwnSfKXkNRToJQTsGfyapmuUSGpZqVkBxW10PBVrUX8T36TgXCxGdL8DIwBPnE/iN+CK0BKth58bhMq/mVZcJQmqVGElP6pVrtTPWNzTKWydXmjSV5va6b6kuczpvpKPqslGPlVa1hFUOUxlzrnVdwctlaMTcLZ2Hc39JLUWltLfWcR1la5S90EenKHLjCRSzI4i6BuQawjKn1UzRSwFg+EoF5Rx5WowhOnGDwV86jmqX3K6s6SuiR8LlE9wVYevj3elEuDSElJVb+ZUAS1mrmgZ9A/RmUEyAKqggpITNsto1pCIL+sAlNIEiqO+6lzSoTLq8Uc940oBUvEzT3ktHZvBJKdkuir+mggk3BwWKUNB5HvVKvmVsCF9dIW6yAAN/6ZyvyM5e6M8doabauSI+t2WpqCaym2ILxrxFx9LBvbe8TDhURgkRodq8r8TCv7LYXVrFJ/ATYhWzrWzE1030mKJwS15ba2JUnV340FFeas4pWVWbuHHhxJ5WvC/wLugwfM7iA35P4zpUCqXeqeQVK3xoDCREB1kqph5eUEpiS15Pfbc866nwZqT4R73t3CDzLzBYzb5T2kP4Gk4SD2j/6r0a+VMPqe3nAiqakuUX/yae1BJKnx2qugJ3Pp3liX5aPagPugZ+B+848ArMzDsY9ujP6QmEt2LFVZujNcOkj927Nvz3YytlvbLgl7kFQJpz4SpD7pmDMQia3mhIIv6WR8aqFHFZZ17oEl1+HBEdv9QUR/ioh+goi+P3w+vH3U9rgPQ/f+cCF/alRO56ajimiZ8lvlnoqkdhLUWdADvkVSaygNoln7whu5QV5OoqbGf+VT0yKspU9colcStfhJ20aCmvmh9qqoJVh+qrXuk/6wQPkaGUR2eN37j5tUFoCsP9JEqdokleAWWq4PpW0SlzCXzRUiS/7JO9X3YFEircD5yWovls5dPdhAvNHKb9NV4ZL7emPE4W7rzwb4cmZ+cfi8bpsi5+Fq+kdOpiaBVFtFrS9QoyZY+lpRu1trq5BU13M2TFKWH6p1rtZ5tJK3a5PZgDHP6ACQK5j+td9owOyVqWJZOudo1sZQ9hx/2rhr7Zi1xFRDnkccHaOJXa4QFesOwVx0YBAGHygVf5b+p7VgFHn9IrE3zP4U942rVonsAtFFthldvpWbzp6BVEvKbhHSta4CG3OCOX6uXXW39ukhNdIKYR1TWhhBrujFWORL2g2r7B4XAEspjZiznO0W5FAHhkkLXcNndfL7lmR1z+u2AR5KlP7WuCqqEY7HFamkCwCQq4QNkkmhnFkBQ13tW3BM7ZWqop7yQP2BU4YSOpukxu01RSNCR8z3dvMp7vRa20vn11Jel5j3e/pR1t/aL5r9nZ9w4vVt3ePZc3AM26KPrG7nxEeQxn+1YcK6N+c8bqXzPcUcEXPFboRNA5l2mr8vLjVYiaTGbeZ2q5wFCmPv/mv7bI55/gxgV1dTd81acGn34+XjM4joB4jo64no3c/RgKuiCgTTvydbJEmXDJIxSFcXGV2TWqqm3vUeK7FUPe1A1zKvNYf/ijo7gVhu0+fSD/seME1rpeuXqaaWqqo1tJZ1dR37LK27VV8IBEvptVqpe+KmA4OeGsBMoGEAjjQuVpC9oIT9VWYL/u73Bd2GVadueVRurXaGNmQuHoMDHwHcDMkNoZlfNZYZYSn2HXlkN1VVtypLuJrobVuVfTZ1tWrFwfJ2ze0fS2mN94xuh3XvbbFSlFb/rKBFub1W1znImVZVgVmuZXOyBcwO1rpQZXWnhSGfR0RvEN+fZuan4xci+m4A72kc9ycAfBWAz4e/4z8fwJcC+KRdWlnBlagC4xKX0RfPcQhsCRNjj+9pD+YSjS1N/RX1dA2afVE6B71fqw8Lg2+2xKaO/D91pHepzlKw2algtSn6hYrvReWLEYLX+qqbpGGTiC9/wuXAb8eUhEjSTOIYTN0IsowCl4CteMG5bF47uAJcBGpq6m51rqir5AawdT2nwtLUXhXci0URzoufZuaXlH5k5g/tKYSIvgbA39isVTNwJaoRUk2Vqmot/+ccX9NTPUyaTFwaQd0ScinVThX1JOT1EgdOQQgzch/ug2ou1mC2Zxeuu7EcrD92VE0m90cyeXv2SbFOHdg1SYOGXM2KSmz0eTUU4Ox85fcF132Wn2ULa1Sc0vUpbbtPmMOv5hLoc/VNvNa95LF2Xk7c87Xf7wtmkNWaqrqaoF6Yqurfwy/rWhLR85n5zeHrRwH4wXO040pUAU9SXTT9CxImHoQiMbskUtJBUtcQ1M1WzcpUz8pg0TsAM4A7lO/mQkDVg4N1fq7wd9i/K/CLkCwMDAeq+S4MmN4TwVWDHju/tGywn2brB7A4/ugm9wQNADsKpDnubLguyHZs+GxqtblJXEsm9BbpyPa1yzyZz+e5VdXSy8XSIWyNmjoxw2Pb4C79N4zya+WV+uSc168VjAt0EdYnyV/1AvOofjERvRj+TvpXAF51jkZciWoJUnXq8b88N3YkqUVf3LUqqg5aKyW9t2Atsxmj/4eKwvpQMai/NTlvpWrq8deMS7fF4CprkimRi2DypwF+aVlExQk5Ceh5vEoqagsbquur/Vc18bHaJvctYW9B6FLJ6pJytsBW7em5bqW+n3PNz339rrjXYOZXnLsNwJWoAqgHRVVJ6qWQoU5z/xLsRlIt7P12qwKLHhw0WY3oOd+a6hzN/9Ff22H0Fy2R1ViWvC+ir2v4E9H0ny04oHxhk4oYy1Z+qDWT+M7oUlnlJksh02RVQ6f0ujAFaDV6TudSLSI7BZ6ZdawtY00b9zzPjX1Wd12u9QS4x03fFVeiGhHT78SJUKei0kE61vElzM1/t7Sc3n060GXmB+YRVG3ynwvr1IKfKiDMJgdjvwIWRf6fA7URTCfFV5ZxZoPMOfVvK8NENP87Bj8mUNyxFrhnBCJmZNVYZnU8dtyeSOphQEqnJQhr0b/WQo20r5zQm8TVIq0l1xcjon/WeZ4KnSSmS33uWWmupDqnMoxjsu87sC3rvqn5p669fr1jrvHCl6GnKy7pXlsB6T5wn4nsk4orUdVoJfhfohwuTcNklaOPn/HQVaOxxT7FujWWktStwOJfMVkQB/M/UA6quXRVtbdtYb+Un9RIi0NHyskOIe+DnuvoPOGNZSXlojcq2QiuIrD3O62Ak4rLE5JqpmfSBLxwLouu/UxlqUpcJbnpMO1fJEntwOaLJrTu1ZKav3UbrCwa8jIu8oMN/9buzTnn1LrPlwSmrR3G5/hoL4RUVS3/1ktVXRl8ccFUl4IrUQWSOXNMUxW+y8GmNkDMJZt7oUMZjOckCesscgrMD5iaHL9CTZ0QHiRfRz+O2qqqJd6Nv/kfzqasLh00I0m9I98HR2uf3LRMRxqJHnOb+MjJ8xAUaPIbGM7XLa9Jzc/YMtkbyCYXTVIPPJLtlt9tD/Rk3uMX2HubaLFYZ1soEV9R/i65Uueit08uaY6tuVEsLlO8lG39olsKelyTS9s6rkWw5XYLe1znOeZ/axC34jEa/XWpZPUKG1eiKpFM/xW/1EuCfNBmkqzmYgVrSOrWKJ3aMJIuAFnkODmaRFAmsnpOVXVGfYf3/+fV34//5NeLL7BVihjVz2Efgv9fCAbKUkR1qpDsGORo9FfNVpvqMHd2RUOLl0YCcMOp7lFZbRfThV6yOhcVc2sWjFW4vxeR1L38OS+NiEZYadB6cannJLH1eGvdH3v1w8QHu6gU9JVXmpN2yM16Llz67XguXIkqkKuphd8vAvJh3ItgbdEPc9XULcaYkAg+5VWN22Zcu139VTckqBruN/8Ihv/rheP9IfrfvfQZX/33/MawgVNfZWRVugPodltpkg6+nOh1MVnaVu5bwEQ5LZ6gKGtrknpqCFJQyxxQJKm1TA1alduDrM7EpnloNayxpMfnV2KmO8dEVQXGfr4PxLeEvXje3HyyJVyyYLQhhifkPOfiSlSBLNE/HYZRVZXpj2omh5pd+RTYglyt9UGtlQNsE1ggy4h9LpcBjWQVwQXgFhOiZaqqwKgWbkFWzfRM8jzKh84hqYcPGPd1H/QMhn/wIv/3f/bD5YOOznfAEd49InxNPp+Wumq0ncH+0rl4HKX7MDOpFZaS7CKpKsKfg0sO3OiuoWFdO7lv97WVpKN0SO35aPkGwpdfjeIvEVS5rZV+7ELMm13pvOYkYK/129z8pfH7ErI6F3sLf7VztzJMLPXVnjPdrVK9Oyt6QKrqFVNciWqE4xQ9nhYAeBKwpYl/T5JqQb4gxLd2QT6Jp+b/7DA90feuK10jsy2SKjBXOW3B/bYfKv8WyGskswl6SdIokbaipxHIB8LxxAD7CTwGSE2CrXozSeh9HXuVfImiZ5HUeG6t612rrzeoR6PX5NoiqfcQm5HVvcbmpYqoHDt6r+k5sIZga1yienzPySoD12CqAq5EFZj6w0XU1NRzYo1K0jqXS50UW/5NUV2VhGshSkRUkh5zn1IeUwGpgp4DmswO3/vC9HdyA7CURK2qhsk5I6txiVNBWBNZ3RAlNXUW1jxDa54Ry1wMlN0llqq29xlz7xfZX2tvjV4CViN9uoxTcadTiyt7k9Ulz3knWb0GUt0vPPFE9fHX/na/Ys5hwJhLFeND0vOwnILI1h6++HDWHtK9CeocNXXJwC1IqF9OE+nvWChHZeMO3lf1jpNPo+6aTFUFJsFVs8hQh0LXIqjD695/sq2k6tOH/UBvy5pwL30Gw/e9ME261dOOni4yL2v0CZZqmZcGgCP7VaiY2hNDY5KlgfqWexUwr+GA8nVqmUO3fIkrEda96luDS1UIrfp7fE5b7V5CVq2AvFOil6Tq9FBr3UPmktUd01IldCzPeqlR/xcmiV0MnniimmHOG+mlmRjmEGuJLSbDWem5VtSjyOqk6AHe7MycP/GFoKrMtXhmJoAeM/Js9VT5OvNAJlnl7/yPtyWrvyUEXH3vC9G8QE7mUhUWiPgdIXBGBlEcyZ4YpCXDgvZPTYfRNqpqdHPQsO6BU+bk7Kmvd5JdS0Rq3VzqvzlYosr11Fkqd+thewtz+rlfSC7Il3lTNAhrK4XVOXA1/du4ElVN8PSKVBprEva3sKUPUbGOGfuWFiroPec9TFFWBKn2gRyCGZp5TP5fOO8sUH5u2ipJUpW5vJekDq97/9CIqEbm/awXaEh5cDcmq2ODINJ8WRI0JRcZuhHNFgnp+eBfFIgAHIPD60DgA/IOLyWxlwQoKefUtXzoLAJbM7H3PidbpIPSZfTUfQpysZRA7kE8l2DrcpeeXw1rydJDiKWwCOWW82qHwnrFZeNKVF0w+58bccBZS1ZLCZ6XEtTatrnYapzIIv0p205gT4iGQG4GHqP/4yIAPZO8FVGtj5GkLmAWQQXqg6eRbmpPuJc+49NcAT47QIDpXuEYuCPElaIy/9boEuDYN10qrFpFrZlvZbYGNSFvpqouwZoI+9p+p1Zt98IlBtrMhSSl+h7d6vzOSVJPIYrMhXRhewLhPaaezHNv4UpUJc428Yl6tySppW0lbK0OZ2VvV3RCb19Zpn81eRczARggpuzY6JvZo/hl0HlxL8AU5T4ouAH8gxeNBFWuYhZmbgbGLAs6J6sEwSfr1ytYGWTUbhDn985WK/VY5ezd/079uxV5vBQF9iFiLy63KiDvgsjM1v6pTyhJvaKOK1ENIEKeF/VU2GrQORchzdqw4yAji25dHhZ+qkJJncSa9ZBVhURSB3hfzdg2Ag7/SVtNHf73F+cnYRGmCxisJyQ1Kksx6AoAZ2Z8ALdjQFVMJ5W5AejTKl1HpWKV1rmfq6qmTA17kdMSAS3VsZY8zm37KcnqxqpqV2qrU8I6v15LTfG3gkuT9dt9wyVcu3uQvur6LmnjiSeqkxWpMrJa+G0r9A4+S+q1HsoLIECL0Ntsqz8ZTT9VuyzURw3O/3Uv+ZEZhQfMIKnRN7Xkl3r3gy8AANy874/Ob4dV3wfbOVn5b/+mRFgJnAckRFeAA+dkk2yiYSnQNNDU7xUoktrFLgAz7oXZCwZseZ+dExdkwr8okroUc0hqadsl4cKbd//AZt7vKy7C2HiBkBPHXg7eW0JfRR0Y1goQq4GpjyjvNahaxU6UDLbrv5DJjb/7fcHf/b7TH2I+0ojWNSIGv/79tmzaatAAf38MNCrYbBCLQFblJy2JKmPJ5O/IfwOwesSaq8Dq/eM2/XmwWPoIPeAu2RznIKRrx8br9b3ihHjiFdWbP/B/4u4vfhA4Tq5hKUgeyKutDnUH770DXiySeJKIX5p+n7vyVHb8+iYtRjT/y38rWQAmKavmVvcPf4O/j47wyuMt+RRN3/V+oAONkfzq3jFTUUVT+kCgAwO3A4bv+Y3AgcFPDT5QDEjuDXc/9ALcvGgbVdUC/c5/Nt34917k04LJIKsboar2kssTpYTag1guWqY14pJVVeCilFWgosSfCzqfKtDvS/0kkNQLEQwAXLT5/xpMVcZVUdVYep9E5fFCH4JNcEnnJq9TZSCME9hs8hBRekKEWRsEDG/4Dflvjj15PITlPw8MHIa0uAS5XOnuXrI3vEjBxRerfYjXatzRfPLg1Ke23xWnxQU9+hZmBzLujdY9fC6sIY2Mi3phueLJwROvqCawUFKPYSkjZ0gJPW9kp0ixUSRQG9S7ByHd8q1ar0sfy58zWVUUrIlILvKr8sCgsJZ9yZ+In4rR8JyCrpgBPCbgyKA7r7ASU8gzClUh7GvAFMzqAD8Ovx98e6QP7t0PvWA8xrhPbl64reJKH/xD4H/wonyjg2/rHYFvCv7Ba4NPcGKSXmqLzACx98ucbMMlqLAq8G1VUaWV2MTYUSOkFxdwZaE2Rummb3Vrt/qk5z56SAT1UlVVAoZLFB0uAFeiCuR5HqO/XfoN+7wZn1oB6PXhXPIA10jiHhOHrG8NWZ0DvbzqwTY33v3gC3x7YqYBF1I2HUMzaQDDeU56XPhCMxBwGxvTaPOJ4H7bGHzlV7gKiO96OzxHs0jqCQjeZLUyXe/WuHSXgRnYShE9G1nVeUm3OJ9Y3JW7bI9LJatXmLhE48R5oAc3psmqQN1Y81a0B9E6BSmO/r3604J0mdCuEzV3Cll+5fTWTIDmOCaT0N9y9rn7oRdMzNccTf+38MriLQM3A/g2mP31+vWx/OAWQG78TILiKsu31nD3zAvaO62Ae+kz9g/WggmnwNJVp3oQzsEkqdb3EnpzoS45biucaV6fBNhdKmJQ55J21vpWBxResQ3WBhpvjPg+v/XnIeCqqAJg9oFTzAAdnc+3eKj4m15q6ifdhj0G9iVuDbU3V/NJsgLICmVk6lXh/J2hvnUqbJMlVvWxjeMAgFxwEzjAB1gdGHRk8LscQT97O+4YVdIDpiQ8LjlKAMf9RDvmpuC6e+YF6bx3C74KCne2EMDahP0Bq03+S9RIrQpLkipnBdm0A/rPeemqVedWVmeY/3vTlHXDUB3vhQuARG9T9whqO8V9oxe0qV3v+3TddsA1mMrGVVEFcPuJ3+P/0GreIP7VkBPlniS1t+wlJFXv02sK6fHRbQWXzX3dK+2vy68NdLXE6zsiNTES5ptRaaUP/UHQ7/n/2zvzYFuq6g5/v3PvcyRBE9QYYoIaHsgkyKxgiAIaqQAKikMZkJRaBIkmcYxDmVBUCGgsiUNARaMhgAMSQlSCE5OP4QUew2PwWYEqUUStVBCNIO+elT9697l9+vZ8us/pc+/6qm7dPrun3b17+PXaa619K3rRrdEyIVE+cQDW4jD6WzcMltsoIIt1trwsDYVbEDhxDtY2Gex/J4P9ly2rSgvvWVlTu8aiYx0d7xL1jnXWVtMyqjwiZvGuXSv6pslx9skSXVaXunVNWrHzctH26fidRrhFNclQ2JKQBpEI2LqADUCLS9H8kVUoHW1Tk7ZunEnSReVtry2xWpgsf+W6WW4WKyLhZdnbHaTMKrL6+TdLrFJ1s5ClT+XIEL0YBWShyBK3dOt6FnaPRrTSCzYzvC74d6b9HBN5RUc5SGP3gjiNWnL5qoTjXrp5fRT4tVWwVfnd98Dw6mcxOOiOapvfNxoIYbhxp/GhZkW532puCrEa13fRPtoYGapg/cwhZatut+k6VYLTuvhImCCoqvF5Su8vYXGcilW1yMLZpX9pm9uuej10Yc3NI/2eLVqmTvkcWGs94X82LlSzCNHVLAy7sZbWDfpJq56iOuVtt8rDbVLn8rwHXs52y3yA4/kjwVrmdpAMMopf3Av9Sd+Urn5WvWzdMHrBLiTKkuPdp9LejInUSQSOMcr7CpEYxcTg4NsZXrXLivNeR6wCDPa5a5TCayRMipq/LSti0XbaEGzJTBCzdgir4w87SV3zREs/brPpUSZSu6aOeCwSarN2HckjT7A2NcTMiVh1VtKnTqWZsnjCNdFEEFU2FqxT8UYp64aoQt6NVMXxu0ykpqfbIt0tn9P1b0ON/WUuW+YyUOQ3DPDIYHQebJDjsznBVV9Hy+c21YD8T8SFEKS1sBykxUK0/KhcthykVSXvaAZjpzm2yooV11CWSG1Ko2Fmu6TudVDFKp+g18E/yWum4TXUlF6fl7ZZTbqoyrEo56/pctDOezWPHrkGGMawg7/VgFtUixi9yW35f0wTH9CxtFctPsGy6lJ180VfmVlpdkr8RFdYSau6CGS8JAcvuXnlrr62R7ZlNdk3HxLtj6ypoy7yCvWoQB03gHiZzH2Hu28sCn9dxnJjFtQqNcyuQx6mKOCLAcsuBZZws8i51off2ZnBc/NdBLIY7HMXwxt2inLLLlph+2fXdUYP3pIPnqRVdUyIJVw0eklRRoSie6LlruDG3f8F9CKoquyQ+iJk67gANKHqel26TEBvRGkeq0VYto0L1QSLJ1zD1s8dGP3oIsfatLoeynbR5CVT0q0/JlBrR/kz8iUcHLGpsBp68S3Lu8kY916H3oZdt/P4S69MJDTs9qqTAKGy+29GXSe9FCvVMxbzA4uW7TInbWBhr++ydNP66EeFPKt9ceEAMn2Cx1wAJvDZ7A3p9kjfJxOI1SwR2YpYnaYv5Wqjqp/zNOhasDpzhQvVCozGWe8jKwKOWtpu2cMqy4qal0uyImUiNc0oUh6wy3dHh0W/B/vfGQmghCUrV+xN+FCum62rbPmuclBXqafJEOpcYMUBVlAgVlPCtXFWgyrL1B0dq0oAWEsve5NVH+2qa1/DPgqZEmZiVZ3Wq6LufqoaSvrks7rGPjzcopqNC9Uiwljqo8CWNqxMVSIam1B3c00fAGmBmiVOqwZ+AYM/ridO84hF6rhCDzUAABQmSURBVIjF5W7/sfd8ByMUVXEFSGcAyFs+q6wt8VoqVgeM3CVGVtX0OUp7szTo/l9ZMZav3xxXgKRYa92yWnRN1BSpySF2K62TQ/IY4+lKgjVvX10Jj66FRPKQq+4nVafYSjtzN4A2mFrkPd1/9FTdfpNrwFlVuFBNsfjaDSz96wHjhZYSrG3QhhtAV12zFaL3M0Vqxou0LSHaiCn7BTYZC6EKhX6uNcmro8WG1NgCvWDh/ZAhVltm4TlReq6lm9Yvi9YCVwCZysVqF21fN+1XQzpxcWhTeKS31ZJYXdHtn3e9N7wPeuGzOgnTFmlti9W8j76+WG9njOEW1Tz66uLfH7a2qU5T5EUy1o1yTD97x/wzG0RLpq+KjOj9kXgfrpw/2syRN1XfZxcUWVM7ouoIsOllq1B7xL+cIJ7c/Q5YziawQBTstGCwmMieUDVStwELe323+cqD1N+k28kqzyP1os1MOyabWIC2MhpXT574paNTZV1Xda63nGVbHYp1kuu/7rpt6ZfaCfWZ/Jop20adfSTPW4fPolmRNxL5JH+rAbeoFmFEuVRHYoxg6enC4lGwzbS7QJVlO7K2jllSYYXqmbk4DSzs/t3xaPopvqDrCNBSK2zTIUfTwT51R0eKrbgWrFCDYOqcknU1ydKt64tX6qBtF3dbHlZ27DpKk3M+8kRlmc/pTALGss5fh+3c6hCqDZmpdXWW4qHpMU/Db7WpO0BWuRsmVxUuVDNYePW1LF24X/RjqMiqlKStBMR1mXT4uaS7QRVxlGIssj8W78nN90SkAjMTqfPMKE0VYITAqni6QKwON+xcOJLVpMQjdyVpddjX1PWxuPOW7OVaolaAVBckBUHevVFXvM4y6KWoC7lAuLTmu1r12Jvupi+iaxpd9W0J4jkUrN71n48L1QJsqOiFYlGCesU5OtNUiqTs6AKc9H2XVffkwyKdfirnBdsnkRpTqgX6FN2aR1vpqioe6yjQK6SqYggaKBr2dQmkeFvjlRhetzOD/bsTq2m0JEYDFWTl+61KxvKFFtQq26t0nid/HiS3UVv4Nvl4SwvcrHRVUEscTGRNzfJ5zDv3FQQrTCBa56WLtZXYCKo9N5saCNp8Lnsg1qrAhWoVkt3dTSNmus5LOc3us76LOxJirk/W1JwHcFdBWJMwqlMqkj0ei3r0/J9B9+ko9VgWdVwlKg8yMP67Uk7aKd8jM7fSJqloYcwVqZMcRtm5L6lb7wKuunguTEOstuHXOgfvmXZZPSNJtU2fXuO9YuG466OJqons26Kqg3iXzuMVov6T032zpj5yVw2LWF7gTNuBJ4PU/zbJqmtWG9bc9ygQLJHqiwVAUdDVaMjV8De8YacGlZ+AYYElsYWXXFEgXCnp4K6pBPKNB2zVDeCqtGzGQAeZFDyfWgloais4J4MufWbjY18Vw8gmz/OUr3VnbeEW1SJMYAZLAxgYptD9P0iYwOqYW8qsqmUO4nk0eegVWRZSX7MrfFN7zJhIrfrA7DqBe4V6VB2WdeJvpQbddjYkGto1HlY1CEQb2mgUptgKNdy4LFZHL+OM7resoKlaVBjJqo51NX3+K5/nOpafonytFakiJtPLFFlbs5aNqZy3tcyCCdUtg1XOe537uul5znimTmJpzdpeqfW2Sy3b5iiJLkxbwYAlt6hm4pdYHZImljxzS1Ml0ZF11MpaOEvkFuRFXbM09emb5h3WhjAvWN5i/9SkhXVAZGGt+rEULqmlG0si+WfERFbUOszBk7eyNbaKJa2tczrD89bUClq0Xu481ytrkmHo/m/zbzXgFtUSbCg0CFZVLSWsqkUr1XVqa0jOQy4tTm0AGlmXGn5Jx3lTe0ytLv+eUttfNSugpOp6dVNWkXh/ipGFVUvRtTESNsn6Z11qE4qWKvlWx7ICNE3xVYVJLe1Vhm9txY3B2hvdq6hORS4o6Xa3jLKifbbBhI/iuj6sjbv4p5FFoU2r6jwwy8wUzkTMwXf97Bj5qcJyQFX8V+flUWaiyZpdlqi/5gOw1LLahFrZ57uldyJ1Hu6sojqmk9gPUtfQYNnCOhokIGFhLfWhtm6tqou7bRnLhQr0/kMrl5aupVicVhWphV3/bdRp2iK1JZI+pkmf06y/3jMPdWyTKvEfM8Qtqtn07BHQPxZeccPyj2l9feaNVJWezqCWIJ3kcHoiUCEjndCcO/RP1eOiTh5NUoI1IVZjwTrv537qTPlctTqgQIuZFTpbv0M6F6LTeg70VaxOo+17KlidcbzrvwKDYzcy/OI+0Vt5SVH3/wAYlrgAlFH3Bil5oFQWqVkjXa2WLqAev9jqkOUC0JmAbXDO4mtt1JumkHt1aGFay0Psrli5cU1rE1tViwYIqHtex9omrxs865wWdZfnzZuRFbhyqqsqwYZN3ReqfETNq5W8KiW9Eq3R13dAlWwmqwTDWNIqPsAJcKHaBOvQ2aXT1CgJX9WY5KHIomNLvFis6OHVA1E4UXL2nhMLolzNMMXzr2H2h9DomhpE2QHika1Yml7dGtHEGtgkuj9d3uZ7qI2MFG1RdmwNfaIrlfXh+CegN7lb0waMPrIK2jsPj/rPp9NXnaSnSfqWpDskbZb05lD+G5Iul7Ql/H9il/Vog8GxG6MbeBgCR9oYdq+vJB4E6mu3UILVnJygDyK1jKSAHfmtqtwNYOIUVTVY4a8ayDy/efVOH2dGeWm71HS1WFGnrAj7lq+FzgYOmCQrRY+u91z61o3ct/q0xTxcC6sESS8P2m0oaZ/UvHdJ+p6kuyS9qMt6dN3kW4G/MrNnAQcAJ0vaBXgn8A0z2xH4RvjdewbHbIwmmgZVFW583Pc09gUs+ksv22ifmdNV1m2wv7XCGjw3lhBQY2J1xYLRv2mK1JjF3bawuMuWUR1XiM0q/rWJZca2kVGe/MvbRmZ5WoSupvuxqJ4VPhB6i3Kmu6LMfpCuT506lcRBON2xhLX+NyG3AS8DrkwWBh33SmBX4MXAxyRlDTDfCp12/ZvZfcB9YfpBSXcA2wNHAYeExf4Z+Dbwji7r0ilVko8nWfHiSiXdrritJuK0tPsfqovvGQdUbb19x04tSyvoS7dTjeMc+ZJOWO8q19p4GjSW74vEvmchUGNGmSGyhGOKvONdcXxMYNEvup4afXgWbG8aVN1/2mWhTLy2tV/ITlFUd1CCDphK97+nZ3JqYmZ3AEgrrs2jgAvM7GHgbknfA/YDNnRRj6n5qEraAdgLuA54ShCxmNl9kp48rXpMyuDoGxleslfIGym0MOlQgM1EaqdU8TfrG32pU9sv1ibbzyDzA6XierX3A5GP6iDxH6YiorbeHonRxV228MiWEv/lGgI1OT9LrDZm1uJylszqnp337vBpic2sAKu+Bl2tAgxY6lE2nRK2B65N/L43lHXCVISqpG2ALwFvMbOfZajzvPXeALwh/HxY0m0dVdGZiBXtuR3w0xlUxKnPlNtqWi+5Vfky9ftqfvC2mi92Kl+kW4b2g8sefOhd23Ww6cdI2pj4fY6ZnRP/kPR14Lcy1nu3mf1bzjazHrCdqezOhaqkdUQi9TwzuygU3y/pqcGa+lTgx1nrhpN5TtjORjPbJ2s5p194W80P3lbzg7fV/OBtNV+khNxMMLMXz2i/hzZY7V7gaYnfvwP8sJ0araTrqH8BnwLuMLN/SMy6BDg+TB8P5Kl2x3Ecx3Ecpz9cArxS0qMlPR3YEbi+ZJ3GdO0l9DzgtcALJG0Kfy8BTgcOk7QFOCz8dhzHcRzHcXqApJdKuhc4EPgPSZcBmNlm4PPA7cDXgJPNrLPs2V1H/V9NvrPYC2tu7pzyRZye4G01P3hbzQ/eVvODt9V84e2VgZl9GfhyzrzTgNOmUQ+ZzU2UmeM4juM4jrOG6EtSH8dxHMdxHMcZo3dCtcmQXZL2lnRrmHeWqua/clpF0rMlbQht8e+Sfj0xb2rDrTnlSNpT0rXBb3yjpP0S87yteoSkCxM+/vdI2pSY523VMySdEtpjs6QzEuXeVj1C0vsl/SAVPxPP87bqEVNL+F+DeMius5OFqSG7fhv4uqT1wYH340T5Vq8FvkI0pNdXp1lpB4BPAm81sysknQi8DXhvSds5s+EM4G/M7KvhAX0GcIi3Vf8ws+PiaUkfBB4I095WPUPSHxKN2rOHmT0cD2bjbdVbPmRmH0gWeFv1j95ZVM3sDjO7K2PWaMguM7sb+B6wX8jD+utmtsEih9vPAkdPscrOMjuxPCbw5cAxYTqz7WZQP2cZA2KL97Ys58DztuopoafoFcD5ocjbqn+cBJwehpbEzOIc4d5W84O3Vc/onVAtYHvg+4nf8ZBd24fpdLkzfW4DjgzTL2c5IXBe2zmz4y3AmZK+D3wAeFco97bqLwcD95vZlvDb26p/rAcOlnSdpCsk7RvKva36yZsk3SLpXElPDGXeVj1jJl3/LQ/ZNdWhvNY6RW0HnAicJel9RAmBfxWvlrG8t1HHlLTVC4G/MLMvSXoF0cAch+JtNRMqPhNfxbI1FbytZkLJfbUIPBE4ANgX+LykZ+BtNRNK2urjwKlE7XAq8EGid5i3Vc+YiVBteciue8N0utzpgAptdziApPXAEaFsqsOtORFFbSXps8Cbw88vEPkXg7fVTCi7ryQtEvnu750o9raaASX31UnARcEN7XpJQ2A7vK1mQlWtIekTwKXhp7dVz5inrv/MIbvM7D7gQUkHBB+uP8GHZJ0JicCBAfAe4J/CrKkOt+ZU4ofAH4TpFwBxd7K3VT85FLjTzJJuTt5W/eNiovsp/lh/FPBTvK16R4hviXkpkesaeFv1jt5F/Ut6KfCPwJOIhuzaZGYvMrPNkuIhu7YyPmTXScBngMcSRft7xP9seJWkk8P0RcCnIRpuraDtnNnweuDDwVL3EFHWDG+r/vJKxrv9va36ybnAuZJuI3J9Oj5YV72t+scZkvYk6ta/B3gj+H3VR3xkKsdxHMdxHKeXzFPXv+M4juM4jrOGcKHqOI7jOI7j9BIXqo7jOI7jOE4vcaHqOI7jOI7j9BIXqo7jOI7jOE4vcaHqOI7jOI7j9BIXqo6zipH08w62eaSkd4bpoyXt0mAb35a0T83l75J0ZMa8HULeyjWBpL9OTD9W0iZJv5K03Szr5TiO0wUuVB3HqYWZXWJmp4efRwO1hWpDXmNml3S5A0kLXW6/JUZC1cx+aWZ74kM8Oo6zSnGh6jhrAEWcKek2SbdKOi6UHxKslV+UdKek88JQxEh6SSi7WtJZki4N5SdI+oik5wJHAmcGq94zk5ZSSdtJuidMP1bSBZJukXQh0Shycd0Ol7RB0o2SviBpmwrHs7ekmyVtAE5OlC+E47wh7OuNoXwg6WOSNku6VNJXJB0b5t0j6X2SrgZenlefsM8rJP2XpMviIRgl/bmk28P+Liio8+MlnRvqdpOko0L5DpKuCvu7MZxXJD1V0pXh3N4m6WBJpwOxFfW8So3vOI4zx/RuCFXHcTrhZcCewLOB7YAbJF0Z5u0F7EpklbsGeJ6kjcDZwPPN7G5J56c3aGbfkXQJcKmZfREgaNwsTgL+z8z2kLQHcGNYfjvgPcChZvYLSe8A/hL425Lj+TRwipldIenMRPmfAg+Y2b6SHg1cI+k/gb2BHYDdgScDdxANdxnzkJkdFOpzUbo+kv6OaGjno8zsJ0HonwacCLwTeLqZPSzpCQV1fjfwTTM7MSx3vaSvAz8GDjOzhyTtSDRU6j7Aq4HLzOy0YOl9nJldJelNwYrqOI6z6nGh6jhrg4OA88OY1fdLugLYF/gZcL2Z3QsgaRORoPs58N9mdndY/3zgDRPs//nAWQBmdoukW0L5AUSuA9cEkfsoYEPRhiRtCzzBzK4IRZ8D/ihMHw7sEVtLgW2BHYmO/wtmNgR+JOlbqc1eWFKfnYDdgMtD+QJwX1jnFuA8SRcDFxdU/XDgSElvDb8fA/wu0QfCRxSNO74ErA/zbyAaN34dcLGZbSo6L47jOKsRF6qOszbINXUCDyeml4ieC0XLF7GVZZeix6TmWU69LjezV9XYh3K2Fc87xcwuGyuUjijZ5i+K6iNpd2CzmR2Yse4RREL8SOC9knY1s605dTvGzO5Kbfv9wP1E1u4B8BCAmV0p6flh+5+TdKaZfbbkOBzHcVYV7qPqOGuDK4Hjgg/nk4iE1fUFy98JPEPSDuH3cTnLPQj8WuL3PUTd7ADHJsqvBF4DIGk3YI9Qfi2Rq8Hvh3mPk7SeAszsf4EHJB0Uil6TmH0ZcFKwQiJpvaTHA1cDxwRf1acAh+RsPq8+dwFPknRgKF8naVdJA+BpZvYt4O3AE4A8H9vLgFOkkQ/wXqF8W+C+YO19LZG1Fkm/B/zYzD4BfAp4Tlj+kfj4HMdxVjsuVB1nbfBloi7qm4FvAm83sx/lLWxmvwT+DPhaCDK6H3ggY9ELgLeF4KBnAh8gEorfIfKFjfk4sE3o8n87QSSb2U+AE4Dzw7xrgZ0rHM/rgI+GYKpfJso/CdwO3KgoZdXZRBbiLwH3AnHZdVnHk1cfM/sVkfD+e0k3A5uA5xKJyn+RdCtwE/ChIKSzOBVYB9wS6nZqKP8YcLyka4m6/WPr7iHAJkk3AccAHw7l54RteDCV4zirHpnl9aA5jrOWkbSNmf08WAA/Cmwxsw/NqC7fBt5qZhsn2EZ8PL9JJJSfVyTW5wlF2RX2MbOfzroujuM4beIWVcdx8nh9CK7aTNQ9ffYM6/I/wGeUkfC/BpeG47kKOHU1iFSFhP9EltrhrOvjOI7TNm5RdRzHaRFJrwPenCq+xsxOzlrecRzHyceFquM4juM4jtNLvOvfcRzHcRzH6SUuVB3HcRzHcZxe4kLVcRzHcRzH6SUuVB3HcRzHcZxe4kLVcRzHcRzH6SX/DzwWXCY1TUtVAAAAAElFTkSuQmCC
+"
+>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[5]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">mask</span> <span class="o">=</span> <span class="o">~</span><span class="n">sst_celsius</span><span class="o">.</span><span class="n">isnull</span><span class="p">()</span><span class="o">.</span><span class="n">all</span><span class="p">(</span><span class="s1">&#39;time&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<hr>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Visualization">Visualization<a class="anchor-link" href="#Visualization">&#182;</a></h1><p>We will now be looking at more advanced visualization methods using the <code>nd</code> library.
+In this example, we are going to create a video from the time series data.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[6]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">mask</span> <span class="o">=</span> <span class="p">(</span><span class="n">ds</span><span class="p">[</span><span class="s1">&#39;mask&#39;</span><span class="p">]</span> <span class="o">!=</span> <span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">any</span><span class="p">(</span><span class="s1">&#39;time&#39;</span><span class="p">)</span>
+<span class="n">sst_celsius</span><span class="o">.</span><span class="n">nd</span><span class="o">.</span><span class="n">to_video</span><span class="p">(</span><span class="s1">&#39;sst.gif&#39;</span><span class="p">,</span> <span class="n">fps</span><span class="o">=</span><span class="mi">6</span><span class="p">,</span> <span class="n">fontcolor</span><span class="o">=</span><span class="p">(</span><span class="mi">255</span><span class="p">,</span> <span class="mi">255</span><span class="p">,</span> <span class="mi">255</span><span class="p">),</span> <span class="n">cmap</span><span class="o">=</span><span class="s1">&#39;plasma&#39;</span><span class="p">,</span> <span class="n">mask</span><span class="o">=</span><span class="n">mask</span><span class="p">,</span> <span class="n">width</span><span class="o">=</span><span class="mi">600</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><img src="sst.gif" align="left"></p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Classification">Classification<a class="anchor-link" href="#Classification">&#182;</a></h1>
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>We will now demonstrate how to use <code>scikit-learn</code> classifiers with <code>xarray</code> data sets,
+with the help of an <code>nd.classify.Classifier</code>.</p>
+<p>As we have no labels for our data, we are going to do a simple clustering using KMeans.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">sklearn.cluster</span> <span class="kn">import</span> <span class="n">KMeans</span>
+<span class="kn">import</span> <span class="nn">nd.classify</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>As we want the clustering to be time invariant we need to specify that 'time' is a feature dimension.
+This means that the full time series will be used to derive the clusters, rather than considering each time step individually.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[8]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">clf</span> <span class="o">=</span> <span class="n">nd</span><span class="o">.</span><span class="n">classify</span><span class="o">.</span><span class="n">Classifier</span><span class="p">(</span>
+    <span class="n">KMeans</span><span class="p">(</span><span class="n">n_clusters</span><span class="o">=</span><span class="mi">3</span><span class="p">),</span>
+    <span class="n">feature_dims</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;time&#39;</span><span class="p">]</span>
+<span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[9]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">clf</span> <span class="o">=</span> <span class="n">clf</span><span class="o">.</span><span class="n">fit</span><span class="p">(</span><span class="n">sst_celsius</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[10]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">pred</span> <span class="o">=</span> <span class="n">clf</span><span class="o">.</span><span class="n">predict</span><span class="p">(</span><span class="n">sst_celsius</span><span class="p">)</span><span class="o">.</span><span class="n">transpose</span><span class="p">(</span><span class="s1">&#39;y&#39;</span><span class="p">,</span> <span class="s1">&#39;x&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>We can visualize the clustering result by color coding the cluster labels:</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[11]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">im</span> <span class="o">=</span> <span class="n">pred</span><span class="o">.</span><span class="n">nd</span><span class="o">.</span><span class="n">to_rgb</span><span class="p">(</span><span class="n">cmap</span><span class="o">=</span><span class="s1">&#39;cool&#39;</span><span class="p">,</span> <span class="n">mask</span><span class="o">=~</span><span class="n">pred</span><span class="o">.</span><span class="n">isnull</span><span class="p">())</span>
+<span class="n">plt</span><span class="o">.</span><span class="n">imshow</span><span class="p">(</span><span class="n">im</span><span class="p">);</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+
+
+<div class="output_png output_subarea ">
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAsYAAAG0CAYAAAAxauHiAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdZ2AcxdnA8f9eVe/FkiVZvcu9N9wbbrgbSEInEGpCGnkTQhKSEEJJCL2GGHDFDeMGuDfZxkVWsXqx1Xu/uu8HyYeFZFmSJZ1kz+9Lcruzu89h3d2zszPPSLIsIwiCIAiCIAi3OoW1AxAEQRAEQRCEvkAkxoIgCIIgCIKASIwFQRAEQRAEARCJsSAIgiAIgiAAIjEWBEEQBEEQBEAkxoIgCIIgCIIA9GBiLEnSHEmSLkqSlC5J0m966jqCIAiCIAiC0B2knqhjLEmSEkgFZgKXgJPAalmWk7r9YoIgCIIgCILQDXqqx3g0kC7LcqYsy3pgLbCoh64lCIIgCIIgCDdM1UPnHQjkXfX6EjDm6gaSJD0EPNT8ckQPxSHcgjQaR9zdwzvc3mCop7Q0uQcjEgThVqdUavDyirN2GEIvqa8voaoqt8Ptr/X3Ictmqqpy0emq8PYegl5fg9lsbD5Gi1pth8mkw2CoB0CjcUChUHfPm7iJFRScLpVl2bOtfT2VGEttbGsxZkOW5XeBdwEkSRLrUrdDoVBjNhusHUafp1RqiI1dzZChPyYoaBoAZ898TETkQmxt3do8RpZlNm/+sUiMBUHoEUqlFklSMGvWS4wc9SiS1NbPY+8xGnUUFp7h+LFXAZAkJbPnvIpW62hpI0kKVCoba4XYr1VWZvP13l9TVnaxU8c5OPjw4EMnLX8fRmMjsmympqaA118PR6XU4OoWTE72AerqigFwcQ1m8R0fU1h4jqrKbLy8BzNo0CQcHX27/X3dbJ7/o5RzrX09lRhfAvyveu0H5PfQtW56Q4b8iISEzzEaG6wdSp+lUKhYsfILLiR8jq/vSMt2s2xq97ji4gtkZuzt6fAEQbgFubtHsHLlJpycA1Cr7ayeFAOcO/dfsrMPYDTpSEvbidmk5+LFbS1ic/eIYNKkZy2vbW3dCAycYoVo+5/GhgoSE9d3uL1abUdIyGzs7Vt2Xn726e1cvhyPLJtBNmM0NpKUuMGyX6nU4O09mOPH/8WggElMmfo8CkVPpXS3lp76r3gSCJMkKQi4DKwC7uyha92UFAo1w4bdy4ULa7lwYS3z5r2OQqlh966naWysRL5OwnerMZtNXLp0jAUL32vR0zF8+P3tHnf+3P+oqyvq6fAEQbgFRUcvxdMrxtphtDBixEOMGPEQsmwmJXkzp06/Q27OIWS56bG9yaSnIP8069cttRxjZ+dBcPCMFueJjllOWNjtqFTa3n4LfZbJZODY8dc6dYy9vRdLlq5BpbJBkiTq60vZ+dUTFBaeQ6+vbdFWkpTY2bkza/bLqFV2REYtRpJ6ZqqYyaRHoVD3iZu53tYjVSkAJEmaB7wGKIEPZVl+oZ22t/RQCl/fUTg6+gBQU5NPUdF5Jk56lqDAKcjIGA0NhITOAUCvr2XHjkdIOP+pNUPukyRJiVbrxGOPX2x19w3Q0FBOQ0MFbm4hlm179/yKo0df6s0wBUG4RUya9CzTpl/zp69PMBgaLEP1SoqTOHTor2Rk7MFk0rV7nFKpxd0jnKlT/wyAp2dUp+Z23Iz27/sjBw78iR+MHL0OCY3GgXvu2YfWxpns7ANs3/ZAq1ZKpZaZM18kbvBd5OUdxc9vXJu/czeqoOAMVVW5nD37MSNH/pTQ0Nndfo2+4Pk/SqdlWR7Z1r4eq2Msy/JXsiyHy7Ic0l5SLICtrSvLlq9n1eqtLF+xkYEDxyBJCs6c+ZDiogRCw+YiSRKSJFFZmU1hwRkxuL4NHh6RDBw4mtOn30GWZUymluOyzWYTJpPe8rqiIpO0tB29HaYgCLcAB4cBRMcst3YY16VW26LVOqHVOuHnP5ZVq7ewZOkaQps7Y67FZNJRXJTAurWLWbd2MRvWr+CLL+4mKWkjRmOjZYLYrSQiclEXklW5eUKdiaSkjW0mxQA2Ns4MG/4ABkMD69YuoajwXNPRbfzWdVRhwVku5R1rsc1obESvqyE6aikKhbJL5+3vxICUPiAv76hlaIRSqUZSKFEoVHh4RuPhEQlAbW0RRmMjRmMD991/hKysfaxft8SaYfc5CoWK2XNepbQ0hdTU7ZSVpTJ+/DOW/fb2ni2+tOrryygpEaW1BUHofhqtE97eQ6wdRqdJkoLo6GWEhs5l44YVpKV91aHjiorOUVR0jqTEjahUNkRFLWHO3H+1mNR3s5Jlmeysb9Eb6rs8tCElZQvHj796zf11dSV8+MF4PL1iCQubi529B1WVuRiMDZw69TZz5rR9bEHBGby9B1uSXLPZREbGHmSzEVs79xZzcgD8/cfh7z+uS+/hZiES4z7AaGxk+7YHkRQqHB19GT78AWJiVmA0NvLB+2Px8R1JdXUeRkMDtbVFLFz0PgMHjmbx4o+RZZkzZz8kN+eQtd+G1RUVnWPrlnsoLDyHyaRn0qRnMRqbHgcmJq4jNHQOdnaefL33V9TWFaPVOBASMouMjD1WjlwQhJuJJCkZM+Zxa4dxQzQaeyZOepbMzK+RZbnDlZFMJh0mk46zZz+ioaEMrY0LU6Y8h6trcA9H3PtkWaa8PI2DB/9CSvLmVmOCO+Pw4b9d72r4+09gxoy/sXPXUxw79irlZWkoFCrcPSIwmQwoFCqOH38VrdaZ4cPv59KlE1y+HI+3d1yL82RlfYvR0ICLaxCnTr2DJEmMGPEQ/v7jLa3MJqNl8rokKVAqb52n1D02xrhTQdziY4yvUCq13HnXlwQGTqW4+AK5OYdIT99FYeEZamq+L+qh1Trz5FOZ2Nq6kZ29nzX/m91iiIDQRFKo0GocgKZxdF7esUyd8idkzHz+2QIkqaln/npj6QRBEDpj/IRfMn363/r9o2iz2YhOV0N5eRr79/+R7Kx9GI2NnT6Pm3sYc2Z/36PpHzARGxvn7gzVKkpKkvjs0/lUVmb1yvXCwuYRF3cXmzf/qKlaRbPg4JkolWpGjHiIE/Gvs3z5emxt3Sx5gVKpaXEek0mP2Wzi6JGX2L//OUJCZrNq9RZycg5ibh6Wcfq798nJ3g+Ap2e0pUqJp1cMLi6BPf9me1h7Y4xFYtzHREcvY+myz8nLO8qgQZMByMz8hnVrF2MyGZg1+59cTNnKxEm/JSHhM8aOfYodXz5Kbq7oMe6owMApZDd/4AVBEDrCxSUQT68YBg2ajJ2dR7ttBwwYio/P8F6KrHfIskxS4nr0hjoqK3M4dPAvLZKzzgiPWEhc3GqiopaiUKj6beWDPbuf4dixl60dRgsKhZrYuNWolBoG+o1l+PD7W/w7mc1GCgvOEH/yDS4krMVsNhAWNo9ly9fx6iv+NDZWtnv+2XNeY9SoRyzX6q//diIx7sMcHHzw9h5seR0waBKTJ/8OaBoLVFKSiKdnDPEn/o2LaxAREQvR6WrYtfNJamsLsbF1waCvJz1jl+VOTxAEQegeWq0zfn5jcXcPZ8bMv6NUaq3SE2wy6cnO3t9mMuro4IP3gN4bz2w2Gzl18m1SU7+0bCsvT6OiIrPD51CpbHB2DmDV6q2WuTT9zenT75GctMnyuqwstdd6j9vj4ODD4js+xt9/PGVlaVy8uBVv7yGUlCRy/NirmEz6FsM+FAo1Go1Dc1LcfjqmVtuhUtng4RHF6ju3XXPxrL5OJMZ9lEplw6rVWwkJmdXmfrPZyMn4N/HxGYbZbCIwaAqybMZs/r6GcWlpCvEn/s3582u69IhLEARBaKlpApWELJvw95/Affcf7tHrmc0mGhsq+Oab33Kt32SjqZGE85/RVuLi6hpMYODUFtuUSjUzZ73UvLBIjxWgssjPP0Vh4VkAamsKmsuWXd/YcU8zc+Y/ejK0bmc2m5AkBZIkWXrSMzL2kp9/kqKi89YOj9i4O1my5H9cvnySjRtWUlWVw6BBk8nLO9ot1ULc3SNYsXITXn2sRndntJcYi8l3ViRJCuxs3a+5X6FQMWLkw5w+/Q7DhzeVcMnK+pZNG1db2phMeqKilqJUakRiLAiCcIMCAiYxfMSDuLkGs3//H7l9/tvdfo3KyhzKy9Isr9PTd3L27Mc0NJR36XwVFZlt9tYmJm5gzJjH8fefgCRJDBo0GUUPTaLy9R1pqXBgNhsZMfKnHTpOrbbtkXh6SmNjJbt2PkVo2FzsbN0or8hk966n+9TKtMlJmzjiHYeusZqqqqaVj3NyDnb5fDY2rvj4Ng0NKi9LY9XqLf22l78jRI+xFY0c9QjRUUsJCp4O0NwTLDffiX5/h39l+7lzn5CUuIH09F2duo4kKQG5y+PBbkaSpMDFJZAJE35FVVUehw//3bJPrCooCLcmhULNU09n4+jo263nlWUzsmwmI2MvKSlbKCo6z+VLx7v1GtcjSQoGD/kxw4ffj5/fuH4/MdAaZFkmN/cwH3802dqh9BpJUnDHkjXExTV1yOXmHmHAgKFoNPZWjuzGiB7jPsrZyZ9BgVMwm43k5h7m2NGXuXTpBAsWvktk5GJLu507HycpcSM6fQ2mTvYK+/qO5M67dpCff5rPPp3X3W+h35p82+8ZM+aJ5pm7BsaMfcKyb/eun5OXd4TKymzrBSgIQq9xdw8nOHgmt035A7btPMXrrMrKbCrKM0m5uJULCZ9jMNRjMNR12/k7Q5bNnDv7MclJm/DzG8viOz7u9huAm5/Ml9sftnYQvcrDI5Kw0LmW1wEBE6wYTe8QibEV7dv3HBWVWciyzNkzH1l6Kk/Gv0lG+ve1dTOzvqa+vqRT53Z1DWbM2CdJT9uFnZ0HPj7DCA6eSVbWN8iyGUlSEBGxkMrKbOztvW76Wr6SpGDqtD9jo3Vh377fk5Gxl1GjfobZbKKm5jJHDv+juZ2Ep1c0o8c8RkHBd8iyTF1dEYcONi3eKMtyi1m4bb2+0usveuiFW4tEy/GvP3zd90iSAnf3cJav2ICXV+wNnUuWm57KHTr0ArU1hQAUFJzm8uX47gi1W3h5xTJy1COUFCexdct9rFi5qd/3/PWmpKSNVFXlWjuMHtf01FrJtOkvEBY2D62Nk7VD6lViKMVNSqFQY2vrRmNjJWPGPMHUaX/CZNLz3en32bPnFyxc9CG+viP5/LMF1NeXWq0Xo7dMnfpnJk76LZKkICNjN5+umYudnQdubmE0NJTj4OANQEzsKvz8xlBRkUV09FISEzcw0HcUKrUNNTUF5OQcJDZ2peW8F1O24ekVg5tbCACpqTtIS93BvNvfYN3axX3qR1EQetLYcT+nvq6YqqpcHBwGEBg0lb17fnlDix70pICASSxfsR6lUtPlmfWyLJOffxKDoYHq6jz27H6G+vrSPjscy89vHNNn/A2Nxh4nJz/s7b16ZWJefyfLMpcuHefY0ZdJTt50/QP6MYVCxU8fOU99fQlmswl39zCSkjYxduyT1g6tW4mhFLcgs9lAXV0RAOXl6ZhMBjQaRwyGOiRJgdHYgF5fS2zcKo4cfhGA0LB5FOSfthx3s5AkBVobJxQKJbJsJjn5CwAaGsqJiroDL69YQsPmtjjmSg3SmJjllm0ODgPw8RnWot2IkQ+1eD18+P0MH35/876fkp9/SvQcC7cEjcae2bP/12KbrY0rdfUlHDv6sqWnrS98HiRJwYiRD+PgMKBTx13pFQYsT5rOJ3yK7jq1X/uKS5eO8d+PpxAaOofVd35JU6++cD2ybGb9uqXU1hZYO5QeJ8tmjh19mby8o8iyieUrNjBmzBPNf/fSdesWd7RdXyYS41tAVtY3ZGV+ja2dB2PGPkVQ0HRMJh1OTn4MG3Y/eblHmlvKGAz1Vo21u7i6hqDW2FFSnMiDD53C3T0cna6aPbufIThkBqUlKcyb9x9c3YLRNK+O192GDPkxALt3PY1OV9Uj1xCEvqKqKhe9vq7Fo/mY5qcrsbGrqKjIIv/ySb766mfWChGQ8PMbg0plQ3j47Z0+urIyi3Vrl1BXV4zZbKC+vrQHYux5WVn7WPO/WaxctQWt1tHa4fQpDQ0VlBRfYKDfmFYrxt0KZNnMmTMfAE0r5u3c+SSrVm0hOXkTUVFLsLFxueaxOl0Ne/f8komTfouLy6DeCrnbicT4FqDTVbNu3RIAhgz9CS4ugRj09eTlHSUiYgH33HuAKz0Hx46+zN69v6Kvjw1srSn+prHEfyI8fD4N9WV88slMHBy8ycjYjYdHFF7ecYSGziUmZkWPR6RQKBk27F7Onf34hkrlCEJ/cO7sf7HRujB7ziutHs9LkoI9u39Obm7P1gO+HqVSzeo7v8TOrmMT7GTZTGVlNsePvQZAXt4RiorO9WSIvcJk0hE3+G6RFP/AhYS1JCZt4GLKVoYNvx+N2o4pU59Ho3Fk2rQ/c+78GnKyD9D/fh+7xmTSExu7Eq3WiWHD7mu1v6Iik+PHX2PKlD+Sk32QCxc+JzFxPRMm/soK0XYfkRjfYs6d/S9arTNLln7KmLFP8N+Pp3LixOssWPgeYWFzGTP2SWLjVrHjy0darGrUd0n4+o5k9JjHCAqaBjSt+lNZmcXWPfcyf8E72Nt7U1WVR0DARMaMebzXI3R3jxCJsXBLOHnyDWTZTGzsKhydBlp6jfIvn7R6Umxj48Lcea+32+N1hSzLFBSc5rvT75GcvLnTk5/7usDAqb3SOdDfhITOJmDQRObO/Zdlm1ptjyRJDBt+P1HRS8nO3s+6tXdYMcreo9U6k5a6g9jY1djYOLfYV1GRRUbGXuJPvE5hwVmcnPxITFyPs/MglEqtlSLuHiIxvgXpdFVs3XofcXF3UldXgk5XxebNP2Lw4B8BEBo6Bw/P6H6RGCsUKu66+yvs7DxabD927FU0WkfLeF9rThyYPedVGhsrSEraaLUYBKE3mM1G4uNfJz7+dXx9R+IfMBGACwmfWzUuSVIy7/Y3iIu7s839V6rJXJGSvJktW+7psxMHO08ibvCd+PqMAMDFJVBUo2iDra0rtraurbZf+fvIyvqWxAvrej+wXubuHsHIkQ/j5OxPVNQSQMJsNnH+/BqGDGnKE44ff5X4E68DEkFBU8nJOcTkyb8nInIhTk4DrRr/jRJVKYRWbpvyR5IS11NSkmTtUDpAYvLk/2PqtJbLjzY0VGA2G7C397JSXC0lJ21i69b70OmqrR2KINx0mhbsCaKiIqPVPhsbF7y8Yrnzrh1otW2XnSovz2Dd2sU0Nk+ia2ysvGmSYk/PaFas/AInJz+RDHeR2Wzi/ffHUFZ68ab5u2jPwIGjmTX7Zb7c/jA6XTVeXrE4OvqSkPC5ZRhSY2Mlbu5hDB/+ICNGPIheX4tG44BC0T/6W0VVCqFTMjL2UFvbPypTxMauZOKk37ba3tZdvzVFRS8lPv4NsrP3WTsUQbjpqFS2LF/RtCrogf3PYzLpAIiNXU10zHKiolo/+r5SYeLggT+TkrKF4uILvR12r5g0+f/w8Iiwdhj9kizLVFRkcPLkW5SWpNz0ZU2vuHw5no8+nARAVNRS/PzHkpy8GaOxgerqSwBERi5m8R2fWMapd2SIUn8hEuM+xNU1hLDweYwb9/NW+7Iyv2Hbtgd6JY5LeUd75To3Sqt1JjbuTtRq23bb6XQ1GAz1llrF1nL7/Lf47NN5VFRkWjUOQbjZyLIJvb6GESMeZPDguzh27FVMRh0zZ/2jzaozFRVZZGV9y8EDf6K6+lKfKCH3QwqFivHjn2HEyIfJzPyGPbt/3qEnTiqVLQ89fNryvWhn59nTod50ZFmmsPAsp069xcWUbTddCdPOCAmZyYiRDzN06D0UFp7DzS0Evb4WpVJ7007eFIlxH6BUarnttt8TFb3Mcmd/9RCXxAtrSU37ylrh9UkxMSuIjllORMSCNvc33elncvrUOyiUaqKillg9MfbwiGDFyk1sWL+C8vI0q8YiCDcTo7GRjz+6jaioJSxZ+hlz5rzaZrsr36uHDr5gKUllbaNG/Qxnl4BW29VqO0aNehRJUjB8+P1otY6WZeoL8k+TmLi+RfsrvyNqtR1ubqEolereCP+mcuXvw2w2suZ/s2+6SZddkZyyhbjBd2Fr64bBUIeLSyDV1Zfafar8wxVh+xsxxtiKJEnBqFGPMnbcz3FxGdSixNGlSyf4asfPaGgop76+5JYY13Q9Wq0zHh6RLFz4Ps4ug9q8W62qzKW+voT0jN3k5R4lLGwekVGLcXT0tULEbSstvcjmL+6mtPQien2NtcMRhJuGJCmZNu3PbQ6vgqaxxOvXLaGiIstqnz2lUoOnVwzTp/8Nd/cw7Ow8KC9Px909vMM11XW6Giors9m+7UFMZgMBARMZO/apVr8jQsc11bn/BZmZ3wBQVZXTJ58k9DZJUvKLZ/KvO19HlmVKihMxmnRkZOxm0qRneynCrmlvjLFIjK1Io3HkmV8WXXMowKaNq7lwYW0vR9U3xcSuJDp6GdHRy1rtk2WZ5OQvyM8/RWbGHkLD5hIVtcSyel1fdeHCWiorsjrc3mQ2cOjgC5hM+h6MShD6L5XKlmd+WdTiplmWZZKSNlJQ8B1pqTsoLk6wYoSg1ToxctQjXKm9rtdVc/Lkm8QNvgsnJ38A/PzGEBGxqFt73cxmI0lJm1osaS9c+f3YRFLiRhIT+1/FiZjYlSQlbujBJF5i9JjHUKubJm5GRCzE33+cZa8syxw5/CKNukpOnXwLna6aJ57MwNU1uIfi6R5i8l0fJctmiorOo7rG6joN/WSZ0Z7g4hKI1saFcWOfxj9gPPb23tccz1RUdI4TJ/6FTlfDyBEPM3zEA/1iZmxs7KpOtS8tTeHwob/3UDSC0P85OwegUCgtr2XZzNmz/2XXzif7zNMZna6aI4dfbLU94fynlv+v1Toxb94beHnFWLa5uoVcs6rG9TQ2VmE2GwkMnNKl429mhYVnOHH8X+TlHbN2KJ0WHbOCmTNfIjnpi25LjBUKFfc/cAwbGxfyco+wZcs9ZGXto7amAFe3ECZO/E2L9jU1lzl+/DXLOOwJE35lucHrr/p+9nATMxjq+OD9sdYOo09QKrVMmvRbFIqmcXFRUUvw8Izs0LEDBgzl3nv7zwIasiyTn3+KlJTN+PqMJCp6SYeO27/vOYzGhh6OThD6Jy+vWJYtX4dabWfZZjLp2b3r6T6TFHeUTlfN5s0/arFt6LD7WLDg3RaJP7Scj9IWSZLIzt6PXlfD4CF3d3us/Z2Pz3B+/JNvePmfPjQ0lPfotQIDpzJgwFCOH297DHxbNBpHBg2aTFraDgYOHENdfTGVFVmo1XYMGXw3qanbkWVTN0Yp4eIShJ2dO5KkxM9vHKtWb6Gg4Dvq60pbLPRRWZnDxg0rLEmxo+NAIiMXtxjffuXvsz+NORaJsWAVLi5BaLWOTJz4W3x8hyNJClxdg2+J8XF6fQ379v2e2poClAp1hxLjxsZKS41VQRC+p9U64+4ezvLl63BxDbJsb2ysYvfun/e7pPhaLqZsYf78t4CWiXFpaTIb1i/HZDK02K5S2XD/A8fQaOwJDp4uxsu2Y9+3f+jQ96uDow8GfT0uLoHcPv8t0tJ2kHpxOwAGQwN6fQ0ajeM1J1cHDJrI4Li7SEj4FJ2uGqOx8ZrXcnYOoKoqF43GgeCQmVy+fIKVqzZz9Og/cXEJxNnJDz//8RxZuxhPzxgqK7PR62uQJAWentFUVeVeo4qJhKdXDBJQUpLU4u9Co3HE3T3McvPl6hrEipWb+OzT2xk79ulWN1Y11Ze5fDne8trPfyx+Vw2zMBgaOHDgeUaMeBjXqz6bfZ1IjIVepVLZMmHirxg8+G7c3EKtHY5VaLVO3H33rg63N5n07PjyETIy9vRgVILQ/yiVGuYveLvVsKTExA0kJ21sVbmhPzMYGrh4cTvR0UspKDhDSvIXACQmrqesLLVVe5XK1pL0dHRS362qrq74OjcOEuPHP0NU9FKqq/Msc138/ccxbdpfAKipKaCiIhM3txA2bliJg4MPiYnriIlZSWLiOkaPfoygoGlcuLCO4cMfIDV1B0VF5655xZmzXmLjhu//riVJib29F1OnPs/RIy9RX1dMYeFZIiIWMXbc03z+2QLS03cydOi9zF/wNklJm0hO2ohCocLDM5rEC2spKUkiLm41ixZ/hNls4p8vebe4cQwImMhdd7esgGVv70llZQ4JCZ8SHrHAMqRRluUWY7JDQmezcOH7LY4tK03hyOEXGTb03vb/AfoYMflO6BXOLoOIjFjEqNGP4eYW2q8eq1ibLJs5d+4Tdu18UqycJwjNwsJvZ/asV3BzD7U8aZJlM6WlKezZ/Qzp6TutHGH3i4y8gwkTf82G9cuprs67ZruQkNnMmfsv3N3DbomncDeqpqYAXWPVtRtITesMdLQEXl1dCSqVlprqfBydfKmpzsfFNQiVSktFRRYajQN6fS0mo47auiIyM/ZSXHwBT89ohgz5MUDTcTX5KBQqbG3dqK8vw80tFFk2UV6eDjJobZyxt/fk5Mm3OBn/BmVlqdw+/01GjHgISVLQ2FiFJCnQah2prr6MXleDg+MAamryOXr0Zc6d/RhZlokbfBeTJ/0OtcYeJyc/SktTcHAYgK2tK7Isk3B+DZs3/5iIiIVMm/4C7u4R1NcV8847w6mrKwZg3PhnmD79BZTNc6ZkWSY1dTtrP19ESOgc7r67b30exeQ7wap8fEawfMX6Pj9Lta+SJAVDh96DRuNAcXEiyUkbb9pVugShI5RKDUMG/wh3j/AW243GRt5/b8xNW94yJWUzKSmbr9tOq3UUq911gqOjD46OPt12Pnv7pkVVtJ5OLf4XsAwpuNLGwzOSwMDb2jzP1ZMtbW3dAJAkFR4e38+/MRjq0TVWcseST/jow0l8vfc3DB16DyqVTYvxwE5OAwFISPiMrVvutVQ3Uiq1zJv3umXlOrPZRGrqdoKDZ2Br64okSTg6Nh178eI2Ll7czuw5r1BRkWVJigGOHf0no0f/DBeXQACyMr9my+Z7gKYhF/2J6DEWeoQkKXF3D2PKlD8SMGhSn6kjXFtb1NaPmesAACAASURBVDzBQmbHl49aCrjb2XthZ9u0Bvzcef/uM/G2paIikzX/myMWCRFuKVqtM25uoSxc9D5KpRYPjwhLb2h5eQYb1i/HaGygrCz1lh9PGx29jOUrNlg7jOuqqysmPX2XpZdU6Dqz2URZ2UUkFLh7hH//2ShLZ8OGFZZl0ptyvu9TrjFjn2T48AdbTeq8ml5fS0VFFv/9eCoNDWWo1HaoVTatJiuGhs5l1ux/8tWOxygqTqChvrR5+xzuEj3Gwq1u5MiHmTvv9T71GK+qKo+NG1Zy6VLLsjwODgO4ff7bBARMBPr+7FlX12BW37mNDetXWL0mqyD0lsjIxSxa/FGbn8+v9/6awsIzVoiq74mOXkZUG/Xe+yJ7ey8GD/7R9RsK16VQKPH0jG6xragogY0bVlJamgyAh0cUy5evw9MrtkW76/3m1dWVkJy8CaOpabKg0VCP0VDfql16+s42hzDNmfNap96LtYnEWOhWkqRk9OifMW36C30qKa6tLWL9uqXk55+0bFMqtUye/DtiYlfh7h5mxeg6z8nJDxfXIJEYC7cEd/dwbpvyXKsf8JrqfNIzdpOZuddKkfUtGo0Dw4bfT2joHGuH0q6amnwcHHyQJKnPd0T0V+Xl6axbu5iKikwAZs36J1HRy3BxGdSp88iyTF7eEQ7sf77TMbi7R7B8xXqcm4dX9BciMRa6ja/vKKKilzJhwi/7TFKcnr6L/PzTpKXuoKY2n4EDR3P5cjxBQdOJil7KyJE/7XdfzCaTgZ07nyT14jZrhyIIPc7bewjLl69vVe6puPgCGzespKQkyUqR9S1RUUuJjllGSMhsa4dyXdnZBzq9wJHQOXt2/8KSFEPTBPjOJsUAaWk7+HL7T7sUg0pti7f34C4da00iMRZumI2NC+7uEaxYuREnJz9rh4PBUE9VVR5fbn+Y4uILNDSUYWfnga2tGxUVWQSHzGTJkjXXXfu9rzKbjSQl9v3xg4JwoxwdfQkLm9tqkl15eQZr195BRXm6lSLrGzQaRxwcvAkImMjsOa9aJlD1dXFxq60dwk1Jp6umoiKLbdseoNxSwk9i8OC7CQ6e0enzXbp0nC2bf4LBUAc01cZ2cvZn/vx3+O6797iQ8Hm7xzs6DOj0NfsCkRgLN2TIkB8THbOCsLB5Xep5NRobycr8lrDwed0W06W843zyyfQW2wb6jcHJ0Y/Tp99l4cL3+21SDE138FdmFAvCzSg2dhUuLkEMHXZvi3rnRmMjJ47/m7NnP77lk2IAN7cQli1fh5tbGJIkUVKShCQpmktlfcnYsU9aymcJ/ZNOV8OlS8cJCZnZal9h4VnS0r6vO1xQcIbkpI0t2mg09sxf8HaLFSE7wmw2cf78mqsm2ElMn/5Xxox9CoCUlC3XPUdg0LROXbOvEImx0CWOjgOJjlnOtGl/QaOxv257s9lEVWU2Do4+LT6gCoUKrx9MBOgsg6Geffv+QFbmtwBtrnSVlroDb+/BPPTwaRz66V3sFZcvxXPbbX/gxIl/odE4IMsyVVU5t/xMfKH/8/CI5I4l/8PGxgVX1xDLzXZNTUFTWSpdNfv2/V7cGDYrLDzLmjVzsdE2leVqbKwAJEBGlmVGjXr0uomxLMtUVeZga+fWojxYf1Belsbp0+8xctQjuLgE9rthcR2hUtng6RnVantp6UXWrb2Dysrsax4bGjqH6TP+jkpl0+nr1tUVkXD+M0sMt015jlGjH2u+AUsmPe2rdo+3tXVj4MBRnb5uXyASY6FTtFpnRox8mNGjH8PJye+6X0R6fR0nT76JXl/LoYN/YeSoR5kz5zVLaRiFQoWzS0CX40lL+4rkpC84c+aD67aNi7sTH59h1FTnc/78/9psEzBoMv5XLWnZF82Y+SKlJUmEhs1hwIBhyLKJrVvuu+Z7EoT+YMCAoSxfsQFX1xAuXPgcF5cgjEY9J+Pf4Lvv3qes7KK1Q+yTKq8aR3qFu3sEy5av61AvYVraV2zcsJLZs19mxMiHeyLEHrNz55Okp+/k9Hfv8cwzBV1KAPs6pVLd5hDF3JyDuHtEUFmZjZdXHKFhc1u1GTBgKAMGDOnSdZuWyW660Zo+42+MGfOk5ffewyOS0LB5xJ/49zWPHz/+GQYNars+c18nEmOhQxQKFaNHP8bQYffi5RV3zYS4pqYAo7GR/fv/SElJImaT0bLspUbjgK/viE7d1cuymaqqPEtvqNlsYNu2By1jniorsmloKOvAmSSCQ2Zx7NirfHf6XUpLU9ps5ejoy/IVG3Bw8MHJaWCffAwpSU1r3cuyTErKZnSN1QQFTRWJsdBvzZ//NiGhcyyTg3x9R/LhB+MxmvQUFZ7j6rqrQvtUKhtWrNx43SdxJpOBT9fMoajoPIGBU4iMWtJLEd64xsYq1qyZTWlJUxkyva6GDz+YwKzZr1xzsYz+qqGhnC+3/5QpU57D0yvGsn34iAeJiFxMVWUOdnYeuLgGdts1CwvPUVR0jvCIBdx22x/w9h7S4ne7qOgciRfWXvN4pVKD1sal3/bgi8RY6BAXl0BmzX6lzT/0/PxTZGftA+DkybeorMxq1UalsmXBwveJiVnRqQ9LSvIWNm2601KcvOtk1q27A2engGsmxdBURujDDyYA8OjPktp8hNXTjEYdJ0++iWw2AhARsRD3NlaxkmUThQVn0BvqOHXyrd4OUxC6TWHh2RbLnZ8+/Z5YwKaLZNnMxZStKBQtV0i7WkVFJomJ67l06Tgmk55Fiz+yrMTWlxkM9Zw6+RZ6fS35l09aOkxk2URBwXc0NlZaOcLuZ2PjyrLl69rcZ2/v2SP/bt7eg3ngwXig7RrHel1ti1XvfmjipN8ycmTXKln0BSIxFjqkqiqPD94fy4yZL1JUlEDC+TWWfbW1hVRV5bZ7vLNzANHRS5FlM42NVZblLX+orq4Eo7EBo7GRbdsepKT4Qjckxc3voTKHqsqcDrffu+cZliz9rMWyml1RW1vU4j0cOPBniovOM2bsk5yMf4PxE36Fj88w9Po6tm9/EKOxkYL877jSS+biGtRmYqxQqJg46Vlqai5z5rsPMBobbyhOQbCWU6fetnYINw2TSc+33/4frq4hqNX22Nq6tZoHUlqawjdf/xZoWmTDbDZQVZWLo+PAdldAs7aqqlz27v01smxqtS8kdA6DBk22QlQ9yxq9ru1dU5bNHDveVAHF13ckU6f9BYDz5z7hzJmPGDvuKSZO/E2/7S0GsSS00EtGjHgYd49wDPp60tK/Irp5ZabIyMUYjTrLajlnz/6X4qIri1ZY/88iJHQ2sbGrGDLkJ53+oOv1tXx3+j3i499oUU+y7fclXXPf8hUbLP+9ysrSSE3dbtlXUpzEmTMfXuOcgiDcqmJiV5GSvJlFiz9qVR6tpCSZ706/19xuBXpdLWvWzGHhwvcZOuweK0TbPoOhntOn3uXUqbcos5Qhaylu8F0sWbKmzX1C95FlmcqKLKqrLxEwaJLld1GWzZw790mXfiutQSwJLVjd6dPvtHh9Ke9Y8/b3kM1Gyvto6aWM9N1UlGcQFDS91T6FQoWDwwDLl8CRIy8xfPgD1NYWsm3b/ZiMegoKTnfwSh1LbIuLE9iz+xdt7rOxcUGnq2bc+F+QlLSpzUk5giDcGtobA+rpGcXsOa8ATYlOYuJ6ZNlEWtoOS2IsyzK1tQVoNI5otY69EfI16XQ17NnzTJs9xdA0f2XSxN/2clS3JkmScHULxtUt+AfbFQwdeo91gupmIjEWrKqsnfG+fUV5eTqvvdp6xSA7O3cmTf4/S1+vJEmcOP4a5879r81x1l2VlvoVNdWXASgqOn/NdjNmvkhlRRZh4fMxm40cP/Zqt8UgCMLNyWw2svOrx5EkBd7eQygqOo+392Bk2cx7747Gz28s02f8jfS0nQwddm+HkuT6+rIWw+2u5uM7koCACd36HiRJiatbSLeeU7h1icT4JqLVOqNW2yFJCm6f/yYXU7Zy9uzHor5tt2jdo1tfX8ruXU9ZXiuVGhwdB3ZrUgxw9uxHHWp3/Nhr3P/AMcxmA+npu3Bw8MFk0newakdfJ+Hg4M33Q07a1thYidHY0DshCUI/cODA81RV5TJx4q/b3K9QKFl95zbMpqbJvnZ2TZO5Tpz4F/X1JSQnb6K45AJlpRe5dPkEA7wHExI6p3nilxcGQz0H9v8JRydfBg2ajKOjL2WlF9nV/N2o0Tig0TQl0zNn/QMnp4Gdil+vr+Obb357zd7i0NA53HbbH/pkBSGhfxKJ8U1k2vQXLDNBJUmBVutEUtImdLoqK0d2azCZ9N2eFHdGWVkqp069RVrqDgbH3Y1G60hAwMTmMcjfy8052G7Pc1+gVGrwD5hIdlbToi0ajT2PP5GGSmXb7nHnz/+PL7f/tNsmbApCf1dVmcPIduoTS5ICP7+xrbZXlGdaFlIpK22qIX0h4TOqq3KprslHAkaM/Cm7dj1FZsYerty0SpLElblLNjau3LHkE0JD51qu1Znxp3p9Hdu2PXDNYSHh4QuIiVmBXx+vPS/0LyIxvonEn/g3cXGrLRUfHB0HYm/vKRLjW4QkSXh5xuDvN56i4gS+3vsrvL0HM3LkI8QNvssy27y8PJ2a6nwAysrT2Pft/7V7Xp2uBpNJh52dB9A0qVCvr+3R92I2m6iuymP8+Gfw9R2JpFCSnrYThVJDRMQCTp18m7DweahUNtjbeyFJCozGRkJCZjF+wi85dPAvPRqfIPQXJpOezz69nTFjnyI8fD4gd2jhjzFjnyAr69vmRR6a1NUVExG5iPHjn0GWZbZtvY+83CPNe5uSYVmWUShU2Nl5cPvtbzZfs/P0+jp27ny83bHSI0f9lLCweS2OiY//DxMm/JK6umJstC6o1Dffoh9CzxJVKW4qEosXf8yQoT8Gmr6g9u/7AwdFknBLkCQl02f8FY3aHkcnP/T6Gg7sf57Q0LlMm/6XNpd7lWX5ukNt0tJ2UFR4jomTngUgPX0Xac3LgSZeWNfDQzWkq2Y9y0RELGT6jL+Snr6Lb7/5P2TZzPTpLxAWPp/y8jTWfr6oubdKfKUIwtUUCjVxg+9Cls34DRwNgJOzPxERC6mqyiM19UuGDr0HtbrpqUzr7waZ/fueQ6nSMnbsU2g0jsiymdSL20m48DlJiestLT08o3nkkfOd7iEGKCo8R27uYXJyDpJ41Tl/yMMjkuUrNuLVvOhFaelF0lK/pKjoPHPn/YdXXvYlNnYVAwYMJThkFu7uYZ2KQ7i5tVeVQiTGNxmtjQs+A4ZaXuflHbU8DhP6Komo6KWMGvWoZUte7mHi4/8DNP1A1deXtDjCzs4TSZIwGnVtPhEIGDSZu+/eSUVFluWHQ5bN7Nv3ByZNerZDPUbtMZuNGI2NlJQko9fXIptN1DeUIklK7OzcOXb0FWxtXTl/jQk4XeXp2fReSkoSW2z38IhCoVBRXJzQ1mGCILTBxsaVAQOGIimUFBclMGLEQ0yd9qd2jykvT8fJ0c/SEyvLMjk5B/jvx1MtbTw9o3n0Z4nXOsU1mc0mDh/+e5tPsVQqG2bMeBEv7zgAHB188PCMxGBooLa2kHVrF1NUdB57ey/cPSLIyz2CLJtRKrUsW76WyMjFnY5HuHmJcm23EF1jJdnZ+60dhvADnp7RNDZWUlOTj0plw+DBP0KSFACo1XbMmPn3FpNHAgNvY+KkpvJDJpOeDetXkJa2A2j6gXjs8RS0WieKiy9wMv4NsrP3tygpV1Nzme3bHyYmZgUNDeWUlCQiyzIn49+gvDyDhQvfQ6Nx6PL7qa8v4/LleCIiFjS/LmX/vuewtXVjytQ/4e09mH37/sCIEd+PbSwuvkBBwXf4+AwnL+/ItU7drh8mxFeUliZ36XyCcLOTJCVDhv6Y3JzDrVYTbGysIDf3EE//PK95qNT1e3fd3EJbbUtK3NgtsZ479wn79/2hzX0+PiOIjLoDZ2d/yzajUUf8idepqsrBtnmoV11dcYtV2cLD5xMRsbBb4hNuDSIxFoQumnzbHzh44E9IkgJbWzd0umq0Widk2UxDQzm2tu4sXfY5kqTAyWkgBn09DY0VKJVqAgImWhLjtjQ9gmzar1CoWLjoAwoKTrN1y73odNUoFCoUChUDBgxl/oJ3KClJwssr1nJ8Q0M5BQVnsLV1Ra22w2Rqeoy4fEXTD1hFRSaHDv0VgMFxd5Ga9hWBgVMoKb6Anb0nRYXnmDv339Q3lLF376+YMeNF1Go79u55hurqS8yY+Q+CgqZhNps4e/YjLiR8TnjEQkaNehRJklAqNcyb90aLx6hVVXlUVmbj4hLYqkj/4UN/5fLl+B4fuywItxqFUsXUqX/i0MEXmuvFyyiUaiQUmEw6zGYTG9avQKlU4+kVy4wZf7cMp+gISZKYPuNvREbdYdmmUdu3c8S1OTr6olbbtfk9YGPj0mIFv6ysfWg0DoRHLMDR0ZeEhE8tk3UBbO08kAAbG+d2v2sF4YfEUApB6AJv7yGEh8/n0KEXcHYO4PEn0vjuuw8YPvwBzp37hO3bHsDBwYenf57XbUusyrJMQf4ptmy5l/sfONrmmOHOnMtsbirPpFAoqajIpLw8nZycg6Sn7aKw8AyRUUsIDZ3NgAFDcXLyY+3aO8i/HA809UJNmvQsjk6+fLXjZ01jESUFDz5wHKVKS+rF7Uyc9GyHxxeazUbOnPmIL7c/1OX3JAhC2yIj72Dpss/YuGEVjY0VREbegUbrwFc7HvtBBReJwYPvIiZ2JWFht3Mh4TMMhnrsHbx7pddVlmWOH3+NPbt/3mK7SmXD/PlvM2ToT65qa8Zk0pNw/jPi41+nqOi8ZUy0WmPPL36Rj0pliyQp+vQy14J1iKEUgtCNJElBVPRSvLxiUalsmTLleRQKNSNGPERjYyUXEj4nLu5Oho946Lo9FUZjI5KkQJbNSJLimrU4jUYden0tLq7BeA8Ygl5fi1brREHBdxw/9iq3z3+7RW/K9d+DhFKptrx2cwvFzS2U0NA5DB16D5UV35edy8r6lqLCcyDLSJISWTYhyybOn19DfX3J9xN0ZDM6fQ0FOQdITd2Bk3MAQ4b8qEPxKBQqwsLmERg4lezsfR1+H4IgXJ8sm1CpbFiw8D1MJj1OTgMxmfR8vffXNDRcnRjLnD+/htTUHfj6jiQn5yAmkw5f31H4+0/AxsbFkmTKskxjY+X3yaja9rpzFxobKzGbTcSfeJ3bpjzX6sZZkiQUP/jODA+fz7hxv2BQ4GR0uprmIWAyDQ0VHDr4AsePv8bVk20DA6cyafLvUKvtRUIsdIlIjAWhE7y9hxAaNodJk56loaGcxYs/IjpmOZIkkZy8mcyMr7l9/pu4uoZ06Es5P/80apUNp0+/S0TEIsLC57XZLjX1SzZtXA009a6WlV5k9JjHiI1dxcJFH6JQdN9H2d09HHf3cMvroOAZluL6Bw78iZqaAlKSN7eq2ezlFUdmxl5sbd1xdw8jLm51p67r5DSQVau3sPbzxSI5FoRuMijwNoKCZwBgb+9JTs5BMtJ3YZZNGI1t1/tubKwgM3Ov5XV+/ileedmXx59Ip7amgOLiBGRg37e/p76+FICIiIUsXPQBNjbObZ6zsPAs69Yuobr6Es7O/tw25bkOxe/k5E9g0BRKS1PYuuU+Zsz4G55esbz6ij9GYyNXkmJX1xAGBd6Gn98YgoOnt39SQWiHGEohCB0kSQqmTH2eyZPbrvtbUHCmaYZ3J8sTNTZW8p/XI7jjjk8ICZ3dYp/JpOfQwb9y8eJWCgvPtoonKGgaCkVTz69CoWTe7W9gb++NSqXtVAydlZtzCJ2+hm++fpaysos4OPiwYuUmbG1d2bTxTubO+ze+vm0+pbqu6upLbP7ixxQWnkGvr8NsNnRz9IJwc7OxcWHEiIc5d+6/zJ33H6KjlyLLMjpdFTu+fIQL7dQGbk9g4BQqK3OuuZBRwKDJaNT2ODkNZMbMf/D13l9R3bycfXlFOuVlTZP/XFyCeOLJDPT6GsxmE5KkQKXSsnfvr8jM+JrS0mSUSi1qtS32DgNwcw1Gp6smPGIBKpUNuTmHyMr6Flk2M2jQZEaMfBhHx4EMGDCka//BhFuOKNcmCN1g+PAHuX3+m93aOwtXxvsaUChUrYZeJCZuYNPGVR1e1luhUDN/wTsMG3Zvt8Z4LSaTgbS0r3Cw96am5jJ1dSUMHXYvSqX6hia8mEwGZNnMhvXLSE39shsjFoSbl4tLIMEhM5k162XUajtk2YQkKampuUxGxh727H4Gvb6mw98nXdc0VMtkMtBWTXE7O09mzvoHhw79jarKbGxs3QgOmkZCwueAjEply+3z3yQ2djWnT7/Lt9/8jlWrtxAYOKXF/Aho6hDo7u9k4eYnEmNBuEGxsauYv+CdG5rw1hU1Nfls2XwPly/HYzDUd6j31Ms7DmenACRJwbzb/9MrPchX1NWVkJm5l7i4O2/4XLm5h9m4cRU1zT1OgiC0ZmvrzoKF76FUqnF09MXHZzhAcw9xNSaTjvXrlpGbe8jKkXbc1ROXKyuzKS6+gLNzAN7eg60dmnCTEImxINwArdaJRYs+JCp6aYvtOl0NKSlbCAuba1kuuSdc6T3d/MXdJCV1rl6oUqkhbvBdBAZOYeDA0Xh4RPZQlE2aVssydUsPjtls4ujRl/j2m98REDAJZ2d/cnIOUlWV2w2RCkL/5eoajL//eEBi9Oif4TtwdKshXJmZX7N+3VJMJgMRkYtQKtQ09d5e3e6Hr9sjk5z8BQZDfbe8h7ao1XZERS3BxsaVOXNfE2XWhB4jqlIIQhcplVrmzftPq6QYmsb4NtXI7N6ZzwZ9HTk5hzh58s0W2wsKTnf6XCaTnrNnPuLsmY/w8orFxSUISZKYM+dfODj6dHtPsiRJSFL3fK0oFErGjfsFXl5xeHhEYmfnQV7eEdatvUOs5ijcAiRUKm3zBLOm11qtIwDBIbOYP/+tdo+2sXFhzJgnkWUzt015rkUVms4ym43o9bVkZe3r0cTYxsaFuXNfB0lCp6uxbJckCY3GsdPzNwShK0SPsSBcg1brzIIF7zRXnfi+50Knq6GiIoMBVy293V0qKrL4YtOd5Oef7tFJZ0qllpkz/8GYsU/0yPnT03fTUF+GWm1HROQiMjO/xtbWtcsT8uLj3yAleTO5uYd/UHdVEG5OkZGLCQyayq6dT+LqGkJQ0DRmz3kFSVKiUCivWdrxamZzUzWZqyvkmM0mLl86jn/AhBZtZdlMSvLmNitVlFekc/jQ365K0nuOSmWDSmVLZORi8vKOYGfvSVVlLk8+lSnGEgvd5oZ6jCVJ+hCYDxTLshzbvM0NWAcEAtnAClmWK5r3/Ra4HzABT8iyvLsb3oMg9Lo5c/9FTOxKy2tZNqPX17Fn989xdPTtdGJ8pSC9SmXTYnt9fRkXU7YybPh9KBRKzGZTj1diMJl0GAx1lvrJ3U2l0qJS23LkyIucPfdfSoovsHzFhi6fb/TonxEZuYgN61dw6dKxboxUEHpOVPQygoKmkpX5DSEhs9mz5xnL5+4Klcq2+btBh0KhZurU53H3iCQgYCJ6fS1OTv64uATi4zOs09dXKJQYDA0YDE2T1QoLz3Di+L8YPeZxSxujsZHCgrMcPvx30tN3WulpTNNqmVcW45gy5TlGj3mC/PyT2Nm6U1p2UQyrEHpNR26/Pgb+A3xy1bbfAN/Isvx3SZJ+0/z615IkRQOrgBjAF/hakqRw+UoRVEHoRwYOHN3idXl5Bm+/NYSY2BVMukbJtvbo9bWkpGxtsehFRUUmX375CCtXbgLA2TkAR0efGwu8g5JTtuDpFUtExIJuP3dg4BQAvL0H8/q/w7CxccZsMrZ/0HU4Ofnh6OjbDdEJHRUePp/y8nRKS1OsHUq/JJuNBAVOxdbGlZjYlQwecjcHD/yZiqvKnU2a9DsqK7NISPiM4KDpDB12n6WH197eE1fXoC5d22w2kpKyhfj4N7h86URTPM0/xQsWvs/lyyfx9h5MwvlP2bXrafT6mvZO1yOCg2dia+eGra07IcEzcHULxc0tBKVSiyRJlu9gV7eQXo9NuHVdNzGWZfmgJEmBP9i8CJjS/P//C+wHft28fa0syzogS5KkdGA0ILp4hH5DpbIlOnopTk4DLdtMJj1HDr+I2Wxk3Lifd2m8nlbr1CIprq8vZdPG1VRW5Voei5pNhhaliHqKu3s4S5b8j4aG8h69jqOjDyNGPMi582v47sz7eHhGoVbbdXms4Pjxv8DVLYRjR19G3G/3DKVSw+gxj1NXV8KcOa9SUZHJp2vmUV9fYu3Q+p2UlC1MmPgbYmJXIUkSarUd02f8rVU7b++4bltyubGxih07HsVoqOdi6nZkc8vPiSQp2LLlHoqLEoiNXcXk237P11//ptcSY4VCjZPTQGbOfImg4GnY2rr1ynUFoaO6OmDHW5blAgBZlgskSfJq3j4QOH5Vu0vN21qRJOkh4KEuXl8Qup3WxpmQ4JlMn/F3nJ39LcmqTlfNji8fJSHhM8ZPeAYvr9gbuk5O9gFq64o5euQl8vNPsnLlF5ZFOpKSNpKe3vOjj2zt3FusbtdT1Go75s77D+Mn/JI334jhYso2Zs95FX//8dTXl1hKS3WUn/84fAeOwt7Og+TkzWJYRQ+YMvV5IiPvoKzsIvHxb1BUdN6yupnQeRs3rGTmrJcIDp6Bra1rj10nL+8o1dWXORn/H3JyDl6znSybSb24DYAjR16ksbHymivgdReNxgFn50FotY74+09g6rQ/oVLZisl0Qp/U3SPZ2/orb3NinSzL7wLvgph8J/QNHu4RLcbBGgwNgIzBUI/BUIezcwCDB/+oy2PdGhubVp3KyvqWuroiy3alSkte3hEkScHJk2/2Sk9oWWkqGzesYvacV3p8eEJTfdWBxMXdxdmzH7Fp46qmBNdnZKcTY1mWMZn0jB33NG7u4WzauJphGpfzvAAAIABJREFUw+7j5Mk3eij6W49SqUGhUKFUaAgNncP+fX+wdkj9WlVVDhs3rOChh05hazui284ryzJGYwMGQwO7dj1JdtZ+amo6V/Nbls2cOtV+dYuucHTyY9asf1peazWOuLgGotE40thYgVpt1+3XFITu0tXEuEiSJJ/m3mIfoLh5+yXA/6p2fkD+jQQoCL3B0zOGpcu+Xya1pCSJtWsXU1tTADTVDb37R7tuqA6w0dhIYuL6VomvyWRAqdTQ0FDOpeaxgD2toaGMxMR11NYVcc89+3r8emq1LdHRy0hN3Y5G44iL8yD8/MaSmvolYWHzOnSzUV19iZycQ+z86jHmL3iXyMhFTJv2Z2qa/42E7uPiEoizsz+FheesHcpNwd09HBsbl249Z1bWN2xYvxyTyYDBUNet5+6ogQNHc/lyPFqtM0FB0yzbnZ39ib1q4vLVnJ3929wuCH1FVxPjbcBPgL83/+/Wq7Z/JknSKzRNvgsD4m80SEHoSS4ugSxfvt4yyaWqKpcN61dQXpbW3EIiKnpZl5Nio1GHLJs5cfxfbS7FeuTwi9TVFWM0NvR4NYrWsTX02rXCwufh6RlNTU0+RqOO/2fvvuOjKrMGjv/ulPSQ3oBUSIAklNARFATpAlJCUVERdV0rttV1X3ddC6u79rauZS1rQTqiiCAqAlKkEwidQBICpBAS0jNz3z9uCESSkEymJTnffPJh5pbnniGQnJx57nkWL74ZL69Q5jx0HFXVFjHRqpW194U2m02YKkspLz/Ppo2vkLpvIWbVxP7UJTWO0+mMdv97bCn8/WOJjR1TtUiLkc2bXnN0SM2STmeoapWm0qZNOFOSv6q+gaygIJO0tJ/p1u0mi8betPFVsk7t5NjRHygtzbdi1DX/7+h0RnQ6fdUCQ6ZLjjHg7x/LNYOfIiJiIN+vfIiCgkymTV9s1ViEcJSGtGv7Eu1Gu0BFUTKAv6ElxPMVRZkNnACSAVRV3asoynxgH1AJ3CsdKYSzc3P3Jyg4HoDs7FSOHllNdvbe6v1du97IwIGPWTz+ul+eZ/Pm1ykvL6K2mUWtbZ5sXt5h8vIOA3D9uHcpLMxk8aKbOH16D1OnLaRDhxG1nufrG0l8QjIrVtxHevqvpKf/etkxOp2Rsde/w/Kv77Tpa2ipPDwDCQjoxJYtb9G3732cOLHB0SE1SwMGPExa2s94eYUybNhcAoPiq/dt3foufn4xFo/dI2kWOT88QWGh9d6M9fAIJCJiEPHxySxerCXsXbvOYPiIf7F37wLWr5tb3YM8sesM4uLG4eLiCcCkyZ/b5YZhIeylIV0pZtSxa1gdxz8PPN+UoISwp96970ZVVVavepQjR1Zx5kxK9T5F0XP1NU9e1nu4MXr2upN1656vtVrcWqiqyuHD313W9mvzpjcorzhf3U5q/boX2LXrU/r1e4CQkG7VVauG0uuNtG8/gAk3fMT3Kx+yekWtNVAUhX797sdkqqCOW0REFW3VS21ZZVU1E58whU5x4wkO6Ups7FgiIq++7AazoUOfbfR10o79RErKV4wY+TJbNr/J9m3vNzFuHQaDGyNGvsy+fQtRUJg6bTFHjqyqPmbXrk/x8gpj6LDnCAnpSmTkNbWO1ZTvjUI4I1lGRrR6Wza/iZdXKHv2fMH586dq7Bs48DECAjo1afxvlt/ltElx2zDr3QxUn/PnT7FgfvJly8keO7amxvO0NG2+8/7UJeh0RvoPeIi2YT0Ja9sbb+8wTp3aWb2a1+95egYzfvyHBAXFExQUj79/LIsWzqCgIN02L8oG2viEExTYhSNHVuPopHTf3gUUF+c6NAZ7CQ5OxMXFu9Z3b9zcfAmPGERZaT4nTqyv3u7q2obRo98k/1wa3t7t2Lb1XSZO/NQmiWJe3mG2bXuPlJQvqagobvL3k+jooSRPXYirqzddu97E1t/eQVXNpO5bRGzsWLKythPWthc5ufs5enQNHTuOtNIrEcL5SWIsWr0zZ/Yw78vLe4h6e7clIXF6oyqWtfl9Mug8FAYOesKmV7jQRWLL5jca9fdw4di1Pz8NQGTUYHx8Ijme9vNlS0Lr9S4kJc0mPn4K0TEXbwCKiBhIhw4j2LHjw6a/EBtTFD2urt5MnPg/AgLieO3VCMe8Pa2qmM0mdDo98QnJrFnzZ86dc8yNXfag17swYuTLxMQM5/z5U3zy8RBA+3ooig6zuYKAgDimT1/KqVM7+OD9/iiKDkVRCAjoRPcetwDav3N//w42SYo3rH+R/fuXASplZQVWGVOnM+Lm5gOAq6s3Awc9DsC48e+hqmZOHF9HZNRgq1xLiOZGEmMh6uDm5ktoaHdHh2EzgUGdbf426KGD37JkyS1N/oF+PG1trdt1OiNjxr6Np0cwEZFX19hXVJTt1NVivd6F6OhhGIzuuLn64OUdysGDy9m+7QOHzdnMzPyNbVvfpU/fe1m79hnOFWQ4JA576dZ9Jj173oFe78rhQ99Vbx869DlCw5L4/LNRnDy5jZXfPcCw615g9Jg3iYkeiodncI1fmBVFqV7t0VoqK8s4dmwNKSnzOHVqp1XHro+i6CQpFq2aJMZC1EG9pHpm6flHj6wiJ/eAlSNrGp3OwHXDX6RDhxF4egbZ7DpHDn/PsmW3U1p61mbXMJsrWP71nej1rjz62Cl27VpEetUNY4WFmTXmTDqKTmfg0hbvvXrdSV7eEXr0uJWExGmUlxex4tt7WL/u8hXR7E1VTeze/TkJidOpKD8PTjoFyBoCg+KJCB+EqqpcqMYqig5VNWM0uhMW2oOOHUdz9OgPlJScRVEU+vT5o11iM5tNrF//D9b+/AzWnlKj17vSq7esrSVEXSQxFq2Gm5sv7dr1o7Q0n8zMK/cLLizM5MD+pXSJn2zR9YrOn2L+/CmUl5+36HxbGXLtM/TvP8fihUoa6kz2XrstI6yqZo4d/ZG9KfM4evQHu1zzgvDwqygqOkNh4Um8vdtRUJBBG59wCs6dIDLyGq699tnqVl3nzp3A27stLi5e6HQGjhxZzbpfniMra7tdY66Lm5svffr8kdTURWzd+q6jw7Epb+8weiTdVv180NV/5lxBOnl5h/DxjcTTK4TkqQuorCzFaPTAaHS3W2y7dn7Cul+ex9pJsYdHEOPGv2e15aeFaIkkMRathMKo0a/TvfstZKRv4sMPB9R7dKdOE+jWfaZFSbFWaa7kt9/ecbqkGBRcXbxsnhQXFZ1hb8p8m17jUmZzBfPnW/YLTFPExo5h2HUvsGzpLIqKzuDu7ofZXEly8nxyclJJSJhWoyuBdnOnSmbGJnbu/IQ9e76wy0qHDRUY1IXErjN4/bVoKitLHR2Ozeh0Rnr1+gOg/VKlvTNkICnpdkJCuuHi4kle3hHy848RE3Od3eOrNJVadTpNSGh3+va9Dx+fiDrbIQohNJIYi1YhICCOjh1HN+hYFxcv4hOmEG9hpfh8YRbvvtvDplMILBEQ0ImYmOtI6nlHnceUlRWQmbEFF1cv2rfvb/G1Fi+6qUFV+ebExcWLdu37UVFeREbGJgCOHfuJjz8aTGnpWTw9Q/D1i8HLK4yQkG61zk8PDk4AICNjEz173UFwSCI/rH7crq+jPiHB3fj5579btUeuM0pKur26apqdvY916+Yyduw7hIdf/IXZxyfC5sul24Oi6IiNHUPPev7fCyEuksRYtAq9ev8BD4/ABh3r59+Bbt1utvharm5tiI4eyt69X1k8hrUEBHRiwICHAAiPGEhwcOJlx5jNJvLz09iw4Z8UF+ewP3Ux7u4BdImfzJAhf7MoObDW3fP2olXQL1Z2O3eZSIffVQrd3f2JT0impCSPpUtu49ChFZhM5ZhM5QAUFZ1mb8o87rpr62W9a3+vc+cbqsYMYMf2D8nNPWjdF2Sh8ooiMg5sctr2gpbq3uNWXF3bsGXzWwQHJxDWtlf1awwOTmTy5C8uO0evN6LXG+0dqlUpip6eve5kyJCnHR2KEM2GJMaiVfj5p78RHJxITMx1NRbwqM24cU1rnu/i4kV4+ACnSIy927SlV+8/1LpPVVXS039lx/YP2b9/aY0Kd0lJLtu3vUd29l5uv319rec3RwEBcXi3aXfZ9u7dbiE2bkz1cxcXL4xGj1rHcHf3Z/KUL6mo0NqYFRZm8f33D3HmdArBIYm4uHo3OB43Nx8MdVzHETIztxDbcRQ5Ofsva4vXnAQFxaMoes6cSSEi8moSE2cQFTUEL89Qune/hTY+7R0dos2FhiUxffpSPD2D0etdHB2OEM2GJMaiVSgvL+Tnn/5GdPS1rF3793qPdXNt0+TrRUVfi59fB86ePdLksSylKDqSkmbXuT81dRFLl95GRXndfWpzslM5dGgFsbFj6jzGmel0BoYOm1u9fG1k5DW1Vs0by8XFs3pMT89gbr31Rw4f/p4OHUZcsVp8waZNr5OauojTdmzFdSV5uQfJ9AhEpzc0m8T4QieJC4+DQ7qSnLyAnJxUFi2cwYwZX1f37L36micdGWqDKdXvXigoilLdOaOhZ4eF9WRK8jx8fCJsFKEQLZckxqLVOHlyK6+83P6KnRLOZO8jILBpq925u/vXWXG0H4UOHYbXuqe09Bx7U+bXmxQDlJTksW/fIiIjB1cngs2DQnj4APr0vY/ExGk2v9kQaPTqYB07jmTV9w/bKBrLZaT/6ugQGsxo9OSP9+zh+5Vz8A+Io0+fe/j5p78SEBCLj084Dzx4FNdGVPCdRfcet3IyazsmUxnDh/+T3bs/Z/WqRy87ztMzGH//WLy8QvHziyYzcwv9BzxMVNRg3Nx8HRC5EM2fJMai1TCbKygqOn3F49b+/DRduky0+DolJWdZtOhGzpzZY/EY1nLhjvsLq3Wpqsq+fQvZmzKP1NTFDRpj547/ctVVjxIU1MXG0TbdhQS4W7ebuX7cf2y+gElTtGkTTnz8FPbutV/3jpame/dbaNOmPX373U9k5OCqbbcCYDC44eXlvF//+hiNHowe/TqZmb/h5RVKx46jUM2VrFnzZI353zExwxk/4UPST6wnOmaYAyMWouWQxFiIS/j4RDJx4v+aNEZ5+XlOHHf8vFxVNfHuv3ug0xkYe/2/cXPzJSdnP9+vnOPEy1Rb5kLXkYGD/gRo/XidOSkGqKgo4siR1Y4Oo9ny8AgiMXEaer2xRku1mA72b69mC0ajB1FVK9AFByfg5RXKjz8+VSMxTk1dTLfuMxv9boUQom6SGAtxiZ697iQktFuTxnBz86VLl0mkpi6yUlSWu1Ahn/dlExv6O3mXgmsGP9WkTiL2culc0R3bP6S0NN+xATVTPXveSZf4ya1q6WKj0YPExGkYXbwoLz/P/tTFdOo0AVNl85gLLkRzIYmxEFWMRg/a1NKxoLFcXb1JSJzKkSOrKC8vtEJkjvfNN39k1u2/ODqMWmjL9HbpMsnRgVzR6dN72Lv3K3bu+Bigaq67dVc2aw06d5nEqNGv23UlOmdgNLoz9vp30en0mM0mhg9/EVdXH7vMnxeiNZHEWIgqQ4c9T48et1llrISEqWzZ/CYnTjh+SoU1lJTkNvhYrSpqHz163MaIka9gMLg26rzG3eV/gdLgjhOXKinJ45e1z5KS8hXnz2c1+nxxkcHgTlKPWa0uKb7g0htgm9fNsEI0H5IYC1ElLu56q443ZuzbvPvvHrSmqmBlZRlr1z7DKTu0IOvQcRSjx7zZoKRYVVWysrZhNmnL7O7Y8SGHD69s1PXGjX+fjh1H1dhWUJBBwbkMQLvZKyS0OyZTGaeyLr7+1T88zonjzlhtbz4URc+Aqx6mX78H8PZu+rs6QghRF0mMhbARP78YOne+gf37lzg6FKtQVbXOiqmqqqSl/UTKnnls3960BVIa6mzeYX755TkGD/5rrTfa5eYeZPs2LRYVM1t/e5fKyhKLr7dk8czqjgcXZGRsJL2qvZmbmy9JSbMpLctnx/YPLb6OuJyrqzfXXvtso98ZEEKIxpLEWAgbcXHxIjFxOkeP/tDs5xrn5h7ih9WPE5+QXOv+H1b/iVOndtr1ZrK8vMNsWP8ie3Z/Xj3PUqczMG78++ze9SmHDq2gqOiM1a5XXJzDxo0v17m/tDS/3v3Ccn5+HWQurRDCLhR7zgesMwhFcXwQotW7/4FD+Pt3tPq4H380hOPH11p9XNEw/v4dcXcPIDNzs6NDEY1kNHpwzTVPkZA4FT+/GEeHI4RoIf7+tLJNVdXete2TX8GFqHL27FGbjDt69OtS7XKggoJMsrP3OToMYYHAwC4MuOoRSYqFEHYjP62FqLJ69eM2GdfTK8Qm44qGqawsafZTWVqrYcPmotcbHR2GEKIVkTnGQohmxdXNB1/f6Fr39e17L1FRQ6qfm80mtmx+k/4D5gDw809/Y8+eL+wRpmii+ISpREQOcnQYQohWRhJjIaqcL8wi7dhPREVf6+hQxCVCQrqRkDCt+nlgUOdGLegxZuxbgNY5w9XVx+rxCdtwdW2DwdA6+xULIRxHEmMhqhQVneZE+q+SGF8iIKATBoMrOTkHMJnsv/RsYGAXZty4HB+fCIvHKCsrJC/vMMu/vpO8vMNWjE7Y0r698+nR/VapGgsh7EoSYyFEraKjhzEl+StOndrJwoXTKCm2PDFO6jkbH5/Ieo/JytrOgf1LAdAbXBk48HG6dr2xSUmx2Wxi1apHqvsZi+ajrKyAnbs+oX34APanLqZzl4nodPIjSzipunprNX6xTOFg8l1GCBs7dy7d0SE0mr9/LAkJU/HwCCAkpBturj6UFDd8WWgAd/cAJkz4kICATvj4RmA0etR7fGlpPucL/wGAotPh79/R4m4eqqqSk7Mfk6mMfXsXWDSGcBxF0RMY2Imc7FRU1Ux4xEAURe/osISoZqgAv7PaY0WFMSvAs+jy41aOgoI22uNiDyjysl+MwjKSGAthY6tXPYqqmh0dRqPcdPOK6p7OHh6BDBjwMEXFORQXZ/PblreveH7PnnfQJX4KHTuObPA13dx8cXPztTjmC3JzD7Fr1yds/PWVJq10JxzH3d2PP9y9s7ojhbd3WwdHJFo7n3xI2nHxeZsC6Lmj7uMvmPnZxcdpkZAWVXN/iTts7odUlp2IJMZC2FBJSR4VFcWODqNRPDyC0Otdqp8rikKfvvcCkJ2dWm9i3LZtHybc8F/8/GKuWCG2trKyQvLz01i4YBo5Oal2vbawnvj4ZK4d+oxMmxAO41UIbqXa46BsuPYnMFaAXxMX9ow6rn1eyqSDXttqbjsYBzt7XHxe4t56Ks3uxZdX3vN9odKOXRvlO48QVTw9Q4iIsO6NPnt2f87Jk1utOqatDRjwkEXzesPDr2JK8nzatGlng6jql5q6hNR9C6UVWzNnNHrQtduNBAZ2dnQoopXxy4Nuu7XHcQeh7cmL+2xZzNWbITi75ragbBi44eLzzHZwKBZOtoVDcTYMxoHCT0DMUYio+vNS23tenI6S2Q4Ox9o2FkmMhaji7u5HcHCi1cYrKjrD+vUvWm08e9m0+XX27Pmy1n2Vl3SmcHf3x90jEAAvz2CmJM/H2zvMLjGCViE+l3+cr7+eTW7uQUpLm1jOEQ5nMLgREBBHbs4BXN188PIKdXRIogXxKgTXqm9hYVlw9bqL+1zKm14RtpbfJ+LtM7XPYnco9IYjHWBbL22fWQdn/Wo5ycm5F4NHMXRJha57tMfe52s/ttf2i4+L3eHr8ZAebrsquqKqdd1KaT+Kojg+CCGAa4c+xzXX/MUqY23Z8hbfrXiAum9Xdh5eXmH4+kaSkbGpQce7u/szeco8YmKuq96mKPb5zpydnUpq6mKys/eSUkcCL5q/sLa96Jp4I/36P4hOJzfeCcvpTNB/k1YRDjl9cXszyyWrXfoTpdIA666GCiNs6g+qE69n7FF0cdpI9DHtExr/dVDRKscpidprtuQL+fenlW2qqvaubZ9UjIW4xG9b3iImZhjt2/e3eAyTqYKtv73DmjV/oTkkxQBt2/YmMLDzFRPj9u0HMPb6d9DrXQkM7Gy3ZLiwMIsjR1axaeOrlJbmc+7c8SufJJq1rJPbOJt3hITEaQ6ZniOaP69C7W35gRu06Qm65vHt+Iou/a5rrIShP4FZge67tG3HI7Ub+spcHT832b0YJi0G70IwVEJg45ob1UpBq6CHZWk3QW7pq81DttZvOlIxFuJ3goO78sd7dlt8/rlz6bz2aiTNJSkGeHDOMbKzU9m3dwE7d34EQGTkNYSHDwSguDibnJz9JE9diJdXiN3iqqwsY/Pm19m18xOys/fZ7brCefRIup0JEz6sdd+BA8vp2HFUdfcKIeBihbj7Lgg+03wrw5a68JPndAgsSIbcQMfFMnSNNmXFVl8DFa1avnAKHOzU8POkYixEI+TlHWLbtvfp1evORp9bWprPypUP0lySYh+fCJKSbq+aShFFVNRg+va7D9BaZF2Y41lRUUJpab7Nk+LCwiwqKopZv/4fZJ3cjqqaOH16D83l71NYl4uLF10Tp1NRUVxrl5OQkK7odHqKis7g4RFocd9rYR86E/ic07oOjP324vZiD/jm+oaNEXMUel9yP3NalFYxBK0y3C5T6ysccrr1JcQXXHjdoafh5s+g1E2bcrFsApzzgQqXek9vGlX7GuvM4JsPPbfb9uugAC4VcMNSWD5Oq5YXezZxTKkYC3G5mA7DmTz5Szw8Ahp13saNr7Dq+0dsFJV1RUUPZdq0Rbi6+thtSkRtTp3axZHDKwHYseMjcnMPOCwW4Zx6JM0ivstkYuPG1rp/b8p8One5oUabQeE8euzQkmGPYrjqV23bpd9xGpsA1Hdua02Gr+TC39Oerlol+UAnyAmyztjeBRc7eoD2C4p7VQt5e349VLTOHbu7ab8s1TffWirGQjTS0SOrq6pQDUuMS0vP8e03d3PixHobR2YdwSHdmDz5c6ssqNEYZrOJgoJ0Skvz+Wb5HzCrJoqLcmTOcCvl4RFEcXH2FY/bueMjVLO5zsQ4rtM41q2by5AhT1s5whakqpLXdwtEpYGqaHf3l1/yu0SF0XpzUt1KYMIybQ5o8BltLmxdmpI8SSLcMBf+nrrtAfZoN8GVuF/cb9Zp/x4q6piV1HM7dDhS+z6XcgjKsWa0llGAdie1ucc+5+DHoZb1P5bEWIg6HDiwjKCgLlc8bveu/7F373wOHvzGDlFZh4uLp91bYWVlbWf//qWs++X5ZrcSoLCNMWPeZNGiGxv07+HMmRTy8o7g79+hxvacnP2k7ltEXu4hW4XZrClmLRk2VsDgtdoNUApade2P/655bJ6/1gbsnA/stbRzpaqtEJeYok17kMTVOfmfBc5efK4C97xT/znN5WupU2HARm2RltQuje/9LFMphKiDweDO0KHPktj1xhr9eQsLszCbKzh//jTfrbifM2dSqKgoqmck5+Pi4kVQUDz+AXEMG/Y83t5tbbbSWFlZId+tuI+0tLVSGRbVEhKmMmbsO+TlHUZVTezY8RE7tn9Qvd9o9MTXN5Lrx73H6lWPkZGxkYCAONzcfDEYPejT5x727Z1PcUkuHTuMpPB8FqNGvebAV+Rc3Iu1dlgDN2gVtMZ0ZChzgezfvc2+s4e2IhtovXQvfZtaZwKv89qc0hGrtPm99VWIhbCXYnftF74TEVWt3ao88mrdUykkMRbiCjw9Qxg46E/Vzzf++gqFhSdpOTeEKVx9zV9wd/cjKel2q06vSNnzJXv3zmf//qVWG1O0DH37PcDo0a8DcP78KV55uT2qagKgS5fJxCckk5CQDCh88flYDh/+jk6dJ+DnGwNAWNuedO16Y9VoWi3LkXPlnYl/LiQvgNBT1qvyXfrd7pdrar4N36ZAq9BB86kqitbl9z+tdUhiLIRogITE6UyZ8iX5Z4+xevXj+PhEMGLkS3UebzJVcP78qcu2lxTn8O2393LmzB7Ky+tYzki0apcmxkVFZ/hxzV/oEj+Zb5b/gYmTPiMy8urqY7OzUyktzScwsDPu7n6OCtm5qVqv2Kt+hdhD1ukXK0RLpdSTGMscYyFEtfQT6zmZuRUf3wjCwwcACps3vU637jNxd/evPq6k5Cy7d31KUXEO6355vo7R5Pdd0TAeHkFcP+49QOup/fu6Y27uQYxGd0mK69ElFSYvAr1JqrZCNIVUjIUQNfj4ROLu7sepUzurt4WF9aR791tJz9hIQUE6lRUlZGVtr2cU0Zp5eARRWVla3X+4vLwQo9ETV9c2xMVdT/fut+Dt3RY//5grjnXs2I98t+IBYmKuY9RomUP8e94F2spiIafBo8TR0QjRPNRXMZbEWAjRQBfuZRetUfv2A/DxjWBvylcAtGvXDz//DqTs+YLErjfWeEdh4MA/kZO9j/SMjYSHX8WBA8uJjr6WTp0moChKoxbiUFUVVTXXe97RI6uJjBrSqlbAiztwcQGF1ryYhRCWkMRYCCFEo+l0Rjw8AvD1jWZK8jzc3f3JOqm9U+DjG4mHRyBZJ7cR1rYXLi5NXG6qCXJyDuDv3xGdTu+wGGxO1To/DFqv3VQXfEYqxEJYShJjIYQQjRIefhWdOo1nwFWPArTspLMZSNwDE5doS+1KdViIppGb74QQQtTLxcULo9GDbt1mEhs3Fn//Dvj4RDTo3NLSc7i5+dg4wlZK1RbLGPst6GVdHCFsThJjIYRoxcIjBhIclEh8whSiooagKLpGzQEG2Ld3AUk9Z1NWdo6UlHnEx0/BwyPQRhG3Lgl7tUqxJMVC2IckxkII0UqFRwxi8uQv8PEJr95WXn4eg8EdnU5PTs5+Vnx7H/37z+F80SlCQrqz5ocnAOjRYxbdut8MQEJCMqmpizl6ZBXxCVPR610d8npaFFVLiq//RpJiIexJEmMhhGiFIiIGMX3GMtzc/Niz+3MqKooB2Je6iOjoobi7+ZGfn8axY2tIS/up6iylenU6FxdvDEY34uOnkLL3K5KSZtO58wRi/QWAAAAgAElEQVSbLS3e2iSmSKVYCEeQm++EEKKVCQqKZ9LkzykvO8/atc9w/PgvmExldR7v5uaLoujw8Y3iumFzq7cbXbyIiBhoj5BbBUOFtnrdmBXQPgPcSx0dkRAtk3SlEEKIVk+ha9cZnDy5jdzcg+h0BlTVXF0BvlRCwjSMVe3XFODaoc9WzRlWWlWvYHuKPahViRNTpPOEELYmXSmEEKKV0+n0jBz1GuvWza1OjA2G2uYCK4wY+RJt2rS3e4ytjb4S2hTA6O8gPF0qxEI4A0mMhRCiFWjffgAGgxvDh7+I2VxJp07jiIwcXOuxer2LnaNrXYLOQNuT0OGIdoOdVIiFcB4ylUIIIVqwnr3uJC5uHKGh3Rvcl1hYh74SDJU1tw39EWKOQlCOY2ISQshUCiGEaLV27fyU0NAkysrOER8/BYPBzdEhtXghpyDkNMQdhM77a+7Tm6Q6LIQzk4qxEEK0CgodOoyg/4A5dOw4ytHBNHuKGVzKLz73LoThq7XHAbkQmOuYuIQQVyYVYyGEaPVUjhz5ni5dJjo6kGYnNAuCsmtua1MAQ36++FxRwXB5gw8hRDNzxcRYUZRw4FMgFDAD76mq+rqiKP7AV0AUkAZMVVX1bNU5fwZmAybgAVVVv7dJ9EIIIRosJKQbMR1GODoMp6Wv1KY6APjnweC12uPgMxCQ57i4hBD205CKcSXwiKqq2xVF8Qa2KYqyGrgNWKOq6guKojwBPAE8rihKPDAdSADaAj8oihKn1tYsUwghhN14eAbh5xft6DCciud5iD6mPe66R7sxDqQCLERrdcXEWFXVLCCr6nGhoiipQDtgAjCk6rBPgJ+Bx6u2z1NVtQw4pijKYaAvsNHawQshhGgYvd4Fg8Hd0WHUylChJaKWMOvAVM9PMsV8eWeIpB0QlaY99iiGqOOWXVsI0fI0ao6xoihRQBKwGQipSppRVTVLUZTgqsPaAZsuOS2jatvvx7oLuKvxIQshhGiskSNfJann7Y4Oo5p/LoSe0h4PWg+BFrYvy2wHv/Wpe3/oKei/qeY2vQn0ZsuuJ4Ro2RqcGCuK4gUsAuaoqlqgKHU2nKltx2W1AFVV3wPeqxpbulIIIYQN6Q0ujmvVpl6s2nY8rC17HJALYaeaPnR0mvYphBDW0KDEWFEUI1pS/LmqqourNp9WFCWsqlocBpyp2p4BhF9yenvgpLUCFkKI1qR9+wGYzBVkndxq8RiensH4+kZZL6gGMpZrq7t5FMPIqluw9SaZuyuEcF66Kx2gaKXhD4FUVVVfuWTX18CtVY9vBZZdsn26oiiuiqJEA7HAFuuFLIQQrUN09DBumPgJxibODQ4J7UFMzHVWiurK9JXQZR9MWQjTvoLxy8G1XPuUpFgI4cwaUjEeCMwE9iiKsrNq25PAC8B8RVFmAyeAZABVVfcqijIf2IfW0eJe6UghhBCNEx09lGnTl3AycwsZGZuufEKdFNqG9bJaXPUxlmtdHYb+qE2VkCRYCNHcNKQrxXrqXsFyWB3nPA8834S4hBCiVXB3D2DkyJfZsOFfZGfvrd7er9+DuLh4sXHjq5jNFY0eV6czEBLagwH959Alfoo1Q76cqk2RGL4a+vwmSx4LIZovWflOCCEcxMcnkinJ82jXrh+5eYfQ6fScPr0bgG+//SMdYy1funnU6Dfo3v0WXFw8rRVurQJytNZnw1drSyRLUiyEaM4kMRZCCDvT610A6NRpPO3b9wdgwIBHSDv2c/UxFRXFqKpK7953k5b2ExWVpaA2vMeY0ehu06RYMcOwNVqXidDTNruMEELYlSTGQghhR15eofzxnhQURYfB4EpGxiZKinNZt24u6em/Vh9nMldw5kwKsXFjefiRTDasf5ENG/6JeoXkWFF0RMcMo02b9rZ5ASpEHoceO6H7LtBJs00hRAuiqKrjv6tJH2MhREvl7u7P8OH/YsOGf+LrG0WPpNtISJgGwNGjP7B0yS2cP197Q19//45MmTKP0LCemM0VpOz5ki2/vc3JzN9qPT40tAf9+88hseuM6qq0tShm8M2Ha36BLqngVmbV4YUQwm4UlG2qqvaudZ8kxkIIYTseHkHcNmst3t5t0ekM1dMbjhxZzfyvJlFefr7e87292/HAg0cwGFwBKCrK5utlszGZygE4fXoX58+fQlF0DLr6zwwd+pxV4w/I0RLixBRJiIUQLUN9ibFMpRBCCBsqLs5mwYKpTJu6CP+A2OrtG9a/QGVlKdrtanXXBrTE+eJ+T88gZtz4dfXzw4dXMu/LG0hKmsXgwX+1WtyKGfzOwtT5EHLmyscLIURLcMUFPoQQQjRN9pkU5s27gUsT3KnTFnHHnVsICupS77lmcyXZ2al17vf0DCY6eijxCclWmz7hWgoTlsGd70tSLIRoXSQxFkIIOygvLwRAVVXM5kpcXduQnr6B7Ox99Z5XUVHEwgVTOXVq12X7srK2s2zZ7SQnf0V09NCmB6mCzgSjVkKPXeBe2vQhhRCiOZHEWAgh7CAoOBGA0tJ8liyeSUbGZo4dXYObm+8Vz83LO0x+ftrlYwbFM3PmaozWaMumap0mHnlZ6zYhhBCtkcwxFkIIOxg8+K8oig53dz8mT/kSgP79HyIzcwulpflXPH/b1ncpKckjKWlW9TaDwQ2Dwa1pgamgqBC/D8asAJfGL7InhBAthiTGQghhR5WVZWRkbALgwP6lFBaebNB5hw+vxGSqwM8vBk/PIIKC4psci2sphGXB2G/B55wkxUIIIYmxEEI0kYKCWk9niUuZzZV4bkmhyz6VUrLY1IjrHDu2hhMn1pM8dUHTEmMVEvZWtWDbb/kwQgjR0khiLIQQTTCWsYxmNI/zOEUUXfH42JOezDhyL27ALGbhiy9hhLGGNaxj3RXPDw5OoEOH4RbF6lYCwWe0zxGrpEIshBC/J4mxEEJYaCQj+ZiP2cpW3HG/YmIcdQwmL9IWyXiDNzjMYR7iIWKJbVBSDNqS0qtX/YmknrcTGtrjyidUFbK77tHmEUuFWAgh6iaJsRBCWKgvfTnHOaYxjQIKuJd7WctaUki57NjytANM29Af91KFLLL4iI/YyU6+5EtccSWHnAZd8/DhlbRt24fOXSY26PiAXJg+T+YQCyFEQ0hiLIQQTeCPP0/zNAC96U0ccTzIg5cdt3TN/UykDZOYxGlOU4jW17iUUp7gCb7gC2KIYSEL672e0ejBrbf9iNHoUX9gKgTmaCvXBTUs5xZCiFZP+hgLIYSFMsnkAAcYwACiiGIDG5jMZPrTnySSahxbTjlppAHQgx6MYAT96MfVXM0c5rCKVYxghNViC8iFmz6H4GyrDSmEEC2eVIyFEMJC/636uKAvfbmZm9nIRs5xjg/4gLOcZS5zccGFTDI5xjGiieYd3qkxVgAB9KMfccRxkIO1Xi+JJLom3oZOZ6w7KBWCsiF5AfhduT2yEEKIS0jFWAghrGQLW7ie69nCFkyYmMpUnuZpjnKU0Yzmcz5nO9vrbO3WjW5EEVXrPh06RjOa0bEPoNfXnhi7lcDEJXDrJ1IpFkIIS0hiLIQQVrSLXfSjH7OYxWQm80/+SQQRfMAHfMEXGKmn2gvMYAa6Wr41z2Y2d4f+nTPBtZ+nM2kLdXTfDV5X7honhBCiFjKVQgghrMgFFxJI4Ad+oJhitrOdD/iAhSxkKEPrPTeHHIYxjN70Zj/7KaAAPXq60pUZyk2kdTSQF1D7uX5nodMBG7wgIYRoRaRiLIQQVtSOdmxjG8/zPAAmTBzjGK/xGstZXu8KeRlkUEklm9nMQAYC4IUXG9lIm6TB/FhLXq0zwZCfYNpX0o7N2ahX+BRCOB9FVR3/31NRFMcHIYQQVmDAwAM8wC3cwhrW8BRPUUwxAD74EEss/+E/xBGHF151jjOGMXzHd0wY9wFDomdR5KWjwuXifsWsrWB31a/QbTcotn5hok5ZoXAq9PLtiyfBlzNqP2fukxB7COIOgmexbeMTQtSkoGxTVbV3bftkKoUQQlhRJZW8wissYhHHOIY//pzkJO/yLumkc4ADrGAFAQTUmhirqGxjGwc5SGhoEhFRg8n3113YCWgJcfdd0H8T6M12fHFOoqGVFGv9svD7660aAWsHX3z+yzWwYVDjxpw2X/vzlk+gXebF7Xe+D9FplkQphLAGqRgLIYQNGDAQTTQv8RLjGMdVXMUmNhFGGOmko0d/2Tm55LKf/UxlKkbFlchBN3HtsGcBrULcaxsM2Agu5eB93t6vyLHy/CA9XHtc4g6zP4SKOu5jdCmHD+4A95KL27wLIeaY9lgFTkRA5Inaz1eB1C4Xx//0Flg+7uL+nEA469+UV1O7gBxYOQp6b7P+2EKIi+qrGEtiLIQQNtSGNsxjHqc4RQYZrGAF61lfa2L8Pu9zF3cBsMzwLaUTx7AvAVChx04Yt7zlVohr+yFQ4g7//BOY9LC7G3w9wfLxOxyGGV9qj806WDZBa21XaywKvPEAFLax/HqNpsJ9b8GbD9jxmkK0UjKVQgghHKSAAuYxj8d4jD70YTrTa23HlkYaJzmJHj3TmU7fyp7k74ZzPjD+a/DNbzlJ8dFoKP7ditbfj4T376y5zaSHwx2xypyIIx3huadqbtub2PRxm8pQoXUTefYpbb64EMKxpGIshBA2cCd30o52vM/7ZHJxEuk61jGIyyekXsd1nOUs05jGUIZW36jXEuT7wKsPXXz+39shI9xx8TiDNufgoVfB5xzMeU1unhTCnmQqhRBC2Flf+vI1X3Oc44xnPLnk0pGORBNNGWW8wAv0oU/18aMYRR/68CzPOjBq6zgaDWWucDoE7n1bm6t7KBbJ/qr452rzlseskL8SIRxBEmMhhHCAq7iKr/iKE5zgER5hAxtQUNjCFkIIqbH88wIWMIlJtc49bg5+uRp+HqI9fuceLSkGJPP7ndkfQPICGLnK0ZEI0XpJYiyEEHYSQQRuuAGQRx4d6MDXfE0GGexiF7OYddk5+eRjxIgnnvYOt0mORcFnN8OCZC0RPhNyxVNaHWM5RFd1w5iwDJ5+GjxK6j1FCGFjkhgLIYSdbGUrPekJwAY28B3fYcTIHdxBO9qh1FJC/Y3f8MOPjnS0d7iNpgLv3g15/vD6g5AdhFSFLxGQA3/4zyXPc7W5xBfIX5UQjieJsRBC2EkssXigtVwYxzjccCOMMOYxj9705k7uJIqoWhNkZ5YTADuS4LF/wf7OUObm6IisL+iMdjNcXXICId9PS379zl6+f+p8mPk/6HzAdjEKIZpOEmMhhHCQTWyiL30poIBkktnEJhawgJGMdHRoDXKhQvzVtKrV3ppXPt8gilnrITzjS201wbqsHAXrroYRq2Dw2jrGsk2IQggrksRYCCEcJI44pjGNJ3mSAgrIIIMgggjHufuVqcBP18KjL8HeBCh3dVwsoVngUdz0ce55B6796fLtigqJKWCsbPo1hBDOTxJjIYRwsF/5lQEMAGAb29jIRu7hnloX+3C0k2Hwv5nw4uO2Wfq4IbrtglErtcezPtIWwbAGqegKISQxFkIIB+tMZzzxxB9/BjCAucylO90BmMQknuRJB0cIpa6QFabNk91w+RokduFVqN3UN/RHiDrumBiEEC2bJMZCCOHE+tGPecyr0dfY3lTgz//QqsSAQ0qrHkXw0Sytz69UdoUQtlJfYmywdzBCCCFqSiGFdNIdkhirwMm28MEd8MrD2DQjDTkFLuUXnz/7FHTef/G5oRJ6bpekWAjhOJIYCyGEA7njzod8yCAcM3fhx6EweRGc88FmGemMLyD0FDzwBkScuLhdUSUJFkI4F0mMhRDCgbzxZjKT7d7XONcfbv5M6018zte6YxsqtEQ4+Ay8eT902w1eRda9hhBC2IIkxkII0cqkt4cbv4D1g7B6ybbPFhi3HP7yvPZcJ3eQCCGaEefrEySEEK3IWc7yLM9SRpldrpfnB9PnwfqrsWpS7FUIn98I86fCU89pCbEkxUKI5ka6UgghhAN44MEsZrGUpWSSyWpWcx3X2ex6ZgX+ezt8cqt1K8V9N0PfLTDyexj7rcwZFkI4P2nXJoQQTiaIIA5wgBRSmM503uM9ssjiDu6w+rXKXGDuk9pnpbHp4xkqIDBH62Jx1a8QeeLK5wghhLOQxFgIIZzQPdzDW7yFGTM6dKioVl8Jz6SDJ16Alx8B1RpDq9oy0S88ATqzVIiFEM2P9DEWQggHSK76mM1sCilkEpO4j/uq97elLQoKevQAVu9MUeYC//gzvDbHOkmxoQL++G/4+99Ab276eEII4WwkMRZCCBuJIIIpTMEHHxazmGurPuzBpNM6Q7zysPUqxXNe01bGk5vqhBAtlXSlEEIIGymmmBxySCKpuvPEOtaRTTb3cz/DGMYUpmDCZPVr5/tqq9lZJSkGZn+oVYolKRZCtGQyx1gIIWzk0mkSAGbMKFUfJkyoqAQTTCaZrGIVmWTihhs3cVOT5hqfCIebPrde94mAHPjfTBi9suljCSGEo8nNd0II4aQuJMajGMUa1uCPP1lk4YKLReOd9YXrv4FfB1opQBUWT4KJS600nhBCOFh9ibFMpRBCCAcawpAaN90NYYjF1eLjEdqqc79eZa3ooM9vMGi99cYTQghnJjffCSGEA93ETSxhCbvYhS++3Mu9GCz41nzWV5s+sWGQ9WLTV8LNn0FQjvXGFEIIZyZTKYQQwoY88WQyk1FQ2Mc+fuO3GvsNGFBRGc94PudzXHFtdMX4eERVUjwQ6zUWVuGRl7UuFNKaTQjRkshUCiGEsJPXeI3lLCeJJNxwwx9/PuIj3uRNJjHpsuNNmBjPeP7Df3DHvdFJcY1KsRXbILuXwANvSFIshGhdZCqFEEJYkRkzYxnLCEawkpX8yI8oKLzFWxzkIDOZyX7244Yb61nPRCbyBV/gimujr1WjUmxlf30GwtOtP64QQjgzmUohhBBW5IEHwxgGwBjGcBM34YVXjRvsjnEMF1zYznYGMIBAAht1jQoDnPWDiUus2H3iEnEHYMUY6HDU+mMLIYSjSbs2IYRwAD16Qgjha76mF70adW455exgB/3oV2N7hQH+/A946z4oc8Wq0yeA6rnFLz1m5XGFEMJJNGmOsaIoboqibFEUZZeiKHsVRfl71XZ/RVFWK4pyqOpPv0vO+bOiKIcVRTmgKMpI670UIYRoPkyYKKccI0aLzv99L+MKA8x9El6bA2VuWD8pBmZ9BM/81frjCiFEc9CQuzzKgKGqqnYHegCjFEXpDzwBrFFVNRZYU/UcRVHigelAAjAKeEdRFH2tIwshRAvnjjuJJDb6PBdcSCKp+nmFAZ54QUtaTTa6OyQgByYvAo8S24wvhBDO7oqJsao5X/XUWPWpAhOAT6q2fwLcUPV4AjBPVdUyVVWPAYeBvlaNWgghnNSLvMgsZuFZ9fEYj9WYX9xYKrD6OkheoFWKzbYqM6jQbTeMXWGj8YUQohloUN2hquK7DegIvK2q6mZFUUJUVc0CUFU1S1GU4KrD2wGbLjk9o2rb78e8C7irKcELIYSz8cSTd3mXN3kT0LpULGQhAB3pSGc6c4AD9KBHg8ZbPRwmLYYiL5uFDICiwvt32vYaQgjh7BrUMFNVVZOqqj2A9kBfRVHqe1+wttLIZTfXqar6nqqqveua/CyEEM3R4zzOTGbyJ/4EwP/xf0yt+viYjwEtWb6SPD+46TO47WPbJ8U6E8z+EMKybHsdIYRwdo2aqaaqar6iKD+jzR0+rShKWFW1OAw4U3VYBhB+yWntgZPWCFYIIZxdEUXMZz6eeFJIISWUMJGJAHSjG+6405OedZ5f5gLfjYZ//gk2DsAmN9jVoML9b2rXc6mw8bWEEMLJXbFdm6IoQUBFVVLsDqwCXgQGA7mqqr6gKMoTgL+qqn9SFCUB+AJtXnFbtBvzYlVVNdVzDWnXJoRotgwYeI7n2MMeFrEIgAgi2M/+Bs8vVoFSN/jHn+G5/wPVDuuS6kxw+3/h9QflhjshROtRX7u2hlSMw4BPquYZ64D5qqp+oyjKRmC+oiizgRNAMoCqqnsVRZkP7AMqgXvrS4qFEKK5m8McHuVRKqnkHd4BaPQNd6tGwPR5UOhtn6RYKsVCCHE5WeBDCCEs0Ja2vMiLACSS2OCb6Wrz47Xa0s6nwqwV3ZW5lsLxSAg5c+VjhRCiJWlqxVgIIcQl4ohjKEO5iZua1IoNtDnFSybaNykGeP4vEJRt32sKIYSzk8RYCCEaSI+ecMKZz3y6073J45l0WoL69r1WCK4RuuyD678BnbxXJ4QQNdhjJpsQQjR73njzPu+zi11WSYoBPr5Nu9nOLnOKqyhmGP0ddDpov2sKIURzIRVjIYS4Ah06/sW/mMUsq4xn0mk3vS0fB5VGqwzZYDozPP6ifa8phBDNhSTGQghRD2+8eZVXuY3brDLe5r7w1TR48377J8VCCCHqJ4mxEELUYRKTKKGE2cxu8liVelgzDG79BE6HWiE4C+mleaYQQtRJ5hgLIUQdetObecxr0hilrvDDMLjmF5i8yLFJMcDcJyEwx7ExCCGEs5KKsRBC1CKKKEYxija0seh8FTDp4dmntGTU5ks7N0DnVO3GO+lGIYQQtZPEWAjRasUSS3vaX7ZdQeFt3qYznS0a93gEbOoPD7wBef44RVIM0C4T4lMdHYUQQjgvSYyFEK2KrurjGZ5hLGPpRjerjW1W4MXH4evxsGmA1Ya1KrMiFWMhhKiLJMZCiFYjjjiWsQxffAkiCD16q41d4gZPzoW37nPebhPrrobPb4KZnzk6EiGEcE5y850QosXToeMf/IOFLKQznQkl1GpJsYrWl/jpp+G1Oc6bFAOUu2qLihR4OzoSIYRwToqqOv49NUVRHB+EEKJF8sWX7nRnCUvww8/q4x+JgavXQXaQcyfF1VQY+iP8bya0zXJ0MEIIYX8KyjZVVXvXtk8qxkKIFq0PffiZn22SFKvAe3dBVlgzSYoBFPhxGNz0OTzwOqy9Rpt3LIQQQirGQogWLI44vuM7Yoix+tjF7vB/zzX/Fex88qH3Vnjmr9rzqDSpJAshWrb6KsaSGAshWpxkkvmWb3md17mDO6w6tlmB70fCvOnw6S04TSs2a7lmLfTcDuOWw7U/tbiXJ4QQ9SbG0pVCCNHiXMd1nOMcwQRbbcxid9jdDR56FfbFQ4GP1YZ2Kr8M1j4/vg0WTYahPzk6IiGEsB9JjIUQLY4BAytZidKEeueFt7FeeAJyA7Sb6z691TrxNQf5fnDjF3DzZ/DECxCY6+iIhBDC9mQqhRCixQkllH3ss/iGOxVYNgHmvAaZ7Zr3HOImU2HQenjlYei6B9zKHB2QEEI0jUylEEK0Cnr0PMVTeOGFG26NPl8F0sO1G+revxPO+Vo/xmZHgfVXQ98tcCgWOh5xdEBCCGE7UjEWQjRrPvjQmc7czd28y7usYhVtaNOoMVQgJRE+nA0LkuFkO9vE2qypWr/mVx+ChL1SORZCNF/SlUII0WKNZzzLWGbx+Srw7VhtPm1h4/Lp1kmFu96DqfO1hUKka4UQormRxFgI0WL44EMkkaSTziu8wkhGEkaYRWNltIP1g+Dud2XaRGP558LmfjK1QgjR/MjKd0KIFmM4w9nKVj7mY27jNouSYhVIi4SJS2DGPEmKLZHnD5/cerF7hxBCtARy850QotkxYmQ84y0697wnPDkXlkyEjHArB9aaKPDPP4GqwMz/QaeDjg5ICCGaTirGQohmY1rVh6XMCjz+Irz5gCTF1lDuCs//HwzcAE89A6dCpIIshGjeZI6xEMLp6NDRmc6kk841XMNLvARAW9o2uuMEaMnawinw1LNwuCOY5L0ym4g6Bq5l8NKjEJUGLuUQewiOxkCJ++XHRx8Dz2K7hymEaOXk5jshhNPqSU+u4zpe4iVmMINYYnHDjUd4hIUsxAUXJjHJ4vGPxGjLG7/yMBR7Wi9ucWW+Z+GBN+CDO2pvgXf/G/DaHNDJTwAhhB1JYiyEcFp3cAcv8AJhVR/taMebvEkvejV57PT2MGYFpHS1QqDC6gwVEHcQnv8LTFgmrd+EEPYhXSmEEE7NHXf+wl9wwYU44qySFB+JgRuWSlLszCqNsC9Bu3nv27GOjkYIIaRiLIRwMD/8eJ/3mcQk0kjDgIFwLL8zrshD6zrx9XhIi7ZioMKm/HPhv7fD+K+lciyEsK36KsZyC4oQwqEiiWQ/+zFjJpqmZbImHTz8Crx3F5JdNTN5AXDT51rXEM8iePB10JsdHZUQorWRirEQwmF06Hicx5nL3CaPVeQBf/4HvHOPdJ1o7vSVkLBX6yJy9ToIOePoiIQQLYncfCeEcEqzmc1/+A969E0ap1IP97wD79+JVIpbEhV6bYOvpkGHo44ORgjRUsjNd0IIp+ONN7OY1eSkuMhDmz7x4WwkKW5pFNjWG0Z+Dz23wfxkOB3s6KCEEC2ZVIyFEHbVgx6MYAR96cskJqE0IZutMMC9b0uluNVQIWmHVkGOPezoYIQQzZVMpRBCOJw33nSgA5/wCbHE4k4tS6E1woU5xW/fC+amFZ1FM9PxEFz/jbZ4yKVemwOVBnj0JfAolrnJjpbZFspdtK/H8UjLx/E5p91QqzODdyEE5lovRtE6SWIshHC4+7iPN3iDjWwkmGA60tHisSoM2pziD+5AKsWt1RV+aiTshVs/qblNb4I//hvcS20XVmunAh/NgtwAePkROB1StaMp/08v+Vr33QJTFmqP3Uq17wPSvUQ0liTGQgiHCyGEFaygJz2bPFZ6e+i8X5Z4Fo2jmOG2j+GNB8CryNHRtAz5PlDQBuZNh0WTtW27u0Fp094QahB9JfTcDr/PIB59Cfptvvz4gFzwLLZ9XML5SWIshHAKP/MzgxncpDEOxsK0r2BnD6RaLBpP1d5pmP1fRwfSvKloC7J8OQN+HAqqgvP8f1QvT5ZB65OdtEN7HHMUbjgJCO0AACAASURBVFhm37CE85DEWAjhUIEEspSlJJKIDz4Wj5PZFkZ/B3u6WTE40erEHYDN/cD3nKMjaV7KXOBMMBzpoM3v35EEZW6OjsoyfnnQ6YD22FCpzWH2LoSwLG1qRqkrZAddPN61DIKztccqcCpUm89+79sXj1NU7d2IuIPQptCuL0c0kiTGQgiHCiOMdNKb1JpNKsXCWnQm+Pg2mPmZoyNpHk6GwYJk7Qa61+Zo29SW1Oy1qsKsN8Hf/6atvHgoVlss6IKYo3D/mxef//1vkO97eaVcMcOYFTB8NQzYCH1/s9urEI0gibEQwmE88SSOOLayFZ2FrdPNitaS7e7/WDk40Wr55ENiivb512cubg853Xpv5ipz0W6aA22axMpR2uNCb9jd3XFxNVcRxyE8HabO124Y9DovlWRnIYmxEMJh7ud+XuM1lKoPSxR6QegpudlO2ICqtQEDrWr49NPgm6/dpOfIG/SW3AAZ7eveP245RB233vV+GgJLJmrtDwHMOuSdGStRzNq/rZHfw6e3SLs5Z1BfYmywdzBCiNbBAw888URBIY00fuEXbuM2i8aa+ySUNtO5jMLJKTX7YD/1HKDCZzdr80rfvhei0myfJOf6az1///432BevdXY451v38f/5A/jnwWP/gt5bLb+uSQ93vwvbesGpMMvHEXVTddq85O/GaMnxzP9pc5ONlY6OTNRGKsZCCJsYwhDe4i1SSaWAAm7lVovmGB+M1d6K3NXDBkEKUZ+qavINS7XevPW9DZ7np3VouGD6PAjIa9hldnXT3mo/GtP4Su2FamRTSHXYvhQzPPGCVvUfsMl64+7vBGv+v737jo+qSv84/jkhjdACRDrSEREUEQUFXEVQARULArogqygoqKioiLqrP8VVsOAiKhbERgfBggJ2rCCWlSIrKEgREAkSahIy5/fHSUhCJn1m7iTzfec1r0zu3Ln3Cbkkz5x5znPOKXifc5do1UhQKYWIeORLvuR0Ti/x833GzRa/YXIAgxIpLutafT0+yv/Dcy6H1wbB8o7Z2y560127NZLzHxk8UBFuneDana1vEfiwJbwd+5ub1Afw0D3Q7JeCrxd/difCknNh8vWuU8ba4wvev/Vqt2rk/90H8aklj72sU2IsIp4obWK8oI/rRJEWF8CgREois2uBP74oP10aMvcf87BLRDoud5vfuMS1PAOXEM+5HI3WClEZbuT/9sdc6U5RPT3Cld74ivFmnPHB0Odda7nY9GKHWi4oMRYRTyxkIWdyJpWpXOznHopzb2EvPj8IgYmEUKONbjQQ4JtTYW9VT8MRIe4QrG8ODbYG/tjp0a6V3S1PulHsLA22wGO3Z39dfTdE5/NiMxD2VHV1+8a6VQ9zvv5UYiwinqhABW7iJiYwodjPnXalm6RSrvqlioiEAwuXzIc3LgvsYZedBgt7w8Nj3AIoubJR6xZTyXLPQ1C/gMS88j5Xq2+AVSfAf0+CK6cX/gbLovNgc0PXh3pVG4g/5JYrP/f97H2UGIsUIJFEDmV+SGBNYALncz6taFWs522v7Zrkf98+SIGJiES4Y/5wE0bP+ahkz0+Phj3V3MInyTXctp9bwsYmgYkv/iB0/cyN+P7WCDY2hjOXFj7Z9Lv28OcxubddMR2m/z37a7VrEynA13zNFKbwKI96HUq505GOxU6KAYY955abFRGR4NhZy9W4d/2s+LXGX3eEty+E8Xf6GRkOkEMV4f1zc287+uui+rUpbGxUtN7fepNSIlpFKhJHHEMYQl0Kb+IZT3ypljWONLdxG5MpXkuJD86Br05HE5JERILshevgnw+6VQ+LwgLLT3UlDv++Bw7HUCZ+Vy/r5EaSi0KJsUS0f/JPGtGIlrQkgYRC9x/JSIYznDa0oQY1QhBh2fY1X/MTPxV5/9RYN4Kxs1YQgxIREcB1s3j0DjdRrrDkeHttePkf0Hsh/NY4BMEF2Odd4HARxrVUSiERqwUt6Ec/DAZL/kVLVahCGmmkkkoFKjCSkdSkJq1pTT/65do3lljqU59e9GIhC5nIRFJIYRjD2I+H68uWEX8muYUUREQkNGyUW0nx16YQkw5tV8Locbn3efkfMKs/fF3y7puem3gz/HR8ZtvFC/PfT4mxhI3GNKYLXfiN3/iMzwrdvx71OJuzmcMc0kmnL32JJ3vd4B3sYAlLuIzLWM1q1rKWUziF1rQGoAlNaEazI/tfzMUsZjGrWJXrPJ/yKfOZz/d8z8mcTFOacg/3kEwygxh0ZD+LpQc96E9/KlCBx3mcWNxL8CSSGMxgdrCjVP9G5d0Nz0J6jNdRiIhEFhsFS85z99/tBU/clvvxw9HF65UcjjKiYVHPwvdTYixhoQY1mMEMOtGJrWxlMIP5ki85yMF8n9OJTrzES6SQwlCG0oMexJG9EsSf/MlXfEUPerCOdYxiFM/ybK5kOIvB8BiPUY1qrGENAxhAf/oDrg65IhWZxjSq4hqQRhNNLWrxKq/mG190jv9eFahAJSpRlarsZz9RRFGRikceTye9wO+1LHubtxnGsCMvSPLzfndY1pEyUa8mIlJe2ajIXlRJ7drEc41pzHSm04lOmMysKI00lrGMSUziDd7gMLnXyOxCF97iLRJJJJ30IyOz+bHYIu2XTjqjGU1XunIJlwDgw0cGGcRQ8qHMwxwmHTft99/8m9/5nUlMOvL467zOUIaW+Pjh7jM+owtdCtxnyjVw7ZQQBSQiIpHLBKBdmzGmArAC2GqtvcAYUwOYBTQGNgL9rLW7M/cdAwwBMoCbrbWLS/UNSLmVQALTmZ5n2eBYYulKV07ndN7jvTyJcXvaU53qR/YtjMEUab8YYniCJ3Jti8r8KI3ozA+Ae7mXn/jpyIjxYzzGfOaX6vjh7iAHsdgjL3xERETCUZFHjI0xtwEdgKqZifF4INla+4gx5i6gurV2tDGmNTADOA2oB3wAtLTW5rvwn0aMg+8MzuBLvvQ6jDyqUY3tbM9VGxxpUkllKUuZzGQWsAAfvmIfoy51OZMzc22zWN7kTVJJDVSoJdaIRvzCLwW2utOIsYiIhEQBI8ZFGgYzxjQAegMv5tjcB3gl8/4rwMU5ts+01qZaazcA63FJsgRZLLF+E0yD4Wme5sKCpmF65AAHeIqn2Me+XCvPHeIQH/Mxf+fveWpvc5YlHOYwz/JsSGPO4jOwr1LeW0YxB5fjiKMHPZjBDG7ipmLHEUssnejEzKM+ZjCDB3iASlTy/IVHGmmenl9ERKQoivon/EngTsg1lFXbWrsNIPNzVufR+sDmHPttydyWizFmqDFmhTFmRbGjFr/GMY4FLPD7WE1q0pKWIY6ocOmkM4Yx1KY2venNnMyP8ziPnvRkPvNzlVFkkMFYxjKLWYCb1HYN14Q87rXHweTrofaOvLfxd8L37Yp/zFhi6YDfF7AFeoqnmM70PNujiGIUo9jBDj7nc7+TDkVERCRboYmxMeYC4A9r7bdFPKa/IsI8pRLW2uettR3yG8qWoosiiud5ngu4IM/IYEtaMoMZ1KRmQM5lMFSkYkBrRTPI4AAH+IiP6Jf5sZSlpJJKGmn8g3/wMR9jsexnPxOYwLM8SzLJGEyuThTB5DNwoCLcMR76zYYRz8CBSnlvdz8M/WfBj239XPiF6EKXPPXW/pzO6UdGhnvQI98R4axuGKdwCrOYxf3cX8yIAsNiOchBMsi3okpERMRzRRkx7gxcZIzZCMwEuhljXgd2GGPqAmR+/iNz/y1AwxzPbwD8HrCII0Q96nERF+Vq+ZUfg6EPfWhGM5azPM9j7WlPAgm0oQ1ncVaJY2pJS67jOnawg2EMK/FxiiODDN7gDfrQh+lM53IuJ4UUUknlJV4KSQwAP7XKHiF+4jZYeWLB+69rCecvgh+KOXLcmMYsYEGeZL8+9bkk86Mf/XiHd+if+dGEJkU69imcQj/6eTJyvIMd1KUuX/FVvvs03gi1t4cuJhERkaMVq12bMeYs4PbMyXePArtyTL6rYa290xhzAjCd7Ml3HwItNPmuaKKIojKVmcc8OtOZhjRkF7vy3T+OOGKI4Vd+pQY16EUv/sE/cu1zMifTilYA7GIXi1nMXdzFTnZisQVOzqpDnSNdGlrTmpM4CYBHeZT61MdgeJd3eZ3XS/mdF+4UTuFmbuYWbmEiExnIwKCfMz0aNjeEixcUngz70+Jnt8TxiT8WvT1vCik0otGRmus44niDN+hGt+IH4Mft3M7TPE066SEfwf2ET/gbf8v38V4L4b1eIQxIREQiTwGT77DWFvkGnAW8k3m/Ji7pXZf5uUaO/e4BfgH+B/QswnGtbtgOdLBjGWv3sMf68Nl00u0d3JHv/u1pb7ewxe5hj80gw/rw2f3sL/Qn6cNnU0ixe9hjf+RHexEX2UpU8nuOetSzC1hg/+KvXMfYz37rw2ct1i5gga1O9aD/+1zERdaHz+5hj00ltRhXbsluH55t7VUvW1tpb+kOVXertd+fVPQnZH2POW9Z/9aBuB3koN3DHjuCESG/xj/hkwJj67kw6D9W3XTTTTfdIv0GK/J7SAt8hJE5zKEvfY98fZCDHMuxXMqlzGY2BzlIW9oykpGAW/mtOc1LfV6L5S3eYi97+Z3f+Rf/yvV4b3rzAi9QgxpYXAuwVrSiGc2OLHpxBmfwHd+RRhpRROHDh6V4P9bTOZ1ruIbbuI397M/TtuwyLmMuc0v3zRbicAXY2Bjuvx/evhBSqgXmuCUZOQ6227iNCUwI6Tn70pdZzMq3L7RGjEVEJOgCscCHhF488axnPRWpyHjGY7HEEEMlKgX0PFk1yuBqeo9egS0+8wNgJzuZxjSiieZCLuRKrgTgQi5kIQsZy1ga0YjZzOYLvihWHI1pzBCGcDmX8wRP8BAPcRInYTCsZnWuleICZc3x8EuOkts5l8P8S2BflcCeZ11L6PkeLOwNJ/8Q2GOXVGta05nOxf45lcYHfMBKVh4pyREREQknGjEOI3/jb1zKpYxgRIELIZQFs5nNQAYe6TdcFE1oQne68ziPE0ssc5lLZzrzAz/Qj35cxmUkkMBTPEUCCSWKywLpMTC7H7zfA749BVa3KdGhSqTFz9DjfXj0Dog/BFEeX/k72ck1XMNiFhfrZ1UaN3ADz/CM38feuhAufQMy9JJdRESCpYARYyXGYSaGGGYyk0u51OtQSsWHj3nM43quJ5nkfPeLJprjOZ6VrDyyrRrVeIVXjoxip5HGlVzJPOYRQwzTmEZlKtOd7kdKOQpjgY+6waF4uHkibK0PqR6teWF8UDUF7noE2q6EU7+BWju9iQVcyc5XfMU5nBOS8/WiF6/yqt8WgrsToc52SAtNBz4REYlESozLhgQSeJzHOZdzaUpTr8MplXTSMRh60INP+CTP4wkk8CRPUpGKtKc9n/AJoxjFIQ5xKqcym9k0pvGR/T/hE37lV6YylWUsw2LpRz8SSGA846lKVb+j7BZY28otujG7n+szHG56LIEGW2DE03DSfyHag1a/O9nJ27zNaEbzJ38G/Xz96Md0puf5me1OhPpb4WDJ3hAQEREpnBLj8FaBCpzN2YxiFOdxXkAXz/DKgzxIfeqzlrX8yI98wze5Ro7P5Ew+4APSSGMa07iO63iBFxjGMPrR78jKdkfbxz5SSeVGbmQmMwFIJJGJTGQQg/Lsv7o19HoXNjUKzvcZSJX3wtkfw/BnoO42OOnH0J7fYrmaq9nOdpayNM9S3IFUi1psZWuePt0+A8/eADc+HbRTi4hIpAtUu7bgdc3wvlWaVzeDsYkkFqnNWlm+zWa2jSHGVqCCjSbavsd7efaZznRbiUp+Hzv69iEf2qpUtdFE2wpUsN3oZveS3VfNh7Wrj7f2+NWef+slujVdb+3wSdbuS7A2w4T25D58dhazbG96B+26jyfevsRLNoOMPOd/ZZC1Ju9m3XTTTTfddAvMTe3awtelXMpzPEdNapaLkeL8+PAxl7kkkURb2lKNasQSm2ufQxxiH/uK9G9hsSSTjA8fn/AJW9nKzdx8pA3YmuNdF4iyMFKcLws1d8GtE6DjMmizCursCN3ppzKVG7mRAxwIyvHjiWcRi/Is+HEoDi56C94/NyinFRGRSKdSivA1kIG8xmteh1GmbWYz+9lPK1qRHu0mtS06H9ac4HVkgXXOB9DsF7h6qpuwV8FX+HNKw2JpTWvWsjZo5+hHP17n9TyTKC960/WRLsevFUVExCtKjMNPbWrTgQ68zMskkeR1OGWez8AXneGZ4TCrP1j/60eUC1X3QOcv4I5HoetnwZusZ7H8wA9cyqVsZGNQzmEwjGRknoVGNjWEFuvUnUJERIKggMS4HKcP4Scq82M4w3md13mHd5QUl5IFMqLgtUFw7hKYeUX5TorBrcb3Xi/XD/n6yfDl6RRzjcGiMRhO5mQGMjAIR3csliUsYTWrc62UWDUFKnjQnUNERCKb2ugHWR3q0JKWAIxhDO1oR3WqE4eGwkrDZ+Cr011f4usnu77Ehyp6HVVoZUTDlGvdSn0Le0OnZV5HVDLtaMe7vMtxHHekS0XVFLcIirpTiIhIKCkxLoHqVOcBHmACE/iVX0kkkQd4gL3s5V7uBdxo23CGcwmX0I1uHkdcdvgM2HzqSle1gReuc/czKsDUq71bpCOcJNeE/rNgxhVw+ldlryw3gQSGM5w5zGEAAzAYoixU2+N1ZCIiEmmUGJdAZSoznOH0oAfXcR0P8iBncibJJLOEJdzDPZzACdSkZpkeGf7tWNh0LDTcDI1/C+65VreG5Brw+ChYfpr/fQ7Fw+4awY2jrNrUyHVyePtCOP1rr6MpvsMc5jEeoza1j7yQPGYn1NjlEn8REZFQUGJcArvZzUhGchu3sZSlR7bXpKbfVd6CKbMZcpG82Qc+Prvox15+GizrBB2+cSOR+TnrE7h4Qd7txuYdvfQdteH5obCmNbxzAWwo24v9eW5XEgyYWfZGjr/iKx4e/DtDXx/OoYxDR7aftwS6fA5v9fEwOBERiShKjIshjjjqUIff+I1JTKItbelBD5rQJKRxrG8Gf9Ry9388EcbeW7Tn7akG+6oU/3wrTnW3/Ey9Ou/b3ol/weTrIeqolmIP3QP/PSn76101I682OJiyRo5fHwjtfght3+OSWs1qfmr/IVW7Hcu0kdXhL68jEhGRSKXEuBhGM5oLuZC+9GUTm1jDGlrSMmiJcc7R4DWtYcoQd3/JueHVo3dflbwJ99YG0PVzb+KJdLuSoOci6LEE5l0GVfaV/Fg2KP0u8vL93338tW0bzIyF90JyShERkTyUGBfDBVxABzqwjGWkkUYtagWlhnhdczeSmhYL170ABxJcfe2fxwT8VFKOvd8D+s6F/7sP2n8HsenFP8Za1jKRiYEPLh/rm7tym6iI62wuIiLhQIlxMbzGa3SgA7WpHbBjZv39/6EdTPu7u//OBfC/VgE7hUQqA0vOcwnyuNFw+2PFqzu2WKYwhRRSghbiEQcOwLx53Pd/VzDsOYhLg2/bw+owemdERETKPyXG+ahLXTrQgYlMZAc7+IAPGMAAtrCFhjQMyDnWNXddBCbeDPsraURYgsNGwT8fdO869J0Lxxdjhee3eTt4geV06BDMmEHKeT0Z+nwiN06C93rCL81Dc3oRERHQktB+JZHEPObRla65tqeQwvd8z1mcVaLjZn2TU6+Gta3cwgzrW5QuVpHiqL8FZg5wS0oXNnpssbSiFT/zc0hiA2DgQJg6FaL1ml1ERIKkgCWh9dfHjz3s4W3epgEN+Iqv6E533ud9BjKwxEnxnzXdBLprX4QtDeBgQmBjFimKrQ3gkvmudd8ZBbTgA3hiwDY2LDeQ2B4OHoSffgp+gG++CRs2QAu9YhQRkdDTiHEBvud72tGu2M/L+c18c6obGf7vSfBer8DFJlIa9bfAoNdg9DhI9LPCnMVyL/fy70eqwujRsHo1tGkTmuCuugpefhlMWenELCIiZUoBI8ZKjIHmNOe9HD2iNrCBQQziUz7lOI4r8nHSo91kob8SYdhzbtnilKqws1YwohYpJQs93ncT805YnbtrxRrW0IUu7J7/EjRqBLGx8NZbcMYZMGAAbN8evLiqVHEjx2cXYzUaERGRolJiXLAkkpjJTLrRDYNhF7tYycoil01Y4OtOrnbzqZvcZCeRMsPC8Geg/yzo+pnbNPq27TxaYwpMmADt2sHMmZCUBNbCgw/CffcFN6arroIpU1RrLCIigafEuHA1qMGJnMgMZlCHOkV+3s4kGDLFJcYaGZayLGknVN/t7m9sDOkxFvr0gd69Ydgw90CvXrBsGSQnBzeYqCi45RZ4/PHgnkdERCKPEuOi60pXZjO7SMnxnqpulG3x+SEITMRLf/wBTz0FkyfDn3+G5pxt2sDs2XD88aE5n4iIRIYCEmO96X+UtrQlkcRC9/uzJlwxAxafF4KgRLz23XcwdmzokmKAVavg5xC2ihMRkYinAr6j1KQm8cQXuM+eqvD3aW5VMZFyz1q49VavoxAREQk6jRgDscTSKvPjRm4sdP8hU2DJuSEITCRcNGjgzXnHjIHUVG/OLSIiEUeJMa5d2xrWcB/3cQwFr8v8VSc30a7QZcNEygtj4MknvTn3r7+61m0iIiIhEPGJ8QhGMJ/5GAwDGIApIONNj4YFF7vVw0QiSmws1KgR+vOmpsJrr8HevaE/t4iIRJyIT4zXspaP+ZilLGUnOwvcd2t9GH9niAITCSfNm7sOEUlJgT1uxYpw111w992uLdzRYmOhdWvYtCmw5xUREfEj4ifffciHfM7nJJLIh3xYaCmFSEQyBs45B2rVCmxnikqV4IEHICYGdu1yfZO/+CL78cOHYd8+iI8Hn8/1NxYREQkS/ZUBUkllBzu8DkMk/F16aeCO1a4djByZnezWrAkDB+ZOfn0+eOYZt++hQ4E7t4iIiB9KjIGmNOVbvqUpTb0ORSS83XMPXH+9u5+YCE2blqz2+IEH3KS6e++FChWyt/fv738Z6AMH4P77SxSyiIhIUSkxBuKJpz3tqUhFr0MRCW/x8XDZZXDMMTB8OKxfD7ffXvzjTJrkVtPbuLFo+/t88NtvxT+PiIhIMSgxFpHi6d4dpk2Djz8uebKanOwS7PXrs7ft3QujRkF6uv/nvP8+fPhhyc4nIiJSBEqMgV3s4ku+LHS/qilw1ifBj0ck7HXv7ibJNWpUsucfPuw6TcyeDYsXu21z5sDUqW6lPX9273a3QNmyBb79tuTPf/PN/GMVEZEySYkxsIMdzGUu6eQzUpWpxm7ovTBEQYmEM2Oyb6XxwgswaBB07AhjxwYmtqKKj4cXX4SrrnJJetbt8OHsfazNvwtHQgI89hikpYUmXhERCTolxpkmMIEnLviZwsZ/TvkW6mwLSUgiZUe1atClS8meu3MnLF8OGzYENqbCrF0Lzz3nEuT//Cf7lpKSe7+F+bwaPvFE2LYtsO3rRETEU8aGwVuBxhjvgwCaL1jFiqtOoFpKwfv1Wgjv9UTLQosAbN0KO3a4GuC77gruuebMgb59S/58nw+GDYM9e6BePdcFo317iIsr+THT011LuVNOgbZt3YsEEREJX8Z8a63t4O+hiF/gI6f1zWHATHhtECTtyn+/Z2+AJhvAKjEWgfr13S052S0A8scfXkeUP2PcKHGWQCwYsmED3HKLO/bo0fDww6U/poiIeEKlFDklJ7OoJ6w+gQJLKupshxFPhywqkbKhe3c49tjgHb9bNzjrrNIdwxiXDGfdAiHrXbcwePdNRERKR4lxTv36wbJlDHuu4N3i0tyIsYgcpWfP4B07Kcndwk316tCpEwwYAKef7nU0IiJSCkqMc9q+HRYuVImESEldc43XEYRejRrQu7dbxe+ii7yORkRESkE1xkdbsYLzzC6gpteRiEiWmBhXShGOkpPhpJOgdWuvIxERkVJSVwo/lrKULnTB5NN2Ykct6PI5rG8R4sBEwt2hQ3DrrTB5cmCPW7my63yRkBDY4wbCrl2uq0Xlyl5HIiIiRVFAVwqVUvgxlKEFPp4aB780C1EwImVJfDw0i7D/HOPGuZuIiJR5Soz92MQmutOdX/jF7+MP/Eut2kTylZCQPVEuOkDVWlWqlH6VvWAZOhQqVvQ6ChERCQCVUhTge76nHe3ybO/4NSzv6EFAImWBzwcZGe7+o4/C22/D11+X7pizZ7uFPcIxObbWfc8VKngdiYiIFIVKKYqvIhWJ9jM3ce5l8L/jPAhIpKyIinKT5WJi4O67YeZMmD695Ent2WfDmWeGZ1IMLi4lxSIi5YIS43yMZCQncEKubXsrw5zLYU+iR0GJlEWNGrn+xtdcA3XqFP/5depA7dqBj0tEROQoSoz9qE99rubqPF0pNh0Ls/t5FJRIWZaYCC++CO3bF+95SUmuy4WIiEgIKDH2oxKVaEHeXmzXveBBMCLlyauvFm91uMmToYPfMjAREZGAU2IMcOyxcPXVUKUKccRxD/fk2WXuZbCmNeTT2lhEiqJmTRg4sOj7R0d7X1uckeH6M5fEwoUwcqSboCciImEvshPjPn3cH+n69eH55+GzzxjFKAYyMFcZxd7KMLevaotFAuK448K3w4Q/W7fChx+W7LnnnQfjxwc2HhERCZrIXhJ63Dho2RIGD4boaFoebsogBhF11OuFUY/DrP4exShS3pxzDnTpAg0burrjvXv975fV2cJrxx7rbiURHR24Xs4iIhJ0kT1iDG7U6sUXAZh5bRVa0SrXw6tbw/s9UAmFSKD8/DO88457Ybpmjf/EMSbGjbSed17o4xMRkYhVpMTYGLPRGLPSGPODMWZF5rYaxpj3jTHrMj9Xz7H/GGPMemPM/4wx4fuXbdIk9zk2lv4zodlRC935jCuh2Ngk9KGJlFuffgpXXQXPPAM1asCcOW5SXrVqcP/98MYb7nbTTaHvD2wtHDwY2nOKiEjYKNLKd8aYjUAHa+2fYYI1rAAAFvxJREFUObaNB5KttY8YY+4CqltrRxtjWgMzgNOAesAHQEtrbUYBx/dmZsqPP0LbtlTdA1OGQN95uR9+5Sq49kU4HAbv5oqUG4cPw0MPwbp1MGYMnHCCS0gPHYLYWG8Xy7AWxo6FFi2genWNWIuIlEcFrHxXmsT4f8BZ1tptxpi6wCfW2uOMMWMArLUPZ+63GLjfWvtVAcf3JjFeuxaOO47Wq2F1m9wPpcVAhxWw8kRPIhMRr3zzDZx2muu5/O23+e93991uYt7Ysa5eWkREyoYALAltgSXGmG+NMUMzt9W21m4DyPxcK3N7fWBzjuduydx2VExmqDFmRVZphie+8p+r763sRopXtfH7sIhEgt273Yvn/Pzzn64cpH6eX28iIlJGFTUx7mytbQ/0BEYYY84sYF9/09TyjAhba5+31nbIL2MPiUmTwMKtE3Jv3tgYXhsEVlMTRSKLtZCa6u5v2ADz5+e/b8WKUKkSRJXwF8WePfD66yV7roiIBEWRfqNba3/P/PwHMB9XP7wjs4SCzM9/ZO6+Bcj5vmID4PdABRxQU6YA0PmL3JuHTEFdKEQi0cqVcOWV2V+vXg379gXnXFWquH7OIiISNgpNjI0xlYwxVbLuA+cCq4C3gMGZuw0G3sy8/xYwwBgTZ4xpArQAlgc68ICIj8+z6Y1L4OeWHsQiUp6lpYX/6m/r1kH//rA5RyXYtGkwejSkpwf+fM895yYbiohI2CjKiHFt4HNjzH9xCe5Ca+0i4BGghzFmHdAj82ustauB2cAaYBEwoqCOFF5rtRYqZw4IaYU7kSC57rrwToythUWL/NcUT54M118f+JHjwYPzX/3vt99gx47Ank9ERApVpK4UQQ8i1F0pjHEjNT/+yAOvteSfY93mn1pB6zWojEIk0JYuha5dw3cZ6FmzYMgQ2L8//30yu9iExPr1roZZE/tERAIvAF0pypc2bWD7dmjWLNfmFd5NAxQp3848M3yTYoALL4TLLoOmTeGUU7yOBpo3V1IsIuIBP2uxRoAKFSAxkQab4aK3sjc/chcaLRaJRAkJ8MorsGKFK5no3h0yMivAYmLgkkugTh1vYxQRkaCLzBHjTNV3w0k/uvs/t4B9lb2NR0Q81qEDdOkCEye6RLhXL7dC5iuvwC+/FP58EREp0yJzxHjTJrjmGipc/m/AjQJN+ztsauRtWCISBqKj4YYboFUr6NbNbbMW/vzTjSJ7sWS1z+c+l7RnsoiIFElk/pZNToapU3mx3x6vIxGRcGRMdlKcZdw4ePNN//sH29y5sHixN+cWEYkgkTliDEQRRZV9rqB4az14+0KPAxKR8LRpEzzwgOvF3KePGz0O9UTC9u1drXNRaYRZRKREIva3Zl/6UiezjOKvRPi+vccBiUh42rXLrZK5dasrsZg3L/QxNG8OjYpY6+XzwZNPwuzZwY1JRKQcitjE+CAH8eHDAs8N8zoaEQlbDRtCz56wYQO88ALcd5/XERUsLQ3eegtOPtnrSEREypyITYw/4iN2sYsNTeDNPl5HIyJhKykJ+vZ1C26UBXFxLjEO1WIkIiLlSMQmxvvZz2EOM/VqdaMQkUIkJbnVMssCY6BqVa+jEBEpkyI2MQbYXwl+U1IsIoX54w9X5ysiIuVaxHalALjnIVh0lddRiEjYu/Za6NgR7r4brrgisMe21k2Yi4oquNuFz+ceD+eltUVEyriIHjFedL7XEYhImdGqFUyfDldeGdjjpqTAwIGwcmXB+z3zDKSnB/bcIiKSi7HWeh0Dxhhvgli7VhNURCR8WJvdJ1kjwyIiwWHMt9baDv4eiugRYxGRsDJjhuuAkZHhdSQiIhEpomuMRUTCStu20LkzROtXs4iIF/TbV0QkXLRt63UEIiIRTaUUIuKdadNUNlBcWXXIIiIScEqMRaT4Vq2Cb77Jvu3fX7LjnHuua1MmRXfgANxxh9dRiIiUSyqlEJHCZY1Q/vEHPP44TJ0Kf/6Z/fhVV0Ht2nmfN2IEHHusu//ll1C3LjRtmn28Y47xPwKqjgz5i4mBc87xOgoRkXJJibGIFOz3392o8K23uj66W7bk3efVV/0/t3Vr2LzZJdIpKfDYY9CkCaxYAS+95BbO+PBDmDw5+zmXXQaPPhqc76U8iI2Fnj29jkJEpFxSH2P1MZZIZi289x40bOgWr/Bn6VI32hsIlSq5UeSZM2HTJv/7tGnjWpbdfbfrzmBM7hFljSbnNncuXHghxMV5HYmISNlQQB/jyE2M69aFr76CRo1CfmoRz+3fDz//DNdf7z7ffTfceafXUWWLioLGjeGuu6BDBzh0yI0u33yz+1yhgtcRho8dO1xJimq1RUSKRomxH2PHwj33hPy0Ip7I+f984UKYMyf/8odwFhMDI0e6kecxY1xZgUaQC5e1mp6IiCgxzuP44+Hzz6FGjZCeVsQTW7bAZ5/Bffe5r3fuhL/+Kvx5tWv7n1CXU2oqJCe7d2AA1q2DgwdLF29RGOMm8d16K/Tq5eqWxb/Dh2HSJLjlFq8jEREJD0qMj9KuHXz/fUhPKRJyb73lJs299x58+23xn1+Ud1WSk+GHH6BbN/f1lCluNHrx4uKfr6QuuggWLHDJ8ptvuhZwFSuG7vxlyS+/wMsvuxcVV1/tdTQiIt5QYnwUJcZSXu3bBxs3wo8/ukluRRkZPlrt2m5yXJs2kJRU/Ofv2uXOn5UsB1vlyjB+PAwd6trJ1arlapD37XNdNKpXd501atXSUsv797suIQkJ2W30REQiTQGJcYT/lRApZ774As4/v2TP7dEDOnd2PXK7dCl5DDVrQrNmebtJBMu+fXDTTfDbbzBgQHZZx44dsGePS4x/+AH+9jf/ifGmTa513K23QrVqwY/XS5UqQatWXkchIhK2lBiLlBebN8OoUSV7bps2rl1bSUaIAdLS3Nv0WbZtC+2yxRkZMG4cJCZC27ZuxLhZs+zHe/XK/7lJSW41uQMHoGpV2LoVGjQIfsxlwcGD7h2IZs3cREcRkXJOibFIebBuHfTvD6tXF+959evDNde4zyVNij//HObNgyefLNnzA+nee90ocX41xsa4keHKlbO3JSS4pNoYWLLEPd6/vxuFrl49NHGHyq+/wu7dcMopRds/ORlmzHAT92rUgO3b3bXWtWtw4xQR8Uhk1hi3auX+mNesGdLTigSFtW5luSFDCt83Pt7dsmqPP/usdGUT4Op6t293E98eesh1qsjPlCkuOXvoodKds6SiotyCJW+/DRdf7Bb4yZn8btvmunaAe6y8LZqxd68b3S/p776DB90xatUKbFwiIqGkyXd+qI+xlBepqVCnTt6Jdsa4nr8JCdnbGjVyo8Nffukev+OOwNXVWuuWdva3ZPS+ffDUU/Dxx25Ue8SIwJyztHr1gjPOcPdvusmVUoiISPmmxNgPJcZSXvh88PrrcOONbjQvS506sGpVeLwzsmMHnHkmvPZadquwd97xOqrcPv3U1ScfOuQm8P36qxuFHzcOTjvN6+hERCRQlBj70aOHq50Lh6RBpLSsdf2DBw92iR240duhQ8NjxbOcv2eMcSPIDz9c8AS9VatcyUMo9ezpJjFeeaVbLnv8eHjlFfeiY9gw/b4QESkPlBjnY+1aV0coUtbs3+/qenNKT4fTT3clFRUrunreK67wJr5ASE52yencuaHtcJHl44/hmGOya6YnTnTt7K67LvSxiIhI4Cgxzse4cXDnnZ6cWqRU1qxxI5kA777rWo317Zv9ePPmcO21JRst/vRTOPHE8OjIcOiQS+4XLPDm/A8/DHfd5e5v2+b+3c85x5tYypqvv3bXUseOcNZZXkcjIpJNiXE+Xn7ZvfUsUhZMmACHD7sJczndfrtbbW7q1NId31rXqWH5cte6LS4OWrRwJUde2rXLJaTXXusS5c2bQzeCXL++q9W+4gq4+WaIiQnNecuiv/5yEz2z+h1v2wbffefmc4wf73pD16tX/jp9iEjZo8Q4H23buqVrRcqCrP+rR48C57e9JMdv1gw2bMjeVqcO3Hab63XsZX1t1veYlgYPPOBKSZ55xpWPhMqdd7oXDElJbvKg5Pb++26hmKyVByH75/bUUzB/vusAMnZseNS9i0jkUmKcDyXGItmsdcnL1VdDSkrux9asgeOP9yYufzIy3Gikz+e+fuop1584OdklzQWpWdONQpdUxYrw4INuBPnAAbegSNWqbtU9yd+2ba4uvl079+9fs6YSZBHxRgGJcWSvfPfnn64OrlMnryMR8Z4xcMklrpRi3Ljcj739dnglxhUqwKmnZn992mkusZ85E1ascCvYrV7tus+0aZO9nzEwcCC8+iq88ELhSbQ/Bw+68pU//nClAykp0L2762gh+atbN3s0+d13YdAgb+MREfEjskeMwb0t+89/enZ6CZG//nI9fl99Nf/+uY0bu1rIOnUKriXdvNktGfzYY64LRHkY9Vq/Hu6+29XS3ngj/P672167tvu3mDwZevf2NsbiWL/erWDXtKn7Ho6WkeFGLletKt15GjRw3SuaN3dlHQcOBG7BFBERCQ6VUhSgZ0847zw3atyxo2dhSJD4fPDSS24BjKVLC5+0ZYxLEI85xn3t77r4z3/glltc0rV+fflIjK11t4cecu+kZBkzxi3/a0z5+D6zWAu//OI6efz3v6U71sMPw+jRrp3bwoWuB/LgweXr30tEpDxRYlwE998PVarArbfqD1pZlZqau3Z0zRr3c/3mGzdpqySOPRYaNnT369Vzq7fddZd7Cz4uznWKuOGGUocuHhk50iW0pREfD6ecAj/8kPu6uO4697VGkEVEwotqjIvolluUFJclGzfmXhnt559dp4IsWaOgpbFpk7tlybnYRGoqzJsHl17q/+16CX9du7qFUEpSa5zl0CH44ovsr1NT3bW5ZYu7HsePL3WYIiISGhoxztKokasVbNLE60gkJ2thxw5XvpAz+QDYvbv0NaKBsHx57olgUnb4fO5dga1bA3vcrJ69v/8OTz8N06a5F97//rebOPjyy2Wni0VKiptkGK1xFBEpJzRiXAS//eYmzkh4WLTI1YCmp7ua34MHvY4of4sWQYcOerdBsm3Z4m7g2t/ddx98+61b/OKNN1z3j759XceMv/3N21izWOsmp+7f7zpGVKniXpRedRU8+6yrqRcRKec0YpzTxRfDa69B5cpeRxKZDh1yf4iHDXM9anfu9DqiomnUyC2KocS47LHWtW0bNsyb8//jH/DII/4fS0wMzSpx1rra/Jdech160tJct5W4ODfqfe21bhJqxYrBj0VEJBQ0+a4Y7rvPTdiS0EpLg5tucvWeGRleR1M8114Lzz+vxLis+uUXN4K7cmXoz20MREX5f+yWW1w/6QoVghtDRoZrVbh1a96a/A4d3ORVEZHyRKUUxbBvHxw+rHq6ULv/fnjxxeyVzMqSoUOVFJdlzZq5SZUffeSWvw5l2Y61+b8QrF07NNdVVBRMn+7esZk40SXkWapUCf75RUTCiLK/o02YAPXrq0NFKK1b51bCKotJ8YknQlKS11FIabVsCS1auM4mEyZ4G8vZZ8Mnn8AJJ+Q/mhxIxrjuHNZCt27BH6EWEQljIfitW8b4fG6VLwmdZctKv8iCF+rUgTlz1MmkvDDG1Ro/8wzUqBGapNSf226DxYtD3+nEGCXFIhLxNGIs3kpNhc8/9zqK4jvxRDj/fDfKKOXHcce5n+mQIW4iWs5VAPOzZ4/rZx0oMTHQo0f216mpMGOGG0lu1Chw5xERkTw0+c6fhAR44gn3x1G1xsH1119u5DU11etIiq5KFbj9dvjXv7yORMLB/v0wfLhrdRYIp56auzwnPd3VP7drl3chmdNOc6v3JSaq9EtEpKg0+a6YDhxwf+hSU12nBP3BkSxt28L8+Rq5k2yVKrka5UDJrwvEd9/l3bZ4MTz2GDz+uBtlVq9hEZFSUY1xfnw+GDPGteE6fNjraCQctGgBs2e7LgbR0bB9O1xwAdx4Y+mXnpayrV8/tzz54MGhPa/P50asr78errgCtm1zrQ9FRKRElBgX5MABGDECJk1S4hPp2rZ1K9y1apW97b33YONG966CRLYWLdyLpOOO8y6G5ctdP+JRo5Qci4iUkBLjwmRkwJNPuh6fEpmiomDAgLxvUy9c6EaQjztO5TYC69e7lTO9lJbm3uXasUPJsYhICWjyXVEYA336uAUoatb0OprypSxMvhsyBJ591nULyCktzW1TUhzZUlLgnXfcqpnr13sdjRMX567bzp2zt3Xs6MqAREQinZaEDpDLLoPXX4f4eK8jKT/KQmK8apVbbEEkp4wMV241ciRMnep1NAWrVAmefjr0NdAiIuFIXSkC5I033AQXjRxHjjZtoFo1r6OQcPTyy66+PFzLrDp2dDXH0dFuNb/q1b2OSEQk7CkxLg5rYcEC9/b5rFl6Cz0S9O0LDRp4HYWEk82b4dZbYckSOHgw9OePj3cvzidNgq+/hthYmDIl7ztZHTq4xDiQNmyAO+6AiROhXr3AHltEJAyESynFTmA/UIRlpiTCJKHrQnLTNSH+6LoQf3RdiD+NrLXH+HsgLBJjAGPMivzqPSRy6bqQo+maEH90XYg/ui6kuNSuTUREREQEJcYiIiIiIkB4JcbPex2AhCVdF3I0XRPij64L8UfXhRRL2NQYi4iIiIh4KZxGjEVEREREPKPEWERERESEMEiMjTHnG2P+Z4xZb4y5y+t4JHSMMQ2NMR8bY34yxqw2xozM3F7DGPO+MWZd5ufqOZ4zJvNa+Z8x5jzvopdgMsZUMMZ8b4x5J/NrXROCMSbRGDPXGLM28/fG6bo2Ipsx5tbMvx+rjDEzjDHxuiakNDxNjI0xFYCngZ5Aa+AKY0xrL2OSkDoMjLLWHg90AkZk/vzvAj601rYAPsz8mszHBgAnAOcDz2ReQ1L+jAR+yvG1rgkB+A+wyFrbCjgJd43o2ohQxpj6wM1AB2ttG6AC7meua0JKzOsR49OA9dbaX621acBMoI/HMUmIWGu3WWu/y7y/F/dHrj7uGnglc7dXgIsz7/cBZlprU621G4D1uGtIyhFjTAOgN/Bijs26JiKcMaYqcCYwBcBam2at/QtdG5EuGqhojIkGEoDf0TUhpeB1Ylwf2Jzj6y2Z2yTCGGMaAycDy4Da1tpt4JJnoFbmbrpeIsOTwJ2AL8c2XRPSFNgJTM0ss3nRGFMJXRsRy1q7FXgM2ARsA/ZYa5ega0JKwevE2PjZpv5xEcYYUxmYB9xirU0paFc/23S9lCPGmAuAP6y13xb1KX626Zoon6KB9sCz1tqTgf1kvkWeD10b5Vxm7XAfoAlQD6hkjBlY0FP8bNM1Ibl4nRhvARrm+LoB7m0QiRDGmBhcUjzNWvtG5uYdxpi6mY/XBf7I3K7rpfzrDFxkjNmIK63qZox5HV0T4n7WW6y1yzK/notLlHVtRK7uwAZr7U5rbTrwBnAGuiakFLxOjL8BWhhjmhhjYnFF8W95HJOEiDHG4OoFf7LWPpHjobeAwZn3BwNv5tg+wBgTZ4xpArQAlocqXgk+a+0Ya20Da21j3O+Dj6y1A9E1EfGstduBzcaY4zI3nQOsQddGJNsEdDLGJGT+PTkHN1dF14SUWLSXJ7fWHjbG3Agsxs0mfclau9rLmCSkOgODgJXGmB8yt90NPALMNsYMwf3iuxzAWrvaGDMb98fwMDDCWpsR+rDFA7omBOAmYFrmQMqvwNW4AR5dGxHIWrvMGDMX+A73M/4etwR0ZXRNSAlpSWgREREREbwvpRARERERCQtKjEVEREREUGIsIiIiIgIoMRYRERERAZQYi4iIiIgASoxFRERERAAlxiIiIiIiAPw/3HP731zUigUAAAAASUVORK5CYII=
+"
+>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Reprojection">Reprojection<a class="anchor-link" href="#Reprojection">&#182;</a></h1><p>The library makes it easy to reproject an entire xarray data set to a new coordinate reference system. <code>rasterio</code> is used in the backend.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[12]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">ds_proj</span> <span class="o">=</span> <span class="n">ds</span><span class="o">.</span><span class="n">nd</span><span class="o">.</span><span class="n">reproject</span><span class="p">(</span><span class="n">src_crs</span><span class="o">=</span><span class="s1">&#39;epsg:4326&#39;</span><span class="p">,</span> <span class="n">dst_crs</span><span class="o">=</span><span class="s1">&#39;epsg:2163&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>The following shows a slice of the original data (in EPSG:4326) alongside the reprojected data set (EPSG:2163).</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[13]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">fig</span><span class="p">,</span> <span class="n">ax</span> <span class="o">=</span> <span class="n">plt</span><span class="o">.</span><span class="n">subplots</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="n">figsize</span><span class="o">=</span><span class="p">(</span><span class="mi">20</span><span class="p">,</span> <span class="mi">8</span><span class="p">))</span>
+<span class="n">ds</span><span class="p">[</span><span class="s1">&#39;analysed_sst&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">isel</span><span class="p">(</span><span class="n">time</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">ax</span><span class="o">=</span><span class="n">ax</span><span class="p">[</span><span class="mi">0</span><span class="p">])</span>
+<span class="n">ax</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">set_title</span><span class="p">(</span><span class="s1">&#39;EPSG:4326&#39;</span><span class="p">)</span>
+<span class="n">ds_proj</span><span class="p">[</span><span class="s1">&#39;analysed_sst&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">isel</span><span class="p">(</span><span class="n">time</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">ax</span><span class="o">=</span><span class="n">ax</span><span class="p">[</span><span class="mi">1</span><span class="p">])</span>
+<span class="n">ax</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span><span class="o">.</span><span class="n">set_title</span><span class="p">(</span><span class="s1">&#39;EPSG:2163&#39;</span><span class="p">);</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+
+
+<div class="output_png output_subarea ">
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABH8AAAHxCAYAAAD0qRCNAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9ebxsVXnn/XvWrnO5CAEhoBKGXGmBIIlgIHYSE+PEPaeSvDFD2yHawAsBXpQgYkBmEAFFpTVqUBrSEDUYiZ25Y517r0NCTGtUIkpwDtgRRRQwEAxy79nref9Yw15r7bV3Daemc87zvZ99q2oPa69dp6rWs3/rGYiZIQiCIAiCIAiCIAiCIKxP1Kw7IAiCIAiCIAiCIAiCIEwOEX8EQRAEQRAEQRAEQRDWMSL+CIIgCIIgCIIgCIIgrGNE/BEEQRAEQRAEQRAEQVjHiPgjCIIgCIIgCIIgCIKwjhHxRxAEQRAEQRAEQRAEYR0j4o8gCIIgCIIgCIIgCMI6RsQfQRgzRPR1InqciB4Llt8nov+XiEr7+lEiupOIfjk47mIiutduv4+IbkvaPZ6IPkZE/05ED9njLyCizQP06aNExETUCdb9ERHdb/vyFSI6Ldj200S0g4geJqLvEtEHieiApM2fJKLbbX8fIKJzVvfOCYIgCIIgjM682GBEdDIR3WHPdR8RvTmxwX6HiD5DRE8Q0R9mjn8SEb2LiB4kokeI6PZg26uJ6B7b9reI6G1h24IgCE2I+CMIk+H/YeY9g+V37PpPMPOeAJ4M4H8C+BMi2peITgZwIoAX2+3HAfiIa4yIXgrgfwF4P4AfZeYfBvCbAA4CcHBbR4jo5QByRsEbAWxh5r0A/AqAq4noWLttHwA3AtgC4EcB/DuAW4I29wOwDOB/APhhAM8AsH2gd0YQBEEQBGFyzIMN9iQArwawH4D/DOBFAM4Ltn8LwNUAbm44/kYA+wI40j6eG2z7awA/ae23HwdwNIBX9XlPBEEQsjeEgiBMGGbWRHQzgHcAOBTATwHYxsz/Yrd/G2bgBxERgLcCeD0z3xS08WUAZ7edh4j2BnAFgJMAfCLpw93hS7v8JwB3MHMvaef3AfxdsOo1tr+32tdPAPhi/ysXBEEQBEGYHdOwwZj53cHLbxLRrQBeEGz/M9v+cTAikoeIjoCZlDuImR+1q+8Ijv2XcHcAGmYSThAEoRXx/BGEGWDdc08D8BiArwL4JICTiOh8IjqOiIpg9yNgDIM/7dPmzxHRvyWr3wDg3QC+3XDMu4joPwB8CcD9AD7U0PzzAIRi0U8DeJiI/g8RfYeI/pqIDmnrnyAIgiAIwqyZog0WktpRbfxnAP8XwJU27OsuIvqN5HwvI6JHATwI4/nzPwZsWxCEDYyIP4IwGf6CiP4tWE6363/aGgffBvBbAH6NmR9h5j+CmUFahPGw+Q4RXWiP2c8+egGHiD5g2/0PIjoRAJj548z85GCf4wA8F8A7mzrJzK8E8EMAfh7An8F48EQQ0bMAXA7g/GD1QQBOBnAOgEMA3Avgjwd5YwRBEIS1BxHdbMX+fx5w//9KRF8goruJ6P2T7p8gBMzcBgsholNgQsmuG7D/B8GEcz0C4EcA/A6A9xDRkW4HZn6/Dfs6HMANAB4YsG1BEDYwIv4IwmT4VWZ+crA4V+FP2tf7MfNPM/OH3QHMfCszvxgmFv1MAK8nokUAD9ldDgj2PcEaGf8EIJyhAgAQkQLwLgDnMPNKW0eZuWTmj8MYG69I2nkGgJ5t5++DTY8D+HNm/jQz/wDAlQB+1oaZCYIgCOuPPwSwNMiORHQYgIsAPJeZj4LJfSII02KmNlgIEf0qgGsBdJn5wQH7/ziAXQCuZuadzPx3AD4GYGu6IzN/Fcaj6F0Dti0IwgZGxB9BmDOYeRczfxDA52Fmfr4E4JsAfn2IZvaCmWW6jYi+DeDTdv19RPTzDcd0YHL+AACI6EcBfBjAVcz8vmTfz8PkCPLddocN0UdBEARhjcDMtwN4OFxHRP+JiJZtVaO/J6Ifs5tOB3A9M3/PHvudKXdXEEZiTDYYAICIlgDcBJOA+q4hDv38kKeK7DdBEIQmRPwRhDmATAnSXyKiHyIiRURdAEcB+EdmZgC/C+AKIjqdiPYhw2EAntrQpHMVPsYuv2jXHwvgH4noKUR0AhHtSUSFnd36LQAftf050D6/nplvyLR/C4BfI6JjiGgBwGUAPs7MbfHugiAIwvriRgBnM/OxMJWMnPfB4QAOJ6J/IKJP2ptgQZhLJmCDgYheCOBWAL/BzJ/KbO+QKRNfACiIaDNV5dpvB/CvAC6y+z0XwPMBbLPHnkZET7HPnwnjZfeR9ByCIAgpIv4IwmT4ayJ6LFj+vM/+jwK4GGaw/zcAbwbwChuOBWa+DcB/BfDfAHwDJsHfn8AY3h8EACL6eSJ6zO7PzPxttwD4rj3PA8y8E8ZT5xUA7gPwPZg49Fcz81/a/U6DqYBxRXgdrrPM/FHb378B8B2YKhMvG+mdEgRBENYcRLQngJ8F8EEiuhMm4awLjekAOAzmhvW3APwBEWXzoQjCBJipDWa5DMDeAD4U9COspHopTHjXhbbdx+06MPMuAC+Bmbh7BMZ76CRm/pI99rkA7iKi78MU6viQ7b8gCEIrZARtQRAEQRAEQWiGiLYA+N/M/ONEtBeALzPzAZn9boDJr/KH9vVHAFzIzJ9O9xUEQRAEYTqI548gCIIgCIIwFMz8KIB7ieilAGBDYY62m/8CwAvs+v1gwsDumUlHBUEQBEEAMAXxh4i+TkR3EdGdRPQZu25fItpBRF+1j/tMuh+CIAiCIAjCaBDRHwP4BIAjiOg+IvptAC8H8NtE9DmYikMvsbtvA/AQEX0BpkrR+cz8UK5dQRAEQRCmw8TDvojo6wCOC8sbEtGbATzMzNcS0YUA9mHmCybaEUEQBEEQBEEQBEEQhA3IrMK+XgLgPfb5ewD86oz6IQiCIAiCIAiCIAiCsK6ZhvjDALYT0R1EdIZd91Rmvh8A7ONTptAPQRAEQRAEQRAEQRCEDUdnCud4LjN/i4ieAmAHEX2p7xEWKxadAQB77LHHsT/2Yz82qT4KAL76hW/lN1D19LAjf2Q6nRGEVfDVz95rn1HrfhGU2Td3+KiRsqsKsU2Pbbmu3HX04bBjfjS7/quf/frQbbXSr2+59yg9hmpPWs6X2ZeqNh994oEHmXn//g2NzuIL9uCHHi7H3u4dn39iGzMvjb1hQciw33778ZYtW2bdDUEQ5oyv3vUNAAQQcNiPHzTr7ghrhDvuuGPi9hcgNliOiYs/zPwt+/gdIvpzAM8B8AARHcDM9xPRAQC+03DsjQBuBIDjjjuOP/OZz0y6uxuapWMuB4c3Whm/sG2fuXJ6HRKEEVjc/UT88KYjAWU/y4l4QCr5YLvtbr1/TfZlvD+zrp9UNwg7oZihdX1d7hCdaT89zvaRlKr3P9kndx3hNSw/eGNjX5b2OqVx2/Kjt2Bp71N9v8J+R+9x9JsygLNp7vrDv40icy3p3zcnLNX+pva4TgcgwvLX3vJ/+3dodTz0cIlPbTtk7O0WB3x1v7E3KggNbNmyBWKDCYIQ0j34HOz/VAIKBZACHgZ691w3624JawAimrj9BYgNlmOi4g8R7QFAMfO/2+dbAbwewF8BOBnAtfbxLyfZj2nTPeAsAEDv/utn3JPBWTrm8nhFTvi5Q4QfYb5Z3P3E6oVmc6OfiC1clpFQ4IUKJzo4QcUe74USzVh++CYs7XdG1Vgo+jSJOqGYMYD3DymVF4ByfSaqCxyOBvEqXNf77g2N/WgSfpYfvcVs3+c0c26tAea6qJZD61gASvvMHG9374M7jhnQACsN0na/3Gldu+nf1B5v/rb9uzsOGIBGg6AnCIIgCGuQ7oFnV2NtqQHFI3keC8IkERuszqTN36cC+LgtAfopAH/DzMswos/xRPRVAMfb1+uC7gFnedHHiUBrBe/1M6s04IIwbjTnvXKY6x4rnBFy3PG2jaV9TsPygzdWy8M3Yfnhm5Jz6nhJ2xwAUsovufXmRYPwo6gu/Lh1anDDLBWglh+9pRJ+9j09PmebwZded5Nnk2tnQOOx5oGV+/s1btfN3lrrBCLaTESfIqLPEdHdRHSlXb8vEe0goq/ax32CYy4ioq8R0ZeJaHF2vRcEQRDmle4BZ/mJH2/rlOZ1d8u5s+6eIMyUebe/Jur5w8z3ADg6s/4hAC+a5LlngRN7QtEnFIMEQZgR4Y1+KICwmalirWMPIOdlQsm+WnuPGCeEAIgEoKW9T62ffxX5frIeNTnhJRF2IuEnRNHAwocTgLY99h6/bmnf0/P9aG0oCVlreo9TnGdRSuCVVXkAUdxe+Dw839RhlLlQwcnzBIAXMvNjRLQAMxHTA/DrAD7CzNcS0YUALgRwARE9E8AJAI4C8CMAPkxEhzPz+IPlBUEQhDVJNLEdjs+DjOmCMHVmYoPNtf0lPh6rpHvAWX5Zy0S5fsQ7TliDRCFfbSTePM4LiN0sVjiT5V67dRbWGot7nozFPU+uNb/8yM1Ru2MTHJxXjPP4ifL9VJ4+bhnW0yclFHxaaQo7C2Ctq6Us4/ezKclzlKcnGKpCrywEHkDubxq+5+Hz9O85G0FmarDhMftywS4M4CUA3B/3PQB+1T5/CYAPMPMTzHwvgK/B5OgTBEEQBHOvE42jwVKWZmFG96BXzbqrgjAz5t3+EvFnlaxbr571fV8kbBRYx0tK4gFTCwFLw7cGFHKWH7k5CpNqJBR0mkKe0vWDJKYORZ8hQqlqMDeLQCrTp1wT4XsXhtolgtpqiELAdEb4qYWejVGU69c3ABo89mUQiKggojthiirsYOZ/BPBUZr4fAOzjU+zuBwL4RnD4fXadIAiCsMHpPu2VzeNmKgIxm5xAgjBjZmWDzbP9JeLPFFgPnkGCsGZoE3tyYlDiMcJlGXuo9PHgyXn/hDQKQE2CTJsY1E/4Cb190uPTvEDThLn+PocCUPreuuvoJ1wFHlzMuu4FpDlrlBpBb3ohYHoC/wDsR0SfCZYz0vMyc8nMxwA4CMBziOjHW7qZe6PXd2IkQRAEoS/dp73SPGny+nHjbeny/5Rjm9wRhNUyCxtsnu0vEX/GQOr907v/er+sFbZ99kq/1LZJlS9hzvEhX8OG8uQ8RoDIQ6Wx9Hp4/lEFoEEJQ58C4ceHeNnXnj6ePr0H3t1a6cux7fvvbdzmEl4D6GvkRe2E73O2PHuD91MbQZu1RNChJxAwtBfXHPMgMx8XLDc27cjM/wbgbwEsAXiAiA4AAPv4HbvbfQAODg47CMC3JtJzQRAEYU3Q3f/MJISa64uFXTEFl/zZiUaCsP4YyAabR/tLxJ8JsNa9fHIikAhAwoYgkwsISHLWNAgdExOAcqXRc0mc033mhFzC6m3ff29zOFmTR05baFxCowA0AxiMkse/9IOI9ieiJ9vnuwN4MYAvAfgrAO7DejKAv7TP/wrACUS0GxE9HcBhMFU6BUEQhA3G0r6nY2nf041XbVlWi/WyzS1A4IVbZrx6BWHKzMIGm3f7a6LVvjYya10AAozgs3jsFbPuhiB4WpM6Bzf83HCzTzmvklQoIJVUBwu3tQsPTgBqEjZ8qXRbMaw6Rx8dvi3Mq6lvYdWr4LH3wLvbz9WHtLT98vf+AEBDlbMQ1tj2g1vjYx+5uTouVyXEXd8g4o3bxx4TCkDk/qbubd4YBukBAN5DRAXMlf8JM/9vIvoEgD8hot8G8K8AXgoAzHw3Ef0JgC8AWAFwllT6EgRB2Hgs7X1qZZeU3DzxBOTH56AaZ3f/MwfyNBaEdcRc218i/qyS9SDytCEeP8K8sLj55UaYyTGA8DMwri13LltWfBhy5eBDlh+9pRI92oSfQfP0NAk/KZqNC7dlrAZZRlAJrz8Vfvw+j9yMpX1Oa297iPL0qQhkumb+pqSVGYZd6fcpMWiC5nHCzJ8H8OzM+ocAvKjhmGsAXDPhrgmCIAhzirdNnJdzWMJ9hl60gjAq07bB5t3+krAvQRDWDTXhpynxs2XbD271S6axOCk0MLTHyNJep9S9fCy+JHyOWoWvuJR7uC577Hpk2NL1/YzUKSWjZAAleOyLIOQgopuJ6DtE9M8N259PRI8Q0Z12uXzafRQEYT7J2iuZip1DoQjdp75idR0ThBERG6yOeP4IgjC3LG5+ef+dBknyzBrbd32gdZdUAPLnZl2FgimKjZ+M0JLLcVMzqLwLdZLEOSQQOhoFnzahJ+xnYrBNygXb5UNqzOeTsLTPacOXol9lKBhpBdDaHrgFoYU/BPD7AJqztQN/z8y/PJ3uCIKwFlja+9QWr+HAW9bZE037huHpQfXR7tNeid633zXGHguCMAoi/qyCQUK+1lLFrza6W84FAPS+/rYZ90QQAvqEe/UTfNpwYlCUZygNAetnBLVtaxJ+cqJPsn5U755Jxt0Pm9DaCz99cO9BLYnzoGTzPGXyC02QWYR9CRsTZr6diLbMuh+CIKwdohw/g5KzfxqEH7dP94Cz1s19kbB2EBssRsSfCdLvB86JR/P+Q9jdcm71w/2M84GiQO/L1864V8J6Juvxk+b76Sf87Hz/WPqy7fH3GQEo9AAKCb2BiMBaG++frDdPcg0NSRSHFn3S9S1eP3NDWwJJv4vKPmfWQ+dhqjGv74sgTJ6fIaLPwZSSPY+Z7551hwRBmA1L+5w2vPDT4q0c2S+hZ+8U8+wJgtCMiD+roHf/9ZGAE3oCtQk6TR5D8yYGdQ95tXmSKSu9dNQlPmPU8l2SH1SYLaTIC0DjEn0inNCUJoMGmhNCh94lOaNnGOEnZ2gN6bmy2ipf42Rp39PNkwGFn9y2UTyB2tqcFAwMVJpdEKbEPwH4UWZ+jIh+EcBfwJSVrUFEZwA4AwAOOeSQ6fVQEISpUPP4GdUjto/HT3iO7oFno/fNd452HkEYErHB6oj4s0pCoWZU0WYeK4Y1Cj8LyUeGCEvPurR6nav4I+LQmqd78DnofePt/nGSDOv145iI6NPUn6aKYNly5Q3ePhkaPX4GPD7aZ04HuzTca1RBJvUE6hceNgvhxzGd1NKC0B9mfjR4/iEiehcR7cfMD2b2vRHAjQBw3HHHzecPiiAIQ+Mreo0DRXFewjYbaL0WpBDmGrHBYsQHbwb07r++UShKPYhmhiKgMKErva+/Ddi8G7D7ZrBS4I4CioYkrcMmbxXWDN2Dz/GP7vm4GUj4ydBURnwcuLZZc3s1saAiGIeVpMLnaWz8sPl9hvluUYvX0KxRBCqKapYwXBr2b1uoKKLnripauETtCMIGhYieRmR+FIjoOTB24EOz7ZUgCNNiaa9T4skhraulLJsnjprG35zwk7sXCLZNyoYUBKE/Iv4INbpPf4394VZAp4PuMy82uUyIzCdmUM8Du0SeQcK6YSqDd4vw01qmfcyE52gUgXKkRtSw3jiDCj9KxUtyzDyFfC1/7w+qFzkhZhziTJNQNAN4AiVG13qZUWFyENEfA/gEgCOI6D4i+m0iOpOIzrS7/BcA/2xz/rwDwAnMc+omKAjCWFnc8+TqhSvdzozlR26u7BOt67ZKJjy9NrES2P3VcUlhi2CbCEDCNBAbrI6Efc0Zs/b6McJPELPbKQAgFn76iT9iRwojMFBZd8s0BJ9+sGZQKigE+X984mcgLpOa2XdkmhIoKlV5HM2h58/ygzeiu/+Z/Xfsx6Cl7oc5ThDWMMz8W322/z5MKXhBEDYQkfBjCb2U3XMKS7q7sTKwV2oh1LlQL6A9wbOMwYIwM0T8mSEu9Csn+Ewz+XP30POqSkakfLgXCgVWKhZ95AdbmCbucxmw7fH3zagzdSIBKOyrNZqiyl9OAGooMx7mranRz7DqU+2r+7RXAgB6337XoJc2WxTVq6o5mlzJ5xUGStHDBUEQhBmRE348zKaiab/CFSnp/iNU9eoe8mr0/vX3Bt5fEIZGbLAaIv7MAXOR5yf09lGqUvIzwg+HyVpzs+tuu3gArRtcsud03bho9fqxosrMRZ+MEJUl59HjDKhUABqH908ToffPnLG03xn9EzC3CUCONuFn3kUhQRAEQZgwS3udEr12k1Le6ycYZ7d9/73xsfucZp40ef20EXo8Z4thyBgtCLNAcv7MGTMp815Ybx+lTDUv6/HDnSqHCCsFJgIXVhByv+c2F1C6AIh+6JeOvmz61yWMlYlW+XJeZw3MSvjZunCCXwDUcvvUwr5CrPjpDawwnj5kGIGjJa9P9DxdN0dCyNK+p1fXHFx774F3m+uKysO25Oppel/S96ht2xRgmEoT414EQRAEoYmlvU7xwg8pVYVzIQ73cqTCjzmwxXZosl1c8mj3vM/x3S3nNu8jCKtEbLA64vkzJ6Ql46fqCeR+3G24l8/vY7d5MSe9X3Kv274Fc1xyWhiecQhAi7ufGIk5i7ufWG0kFQkss8zt4wWfkECgqgk/OfEqDf/KbItXBaFfTYkTm2gx0mYiKveh990b0N3/TJ+M2v/mud+MQX872t6XUbeNFUKJ+RHfBEEQhI3B8qO3ALCl3Zm9HeLEn22Pvafx2KV9T+/v8RN6LzeFiOVyHibHd7ecayoLC8LYERssRTx/NjjdIy6MwroaEzsHYlCNwBPIwXPkaSDMH07wWdzjpMZ95iGp88AM6grdVP2rn/fPMELFMILRDFh++CYsP3wTuk99hTcauwecFXvkyO+HIAiCIAyN8/hxwo8nM6625gLyh1V2RO+7NwzfodAOcTaPTAoLwswQz58x4RKqhqwmuerUZuqdYh8KPy70AjBhXna7J52RH9D/benoy7D8uatW32dh7aOoEn7cZ9AJIBPO73O8eql/vkN/sLZ968IJfcUc7/WT22+QOPZcLHxT/p9RBBEn3mo9l14/APz1eOHHrQsrpDnc782ootAMxSRGf21PEARBEFZLmt/H43IAWvt922Pvad43ICrl3kZbYugmz5/E9hHvH2ESiA1WZ/6mhdcgOeFnLdA98iLzJPX4cblKwvwhTXlDGoSfbCJoQUD//D3jFn6OVy+NFg8pHF/8Jo4vftOvasrtkyU0isIl2qctXj4jbjSeq4/h1bC99813th83S9xvSipuhRVD0t+g8NhhziMIgiAIG4Sa18+A26L9Hr7JPEnsmt53b6jbPIOMszmvn9D7We7QBWEqiOfPKmkSfua9pHL3mRfXq3cFN12N4V8NNIo9yY/90rMuxfLnr15N14X1yiDVnYYkEntCEo8dJwC1JnD2h4ZhVYNVm6rl+3GkM2KagaLt5JlKemtV3GgrVR96F64mb9iclIWXeHNBEARh0iw/ekvWo2f5e3+Q3bcfve/eYEK0A7pPe+Xqx9LQUyh4Lt4/wiQQGyxGxJ8JMO/Cz9JRlzTn82nL+5OiA9Gn7eYs2bb0rEvj9YEDBDGj94U3DHQdwvpjnF4/jcLPqISCEamBZ7wahR+H8wByiRjLEoSi+g76hhq8YBJ6//p77ecbI939zxwtBwAwWJn2XAhYSlsyyUHONWEYYngIgiAI02FQz56BsZNyfqwf13gqApAwBcQGqyPizwZi6ScuMU8y90nLd12DpWMuj4WfJpjzws8YQr0kUfTGJFtidJXk8vn0E4RYc6v3T73C1wif16bvSSBiMGsjANU6sPa/H92nvwYA0LvvHeb1wedE70nvvneYdTkvpyYGEYAEQRAEYZ2wtO/pVWjWNGkba9smagZhHdg4gjDviPizzvFeNkBzzgyiuvCT+wFm9jdikfAzjPiT64PigZNGC2ufxd1PHCwp8gTYoT+4eo+g0OsHsWcPB4ZPP48fTowkcgkZlTLfB2KzaA0UVggaJr5+BLqHnofePdc1b3/G+VVo3s6dwG6bhj8JKYC1EYFK+x6kQk9Y7h1Y8x5AmsWgFQRBEFbP0n5nTPV8We/epnsEZ8f0o9XzV/W1RQRhGMQGixHxZ5XMa4jX0tGXmScDhFZ4b5t+Hj8O97ueE35yv/nh/ZgbHMJjhI1HkNtnkpW9cjiPoDDR80hkvit9Q7wsqfDj1kVCEmsQt4R4DVpe3tJ9xvkAgN7X3tK806CiHK/S08YKQFV71q3cegPV96f4twOoG5hpf9JcZoIgCIKwhomEnxlNorkxtea9m47TTSLQIGNyIZ68gjAp5Nu1Dlk65vLmjUHlLnb5fYBY+GlS9JuwYWAuFMwtnvD3f9SKPcK6YHH3E2fdhVZ2lLdh+64PYPuuDwy0/6BiT4gXfpx4GoqogDGYctUw/EmpudJYgzHohB8A6B72Wr/029evO/yC6tzuHPZ83S3n+uPSY7tbzkX3kFdXrw89L3vO6JgkDKzxd2LY935Gvzcu3nzciyAIgrAxWNrnNCztezoAU37dLdOke8BZ6B54dn4jUX3yxo3RaUXPhuM9hQKUQveIC0fvrCBYxAarI54/64zFZ18BENU+llEunXS8GESQceFeZRLuFdykpTmAyM4EMJERgIrkPOFMASTZ83pncY+TZt2FOs77JFP9a5DKX8OfLhB+HJqNkMJcef9obUUeNt/XsBxqEYgvme+rF3XSilmO4LkXdVyfXMLFsI1wX/e6aMhHRGT2YzYhXUS+vzlRyQjHut1NfBQPwTYjc8qzpQxCKfMsgiAIwggs7X1q42THqooujIu2MbptkiYN907HZkXoHnkRel984+r6J2xoxAarI+/GOmLx2Vf4507sibx7gFplr4Fmw9OQrtRTIbdv8JrSWfwWD6PukRf174+wdkm8U6Yd8hWyo7wteh6+HppBv0spmuPHEGawE6d0PURqoL6E3/O0j+m6pucDtNk97LX1/RV5kagm/Ljr6mREpGHEnjnN8SMIgiAIq8ULP3ZMJZdzcAYhX737r0fvm++swr0OelV9n2++s7mBprE9sh1UvF7GcEEYOyL+rBMWj72i9tesiT6DlG9PQ1EC4Yfc6zAsJW2r6XWmb+z6EuXx4MZwFGFtsrjnyVjc8+R4paKZCj+OHfqD2apggKn8lV3H2os1tdw9w4iqTYKP+35pDZQaXJb2uX0M+5ALCcuRE4HCULFofYvxFe4TPg9fJ33p3fvW1uvtffOd5vH+66P1UT6xfjOLc17pSzONfREEQZRWzRYAACAASURBVBDWJ0t7nWKEnzZmJAIBiMblxlx9wxLds1QT2IKwWsQGi5lvi1kYiMVjrcdPU+RE6O3jHtMf1CbRx7Lts1eam88VHXsAtZEmlA5yDdWTQMdtigC0PqiJPpZJlHYfN33Dvgb8/PvdcyFffTsx5ACTazvXRsa9unZMv3O37NP7ypv886hCGBAnenb7B4nznSHZu+8d6H3j7e19aOqXIAiCIKxBohD5nNfPvBBMfg0lAOUqBKfXFdgMS0ddMkrvBEFoQHL+rHFS4ScMseLMLHxrMufwnszmGdl2x5XVurbqjQpgTT7PT9SHtIqYSo4Jc5MI6xf7d5534cdVAWPNg+f9ST73Q9N0HpdM3ZV9j8RZDaCon3vUvrg+5Dx0hiGN43ftZUSfRvFoHDOJcyICuWSDgiAIgtDE4u4nxrn8+uXLmYHd3H36awD0Ce9ypHbJMCQ20dJRl2D57muGa0MQIDZYDvH8WQ8EVbbCm0NKf2ybhB9tEjmHlbqo5Ejs6T7z4ub2fPgHwAWZhcxjGGrGSpl1DaEk3OJJIKxNSKm4ItZa/vta8aIx9KuP1w2lFS9yFbpSY8mGgDGbEDAf+lWGr21y5TRUKmxnGPpUDmskOL/39nHvVU74GYDGyiI5BglpBVYvbgmCIAjCGFnc46T8mBt6/YTrZowTgXJkhaF0fO5nl+jqPqZWQVgQhFUh4s8axnv9ODKhW40/mD5/D2qika++tXMFgBF+ItKy8LlEsCp5PchNmUNEoHXB0t6n+r+jE4G2PfaeGfeqnePVS4c7IJPgfCByn++2z7xOkj9H31ft9/F5gNLwzbZ+tX1Hh/F8svS+fG1jfp80pNTnAxo3c/X7QShZjX0RBEEQ1j5RmFebl/4chHwNPGaPMgb3CWuTgjDCaIgNlrK2e7+BCcO9suJN281eLolzctzyna8HEAs/tVw9uSSyDUvtWGH9k3q6zDnDCz+Vxw+3VePKef8k69uFn6TtcNGBABSKQNn+Buub9hnlb9X6W9PgFZW8bptF9P0atG9z9nkzAXpq7IsgCIKwdvHFMBLBhwYpjz4Duoeeh+6h55kXzOhuOXc8DasBxnfx/BFGRGywOmu79xuUpWMuNyFZaQWu0oRr+ZAtXzUI9ZvGkuvVu5zw87mrqjCv0BMo/PENRB12IV12SasBRcJP+AOfiE81IUpYk3T3PxNL+51RqwS1/Ogts+5aI5Hw0xamFIZ+AZGIUqv8FdImACVGT7Q99NwJPXuSimA+7EuXiCqBDeIBNOh3bQCRufeVN2XKuufb79371tiYzNFQQaxxnzkTfgRBEAQhZGmvU+rFMFLhZw4TPffuuc7aR/1tBp+3r2lMHsXDXzO6R1w43DGCINQQ8WeNsfSsS6M42KbwrVCoofDGLxfqFbD8+asBAL0vvMHcUKa0VRSznyYORaGmH/d08EgFqty5hbmnu/+ZAFAZK3aAX37k5hn3rJ2mcu9Zcrl/BhFQEgEond3LrTMnCgSm8Hxp+JcOv+e62bvHEVXgatg3bLOB3lfe5BfPsIYqDTEUtRmTc0oJGvsiCIIgrC2W9jqlcaKolhdwDuge9lpffbfNQzc7iZNeRy7E3NuJA+Y0Ykb38AsG6bogeMQGi5FqX2uI7hEXAp0CUFyF1LgbPwWgRHVjSASCAkMDSoHKoKGM8LN8VyaLvvUQQpHcmLnqQwAIMEmcHSrZL3xuK4i51xTcwJIOvRfMPm4w6d1z3UDvjzAHBBWjiBRYDSBCzAmhAOQqfg0Ea0ArW71OGwPOfgdrJBU6Wt273f7hoz+n+x7puCJIyVXOLVT98ucNH2vX0bA+PWdCzRDrV4XEbu8+4/z2+P6DXtXeRr9t4j0oCIIgzAljF34mXPGre/gF9XOEE02roSmnUevkjozpgjAORPxZI3QPe60RdJjBmrz4EtL7whu8Qu9/sBv2DckKP4C/Gex98Y1+1dJRl0TbAFTCTkgwvjnPI9YUr3PCTxmGsyR9nQNXV2Ewuk99RfVCEaAZyw/eOLsOjUgo/DSWe2cNkMpu9wJQE4MabKkR1O+70CbepNvca81xu8MakqPOUHbGPPTMcdgXM6355ICCIAjCaCztfWrj2NpqK6RjfsP41n3qK9B74N2jdq8vva++eaD9uoeeh94916F78DntO7rrCL1+Ak9xF+5WQ5GZ4BKEIRAbrI68G2uA7jPOr+fsSLx2vICTC+dqyKETHddEGhZ29zWN2zxW+ElD06KSjW39czlXRiwPLcyIRLjrffeGGXVkRqThX2OakVt+5GYsP3wTAMTlXv15dfy74ERUF/41blZ7XaSGmzkctfrfHAlBGjT2RRAEQZhvlvY5Lbs+G+btRRFV5QDql+9nzNVx/QRyuj4X1mX71T30vNhmH6Q/gwg/uXZsJIKEfgnDIDZYjHj+rCW0Nt4/xEAJcId8jh4giMclZbx9Sg3SJmyLCUABk3/lc1cNfMqc4r989zXWA4gB9xXQwQDUlFw29D4IBB/uKJBPWpvcrJYlhLXHJGehpg0HQsWO8jZsXTihtp2UrmLWmfuHf/Ujc0xkBA4TthV69+T2Sb1/cu3mxOdcCNkgwpCvShYbvt1DXt1+LaO4uFPmugepLCIIgiAII7K07+nZ8arR06dpzM9tn9D45SIMfLhXQO+e66p7DOvZDcBU/ArG5mgcb+p7KvwEya3T/cO8oQREtkf38AviXIOCIAyEiD9rgN7X3uIr6PS+fO1gB7lBh8iIKp0CKBnLd1/dflx43kFcPUuu/MdyYo/D/oAvf+4qLB19mV8deh61Vv0R5p714umzo7ytMedPKvxE+Nw/ZF82CEBDCBhRouxhQiCZgUnPTKQCUJPo23icFcxc9ZDAoGxk1BwHofDj103H8ZUBlOJkKwiCsCGIhJ/QMzdHLbw7EULSyYqm0K+nvRK9b79r5D57wac1n54CEIzXDn+tic3fet2Jx4993lgkBkYIIsDecwxgLwgCxAbLIeLPGqH3tbcMf1AYGnZ3n/CuIam8f2DDvAIRyDnvBN+10EOp1fPIe0+YRnr3vnUc3RWE6aHZJ1mOBKAhaayQNkhSZp/PB6NrQMMYVqOGgoWefgNUFhsLaWURQRAEQVglS/udEY+bDcmdPU3Cj3/dMnhbD6LeN9+J7gFnGY+dEQWgnKdPI6QAth75g0zWpIRiFlmvH0VgX+K+vUm2UQbEDBSE7jMvNtWJBUEYGBF/1hGpUNJ9xvmDewqNwPLd16D7zIsBWEU+TcRWAlxQ/7xCGcJrecFi5db5sW0S5ytMnjbvn1acN0tOAOp7qDEUSama8NN96ivG4/Y97sTITV5NmvPCjqPt7RjWu2eQawrdyfvlUBg7kmxQEARhPRMJP5ncf+H4niVcr6gK+cqN+8G+3QPPNq+1Hq/wY/sdhVU579zcGJ2+7mdjOBHICT9qgGMAk76CGQyKKwoLQiNig6WI+LOOGclbaNhzBIq7E4IA+JvCUYSfLFOIYhGEUYmqfnGc/2cQgyYs/9pUCtYzjXw1q/H60XXDt7F9954NmwB6GHEoJ/xMMeePyYwmhocgCMJ6o+bt0wAp1Ty2h2XenfAzSKWvcF1RDNhjQ2PC5Iax1eUDggLgUnE6MahpPG66BlJxgucieN7Sh7qnlNlv6VmXRtEFghAiNlgdEX+mSPfAs6PXvW++c0Y9mQyREHTkRUO7YvbuuS67nlYYxRMlin//AbpHXDhRb6Y20r+fY739HYUBsZ4t23d9AFs3vSxKDA2UIBTe+Fl+9BYs7XVKtTkQMPqKPSGTEi36JX0Oz98mvOSM4CYxyIWmpQwi7Awyq5jun6sqIgiCIAhD0t3/THBSoMRV5RyGpb1PNU9y5c0nldg5FH5ynrvO68fm/awJRWHoV0hToYb0WIeyOX4ozveTu2qfCyi8h9c2/IsIS8dcjuU7X585UhCEFBF/hInQ++IbJ9Pw9//DxDe7wWkVCe4GoXvg2SamukH4CfcR1he50K/Iwydg+873AwC2bnqZX7ft8fflGw7DlFL38IyxVwv5mgVhX9O+5MSaXIn5tup/42QOhZ+SRWgSBEFYDyztdwaIFIgUmPVIos9YGXA88yLOoPs3lH33bWTH/pwAFAs+/njnSeSEH+cwnYZ0ucPTsZu46oKEgAktiA0WI+KPMPdQqUGlhn7SJhQPuZUmUVz3oFcBAHr3vWNi528TfgRhEBb3PLk9708w47bt+++dXEdGEVxyFb0mySjnabqmNLlzruqXIAiCIPRhad/TzRNF3utn+cEbR29v71PjXD9AXN59TBMkPmSrFjbVEnadm+xpC8dq3NYQah1MgrEL/Qopkj6ElcB8cRnr+cMMKMbisVdg2x1X5vshCIJHxJ8pknqQiMfIYJBmoGSo7z9hStZnvBC6B5/TXGra7jOKQNTP60dY3wyS+HnrwgnZ6lFbN70M23e+H4u7n2iMxabKXy1CR/fAs/skMk7Om03caEvQF4kR11ZVJDUK+xmg0xKF2ojKuAe5BQCgCHIMTD3nD0mZUUEQhDXM0j6nmSdJuPLS3qeaBMQ2fHvbY+/p35YLAc8UK2DWRgBqCsVuGPN733h7bVfvuROOfTkUNVfb7De2h8emIlA43maEp0jMCcO+MsKT9wyK8hzZ04UikCAkiA1WR8SfGbLRhZ/uQa+qwrda3osP325KynePvAhQVvwpEx/PdMBJIUJ3y7m17YOUknd9cyJQ02thfbKjvM0/H7kCmDbVLNLKX2G+n9Djx3m0AcjOqvXuv354UXKUWUQVG7qNs4BtM39pG4OcK2dE9js23dcJP+E2lRiTgiAIgpChlqcPqIsvCYt7nhy93vbYe/w6ChM7u7Yy3qheAGo6dygatY1jGXGplXTczQlQqT3Adh+Nuo0RJnYuMqJVQf494KK6FkZ9/De5gZLrYgaYQC78SxMWf+pKbPv0FYNdryBsUET8mTIiFBi6B58Tvz7gLADmphYAuk9/DUAqTgKt2Q4gCigYWFkJtgWN9VP/m3KX9CH928nfcuOxo7zNePqEZLx+aiQC0MAExpv7bgANoYijihn9QqBy23Vi5LnvlC8Fq/J5f/qdIycAtXo+NbiSh9vTPD+h+/iU0FJmVBAEYc0QCT9ANcal43cfe7NV+AnpV3ShSfhpOMaHeg1KUxn3tF/pGJ964rsxO83tk/TFiT21hM8EW903HdvNunAoJW12ZpDRhRSDNWHrc16P7Z+6fPBrF9Y9YoPFiPgjjI1cGFv3iAurF8xm4CxLI+I47x1mP7BFbSgyCercQKIIKOxHttTVYOgGHt+ezq93g5h7ZDbeQKG7q/NEmmAOIWHtsLj7iQBakjf3IUwATcoKQBigslYUkqUArdE94KxIAGrcf5AQrXCf0Lhri++P3K0Dg68M2ssdM4jbeLhvKgCF+zT1J1ofePyEhrIKDMwpwoC4HAuCIKwBUs+dlFzuvqEmdGoHB+NnPwEoJ/zYvHbdQ8/zk6WNwo8bVwfNedfXTgkEIJ+HB1W/3GOh6uOu9wgyXj8cCUZ2n8RW4TDsixmsEgHI2hrUz+YQNhRig9WRd0MYHza0KlyMYBMkfFMKKIp4NiC5cY1CXoL1rJQZJAoCdwqT/6dQ5rFTAAtWGCoKoNMxS0g6m+HIhIxk+yBsPFRlkCzucRIAU9p9ZDgQIttCodLvRWBwRl4/me/P0DQZeP1cy5tcygc1LNPZwfBcwfte+3429kflQ70kvEsQBEHogxvjAVSTgcnCWteWpn3T43y7QOxBlNqmmk1CaZ3JY5MRfsLxMiv8pPlwBgnDbhJr0vHZjbtheJfvl6py+1infSiYyaMw1Mu2yQrxUlD16D2FAKakf85jKBChFn/qyv7XKAgbFPH8EcZC9+BzjACjimqGfdOC/5EHYAafkkErpV23Yr2BOB4Iw1mQwg4KYWxwzsvAPd+84NuinSV6X3tL1T8Ava+/Dd1DXh0PnKwrT4Y0nEXY0FCnAzCb2UAiLO5xErZ9/73YvusD9fCvPrA1uEjZz7pL6pgQhUQGVbZ6919vRMk2ISZ8PmxFq37tIs6TQ969G/WwS0XGy8mJXWFOgFx/a6Fz7rikH7mSsW3XMup7MUYYJGVGBUEQ5hjn5WvGszZxZEBP1rSNMOdfTgAKPYqIjACkNEjbAZa5mjj1+8XH+ATPTV674fjb5AUU7ts0seS8dEMPYBTxdufxo1R8H2C3cyAAsRV+nLhTI2ObuGAvVgxyuhqZ8C8m8f4RKsQGqyOeP8J4yA0SVrDhjllgBwHuFJUHUCAWDeJBEM4geC+ggvw5WClwpwMUBXjzApaOvgyAqYTgqyEUypy3cOcOZi4CbwOfIFrYuFhjqxavD+MBtH3XB7B95/uHapJ9mGGDq3g4S2fP15hfKvzehM+jePsBfuYHEDxTt+1s+FTaB/e9atxen7nMtue+o26/nMGaegU1PQrCOoaIbiai7xDRPzdsJyJ6BxF9jYg+T0Q/Oe0+CsLcEoo2rOtL07bw+Jx4pGPPIdMG54Ugtz70AHL7cNK/tHpl6nWUnse9Tvub9jkdU/stSsVLpzB2f+Ddw0p5D36QsdvDNrxHT+plRMgs1f4+HCwc4pmxeNzr6n8HQRBE/BFWT/eQV5snoXiy0PHCjxsMvPeOQiAAqcpV1LZRK1kZDmzuRz4daPyAo6oYYusp5AQgAOg+4/xA9KlmJ6IbVdcnVUDYuHQPOAu00KnCCFtIBaCBBaG2pMhJ/qlaBbAmb59c/p4hwqBGyomT5tfJtaGSPobCT7iP+y76/iahXDnDMyXsywy9fhwaauyLIDTwhwCWWrZ3ARxmlzMAvHsKfRKE+cbniswIOul+uW2549O2gjCumggEGHEnXJiBUhsBqEzCy7wglBF7QjEnFYF8f/uEnYfP3TgaLtEYG9jOnQLshB+lwIV5zgUZIcitd5O1LtzLCz+IFrbe/umSFYCAuCS8eP8IFrHBYiTsSxgPoXiy0AFv6kBv6lhlHwADtEKAMq6k5JK1lTbZMzOwUvqEdb1732qEmhQNoAhuUIMEcGlICq2YwZVWGEs/cQloRZsb+dCdNXTRVWwDjdkn3usefoHpz1feNIE3TZhHuoe91hhanQ7g3LS1xvLDNw10vBN+tu98f5TwOdy+uPnl1QrWAKkq3CsRM5rWZ718gLpYEm2j/LGuK8l3KXSdJuZ62FeIC+0Kz0lsrDrNVXil62NqQAKVsaYAoKgSYLZ5Nw2Zv2Da7uAm2nVtGwrC2oGZbyeiLS27vATAe5mZAXySiJ5MRAcw8/1T6aAgzCvDVKi0bPvBrdFrN7ZzMC6RIj/OmzHNbaA4FCz14Am8gbgAqAxO5MdBO8a6cT+8hhKBPYBKEBlkgiedPEr7Fo73YTEF59UThHtF9rq7bisoVV47ledONAGl4nXkxTMCmbJgVb0vAqKwPCIsHnsFtt1xZf/rFdYtYoPVEfFHWBXdg8+Jb8goDsWqbi5NfDCXALlHpcDQICPd1wQWl68HAJZ+4pJo9iK9EQ1nAuwuQEeBVoyeQ3CPGn6ECQcYF7vsKoO53wmZOdh4dKzH14qd0dIavQf6T47nvH36eQBt+8GtWNz8cmx7/H2VB10Ojg0aTy68q8nLZwweP32FEy/IIBFZYSudBfslvxtVRzjez588mIHMGIfmvA3HCoLgOBDAN4LX99l1Iv4IQgInkwukqCb4hGz7wa21SR/WnBGAMkJMMPY5ryA3+QQATFxFNvnjFAA7eZklEZ3S8/Ub94Nx1Asw7tjA/nCe/ZHoE5Vzj/sdVu5iG9rVJvrUhCFCVeFLkx/7qYTpAzSgSXL/CEIGEX+E1RGGVRQmjIs7HevqaRK5EcOI8UQgaLBSIGIzDpZ2YCgZS0ddAgBYvvua5tMxA6UZGKkggAncsQNHUA0AIJAdcKkgYBdAZESnarYCcZI9ZisY2RjrsrSutqso4ymsGZaOvsx8nndbMK7JmxdA33+iHoY4BkLj0T/PiRVpyXNH5A2jMusGEH2y4WHxLqzrHkA1UhHWtkOpe3pqnGZDsih2Y3f7BaKPd+t2hH10nkW5xNLRhU3TICRoNPRDEKZP7sOY/UIQ0RkwoWE45JBDJtknQZgbUsHHMVR+Pyf0DLSrjkrIc5Dbh8vSe8uDjK8LWIMo8BZSyo+D9bGfvcc9tIq8bxppSgKdIxR+Ogq8UBjxRbkS7sHxLc2E43okAhGqJNCRrWEdi62tz0xQK9rcc2gGSissATj+567Bjo9f0nxyYZ0jNliKiD/CeCiMtwTbnD5hdn8mGJdM1iYbv/XaGearuHyXEYTcDToxGyGngL1RzNzsklvswOQHWF3tF7ikknWzZaVA2lYk4xJgrqqFTUAIEGbL0lGX2DxRRSUeFATauQJs3oTukRcBu1aAlRXgiZ3gXbuAnbuMUVaWkaE4bPJnR2NycUV5b5ZQ+Elz4YTbc+1lqHn9OPdwV2iEghm0BmElFWVYm/4QOSEnuJac8BS2HV1jRviJBKvKDRxAVYWsH4OEiwnC+uM+AAcHrw8C8K3cjsx8I4AbAeC4446TL4yw7qkVZLACzjBj+/ad7zfVQAcUgJqEn2q8DASi0hi+jNLY0KEHUS58DLDpEga0uFs8ZhsngcgWXSkKcOHy+ZjJX6i694650Hx7dU8fRPcSvg1lhTBt7yc0Q3dU1U8Nf6/BHcILFt+Ej227YJB3QBDWPRIEJ4xMVJKayITLLJhEzkyJ4g/UByR/Mzf4x3D5c1dh+c7Xm8O9Z0G1PdSA2HoDsZ+ZQHWDTMnNZBGUky+qm00/cNu+R9csrA/c58ImCfdGTKdjPhNpYsWAphnCVZHz8sklcm4TftLkjG3VtPx5knVhyFZb/5AkWXTJ122CxzD5uvMODL9/PoFjeL3h9zQn/OSErtysYY7QG2kKMEy8+bgXQRiRvwJwkq369dMAHpF8P8JGpy2Ua9RJHQepYMwelMwY5YWh0kxKclmaSShvCweJorOLrrc7ihdsMAHEfpy2xVY6CrqjoBcU9AKZ5x2qLVwQtCvzHtoBVuBhqoQfJhcmhsqjSJl1LpE0q6rtcpNCuZvCyuYC5ZMKrOyusGsPKeCyUREbrI54/ggj0T3oVcnNpr1pJoJeKGwoVqjE1G+cjWBEwK6yNdQrx/Kdr8fSMZebEC3fnvIDhZkdMIng0CGgVFYkKkH+LtHNqqhgtkF7d1Fy3g9uPQCshBn3hLXI1ue8Hts/dTmOf+7VoFKDdluoZq5UJSQYcbEACmtshTNynY7xBhonOaE06wmTEX3CECo/SxaLIE2zdpHHTiqsuO+tMikV3WxadI5A9KmFZAHVDFyu4ojvhGufovCtKFGkE5AQeCK576j3VIq9gFqvf4qhX6XMswhTgoj+GMDzAexHRPcBuALAAgAw8w0APgTgFwF8DcB/ADhlNj0VhDklCPVfrfDjCYWfBs9X1g0pBtJ8PU7oUdauJU5CoXXdC0i3hEWn3kJtEyi1Qg/w5dudt4/P+6nMtTqb3E3OOmdgcmkYmE16CHeKnLePCm37YB9mn1bCnyO4D9AdMiKUaD8bGrHBYqYi/hBRAeAzAL7JzL9MRK8DcDqA79pdLmbmD02jL8KYcVW+Cjvb76p7BYMH5e6xFEwlAsB78gzL8p2vN1W8SgJIg12lLp/Q2f3nXGJhpgrKWMCJbliZTCiZNrMQ3h23NNfau/etI/VVmA5bf7r6LG3/5OXRtuN/9mrzpKPw4uddA15QoML8jU31uVCwZD+jRQCwc5c3eogUGCW2Pf6+sfW79/W3oXvoeajll6p5y/UXfpo8X/p6xKTCT3p+l4Mg9RZywk9RHR+FUhKbQ8OwrLTkbCC0ZttP2g33o6BvabiaIGw0mPm3+mxnAGdNqTuCsCaIKnCukq0LJ+Q3DFKEoM+kRFQdTJsKtswa5PL5uDEwFICitm3JXPe6n12QEky4VF4/Zn0lAFWe9zlBhmHnU8l2p0TskeT2BWrCT5j/x6WUcF5CxhuIwAWsZxGgO7AeSMDR57wNn3t7Q4i9IGwgpuX5cw6ALwLYK1j3Nma+bkrnFyaJLn1oh14oqiRvDmbzQx/G+I7rxkzDe+uQ1oAuwCoQgAAzSCgG+cGn8hog5ijTpc9FZMOAoO2oUqi+g7IwP3AQSvjiX3gDAOt6zVwZKIUCF4AiXXmlWMOGSpi//y7biM3v4xi07PsgdA89r3pBqi4AhduahJ/U26dtkiNtPrNvVNI92jfjvec8foiqnF+uP3CGKECKras6qu+gP6ETaDPth8JPxqvI7+faCa8rvdY276MJwSDo6AdREARBmDWp4OPDuO04vH3XB8Z/0tQjN017EHqcOxLRyAlAy4/cDABY2u+M/LlSD6BSG1u2LH2ezuicqSdSkzCUeuQqFXn9OC8c0wasbQAvDPlmNIFKNpkfVoDIGG/x9gmFIW3tDd2xXj5W7Ck3AdwBygVAb4IVhIAjrnobvnyZCEAbCbHB6kxc/CGigwD8EoBrALxm0ucTZgN3OuCFwijzwc0oaQaVbLLvT+CGi1ZK+NFkxZ5TFbXZBoK52QfZMvFaxzeGfjBjEzJSEAgK3DGikQv36j7j/KgE/Xph6ZjKS2ZUT6y5wMWOdwgvev4bIq8YDh+dIUIAdwrzOV2xn1MLK8L2z14JAOg+7ZVmXTmesL9I8PEnTL1+GtzEm0SfQap4AH7Sr+b63SCyuHAsALXQKbYiqSvvGhl/ficj/rI23z10zG8C+zwFVHkDJV5HtTw/0cm5+r66vqWeSu46wrdWEj0LgiAILYxd+FGZMazf/q4kPBB70yeC0fKDN6K7/5n5dlIByIV/hW23eQA1TSQFHr+1Mb8B4w1U2eauIi/cMK8RFYVo8vYxz523D4Gt8FNussLPbsDKbgAvwIhA1gMIiiEagCBMx/Pn9wC8FsAPJet/h4hOggkH+11m/l56oJQZnU+6B55d3YxpCFQ5xAAAIABJREFUBj95zyq5a0dlbtLsY3Jv2zcMZVDChHYa5saysIIPXCgJbB4X4w5KTL5jtKsEF/ar4LwPtBWNqHpcr54/ofCz1qkSBlazT+nnLHJFDo6jID5xxz9cGh3T+/a7AABL+56+6j7WhJ+cp8+Awk/k6dMUrgXkP7uDfP8CUdR0NTjGuXpbbx8f66+q9x5sF/eSjYHHBYx3lW3bVwYL+pkKP7UcRqiONx6AwexlEko2ayTeXBAEYX4YZ5hXSGPIV0DN26e2gx27BgkTc4TiUr+x3YV/haFi/fqT7kNBkRTr2ZNrhxh1wcZGB5CiytRhgIih4Ca0UD2mYWCohB+9YNorNwHlblb42QyUu7uQL3M/wJ3KFnj67/933Ps7v9t+zcK6QmywmImKP0T0ywC+w8x3ENHzg03vBnAVzG3BVQD+O4BT0+OlzOj80T3wbPOEyFbuKaof/0LFpRitt4+f1Q/DMHIz8qPgqn1Z0ceEgMF4A7kqXm7w8N99ZZPQluYYxN6mgAkbImgwChCvmGu1yfhcbpb1kv8nys+yDtCbrOdXUVWPyM32eK3HhiMaLxaAVsb7PmS9fAYlrHwFeOHHh7XlvGJyws8oQmt6Xnc+xOFlRvwxVTbMowqUGXu4dsKsBrEVaBXbUE1UIWFpuGYoANnzus8pl7EAxJrS01aE2xWAcn181gVBEITxQIrAmkdO8rxa4YeUqpI+N4zZAwlHbYR5MfuRqa6ZFmGIJnxgbSkGwGSEH3dOa4T5nEDKbYPpDwPFLpi0DW54DoWfaLLOrg9CvcrdCCu7w4g/uwPl7gzuAFwYW8Mfn7QlCBuRSUthzwXwK0T0dQAfAPBCIvojZn6AmUtm1gBuAvCcCfdDGBduYLKPvPsmk1jN5vqpxTMn4s72T12O7Z+6PHo9Dij1/glfRzvmPSW2f+KyehiMazf0JFBVTpbu09dXFCMTre2QLwA7/s+llQdKFGdeLVV+GPiwRCdCfuSjF+HDt1/S2P7ywzeNNd8PANTKv7rX6axfEupVM8xys3MYcJ9w90xoF1NQwcN6+flwLxfq5UO+Anfs8H1XMAJxuL8LF3MeRM7LJ6wc5s6fenKp4LndN3odPubekynBADSrsS+CIAjCeBlbda8A1uwnQxsrellIKb/ktjXRe+DdA3TE5dxsScOQ2xbYAG5StQr5UlWeTzfsWtsKpQmnVyX8pA9pBisXpmWWld2Ald3Nc+2qhDk7guLnTvjRHev50wFWnkTYuSewaw9g517Arr01yidp6CeV0Js1sMCmamvB4A6DOxpbbnlz//dLWBeIDVZnop4/zHwRgIsAwHr+nMfM/42IDmDm++1uvwbgnyfZD2E8dA+IC4T07n2rCRlyN4CJop6t8jVmel95E7qHX1CtsF4EbGcTSKPy+GkJA1k87nUmxKtT9zwgd8PcKdZnqff1VhnJiQC5WSOn7zlDJKgw9dGPXDiW03ePsO04I8/F7rvnKZrrAlAu1Avwn8nWGbmARm+upu+CzwsAE06VEUsrgQXeo44pEIkyvwXme1TXXMid0p476/kTnMu2Bobz4rEziu5alAlNq4m2bt/w6zs1AYhQylSjIAjCXNAU8rXtB7euql2XMJrCcZ41qkIOw9Ub7+vlk+1E4ukbtuEG4TRELNo/Heczk1BuMij0/FHBJI3bVZu+sLbePFQJRT73DwANk/+n3GRsduMxxIHNgagvrrJXucmJRibMa9eeDL0bg3fTUZiX80Qy18egggFibHnvtfj6SeOx+4R5RmywlGlV+0p5MxEdA/Nz8HUA/9+M+iGMgksgB4AXCnBHVTP5oesnwfqWKVCpJ5t/g6sQM3bVmsjMMBBX8cJMADrKD0oOWtEmYXVT84W9IV7ogHaZElAu7Kt78DnofePtE7qwKbG2RWy88PhrAcAbIe45K8SCi52Bo2ABMz7S4u2To3vkReh98Y3oPvNiAEDvC6aimBd+mqp15BQQH/Pe4KVGFBtkrsKG3dZY4Uv3CekLBaBkOwGVEONCuwKxJ+wf24SNXFRCEIqM6MbGCKSCvPDmk2yX+X7E4Zp2lbbn07afBeKk0SoQkVwyaOep6PZdV2qnIAiCME2OVy+NVwQTOOwSGadothMU2h4yvOHV6jlkhZ/e/dcDqE/Y1vob9jGwM/pNjHAqIgXe1r45F+llw8yiyWAr3lS2BGw1JoZeAMCAKvN98MKRDTXXm4Bys1n0ZgZvMp4+Pocjk40ss8JcYWwEsosgbESmJv4w898C+Fv7/MRpnVeYDL1vvhOLx14BLopqpr+F7Z+4LH79yQkkGQ5DvdLBy60jArSuSroHbPv0Fdj6M1fV203aWi+5fjwtHlFrCQ5niSjzmbSzT1WunxbX5xa6R16UnJjNurSKVOp54talRlboit1GZgYuW/7cEXh0hblyauQEIOv9E5VtdW7fSGbiKPC0AmqPXgRidw0254BG3HdmI+y4lw3Vy0yuINMEw16X8/ipvQdcJYMOr3GKn3nnciwIgiDMlq2bXpYVZlbl9ZN67iLxAmIN1gqk4iTLrmR73FboNTT8GOWKUwCIJolqXj9hPsHEJql5EbOZTmFNRjixXrqp128t158XgOC9rgFUIfnW+4e0207QJUClFdA4acc3bI7VtppXudnm+NlNAws66QfHJgQxVKFBCig6JQ7/X1fhK/8lvj8R1hdig9WRd0MYiHAGwc0quDwb3g204UZ0Zt85tq6mLQPowBXHvMdFfnP34HOG7t7ckIYWrTFe+KJrmxM7J0aeF340RgpLjEIMh8W9x4Uy7tLWY4477nVhEos776VwyYRfZdtO/5ZhyfacUZf7uzfkyvLu2pHRiPh7nwo1hOD3wc72OQ+hoDqYX/y25Lhg8d5AgSjlrjXNHRTlAgpe5/q63iCig4noY0T0RSK6m4jOseuPJqJPENFdRPTXRLSXXb+FiB4nojvtcsNsr0AQBGG8ZD1yhuB49dK61w9ruFyQO8rbsKO8LXusCX/SUV4d1jr25mnwxo0bGm3iqhJ80jGSgvE2sTWC/pArsJJOFKU5egJSO8sne1aALqyIY4UcJluhq4Mqj1DYjo0RZ7LHdAC9yRyrFzTQYdsXrhbbN2O/O48fQBUaSjGKQryAhfEz7/bXrMK+hDVG7/7rsy6kLuZ37sIpg4oG3ksgGkiCeGAibPvslQDqHkqLx15R5QnJeAt0Dz7Hr+se9Cr07nvHWC8jx/Ne8hYAwO1/ef5Y2vM3xnPE4k+Zv8e2T1/h1zmvrO2fuAwvev4brAhQCQaRt497dLNv1mDxiQgB6I6C2lW2JngO6R5xoRFn7Hu1dNQl1ce+yWsnDN0qbBJjK/YgTJDujLky8F5zhlZDe2klLL89TVyeuDZXIVF2N3d+wFThIgLIze6hSvbsEjcDNRGUE0+r7HMfjmdtT13ZoaqECdHS1fe2CZfxx3gA2b+9PYlz9fZfUxf2RdrajQomt5Ceap6rGcWbrwD4XWb+JyL6IQB3ENEOAH8Ak3/v74joVADnA3A/fP/CzMfMorOCIAizYBSvnx36gzhevdQ/AsiKPj4EzIpDrBWAEsRu8LPjYhgKNopH8oFn15M+h/aHf67sJJPyok8tdDw3IWQfjSNP4YUU473TML7Z4Zy09RQyBxvBxwo3ZvwGeJd9/gPyxxVPwCaJhu8fAz7kq9xk2io3M3iTzeUDG87lusQMdvaBF380Op0SC50SnULjJz90Kf7pF68e5u0W1hgzsMHm2v4S8UcYGO/xA2Dx2VfYm9f+x6UVv8ZJ9/ALmj0hQpwXUNqfglrLPm+7w4gQS8+6FACwfNc11bln5O3TL8RurbN43Ouy6yMDwyUXzH0G09d2xsgLP8Hff1Dhx52zSjjY54+Qbnf5sKynD6znT0TJ5sPpElFrXYUtAf09VkJDD6iLQE2iUJLD3JdqDfChW8q9Tqf30jYybtpU7WpEJJP/B3ZfCku8NmlANnQsFYDcgU7Y8ocmYV/sPi5ENVFsUjDTTFyObVGF++3zfyeiLwI4EMARAG63u+0AsA2V8SEIgrBhGFb42aE/WHservPbyttwfPGb9QZsAmgjCtkwMCAKBQMwfD4gouYJSOfdo4pa2Fej8JNOdgaTUUTaTtaQ9wjSqUdVOrySFWo2kffucd4+FM53dUw3ecVOFCX2ia8EVgDcMWXd2ebxAYzoE4o/rMlPCpEN+ep0jNdPp9DoKPH8We/Mwgabd/tLwr6E8RL8jhJXHhcTp2mmwm3WqBL8ul1stQLn9dPG8uevxvLnq5mBWQg/P/cb1+HnfuO6yvtiXLSEs80DXgxSBL25wAuPvxZ6QUEvVB4pTYJI9XcH1C7tEwwT89DVvVz58SiJcu6z7UK1ChPKxZsKk0x8oQBv6oA3daB366DcrUC5ueMXvbtZz5s7JpF6UZjZOVdafQgPLRf+FC2FaZM7NuRsoaiWovCGYFbYcdt8iJZbj7zYFnpCOeHHinU6KBmvC4A7SRiYOw/FS9UX15/gGFeC3lUd8Yt5/9x33ZWVN8bvHH/oxwwRbQHwbAD/CFNd81fsppcCODjY9elE9Fki+jsi+vmpdlIQBGGCNFX5mjScegZ7LyAbBhaGgmXCwZYfvaX/SZrsg1DMSfL8VAUkEK2vTSS5pjiYmCqdVzX7MHq3pMKPywvq8/wUAC/Y8C4nBFkxyDwPcgKlw3TQjjmewQUHXbYCkFuUSf7sw70UQymNTlGiozQWihKbOit43kfG40kvCCnzaH+J548wGcJcOxMKKeoe9tp82w0VNb3HTxBvvf1ToyWe7n3j7TUBaFIhXz/369eBiyqZ7cf/7LyJnGfU92JiOG+NhQJbf+Yq6M0dLx4M9JlyHj8aUCvGuCI2hshHPnpR38NDln7iklggCyeLQsNOJUZVaGi53D5esFA+Hw0xGyfRjgJ2aaAg4xaec/PKCTThZaczeelx4aFsLoa8ZVbGCZJDvNdP/BjF9IcJrkPvHQpy+QDG20iZsq5MDLKzjExUr8ARJK0253Ozeu4YmMLvzL79KnF0piy8e5wi5WRmnfYjos8Er29k5hvTnYhoTwB/CuDVzPyodTV+BxFdDuCvAOy0u94P4BBmfoiIjgXwF0R0FDM/OonOC4IgrGtcmXegXgEs8gAiKwAFXkAAQITlR2/B0l6njHb+MKdPuC6dQGwQe/y6dJJLOw9htqXZubG6qLc5XPh4kOeHC8AVg2A25off3gGIySR/tp77bsJHF5VwxAWMvW9Fn8rmcN4+8O5FTgQqFNu3gVEoDYWgOpiwLpmVDTav9peIP8LYaawqNA1y53Y3pC6vyZj7NwnRp3vEheBOAb3XZtBTN88uafasCAQOVk44qbx8aokAQzjeZgyTyuvrIx+7eKT+mLb7fHZcvwNPHScEec+TTiAAub8rk/k1LgEqCQxbEaTgyu05V8WuiSAXUOw1E1fsIoYRnVz32U3fJQncE8En/D75dnwbeW3FewvBGmylPdZ7Brljk8pkrg9p5TInACGSeLwIRF7E4ugz4T4/M/2dGg8PMvNxbTsQ0QKM4XErM/8ZADDzlwBstdsPB/BLdv0TAJ6wz+8gon8BcDiAz2SaFgRBWLOsqrrXMCQCEGBCwrYunJAXgAAzOUIK2x5/rz0uUxWsDzXvdJfk2XUrnaDy+zUIQFqbcTus0uk8+7WxGSh1+XH7qWryRzvhxwo3zn7QDFBRbVcFQWsGdexkDrP3OnYiki4AVs5mMV4/ZnHddhPQbC+Toch4/hR2UTACEAC86GOvwUdesM6q+QqTpNUGm2f7S8QfoRGX4DnM9RORDBr+Zirw+mE1ZF6VYSi1DfNQ5jnZJHRamxvtEDtz4EN10jLTM2TpKPP+0K7wLtzc4KrHd2G37xk3pp1PXhhbkueICXlmjcLica8LQnUUXvwLbzBhUx0bLqQCzxXnYgxUwl7o1sI2xKtkqBXuX0o9w9Ixl9fEQzfr5Y0eoPL4CfP5OKHFCyk21MlV+QrEH4YxcEgZ7xe1qwSgzOwasc0H1PB3CkSh0KDzQlnwOk2QDQCk2YbEaaidCuSSTlNQOcu13UIk+oSpApxTkQ3tMgkgjdFGTMZRT6PK2sOoklL7tjmuXOZKxTsRh8j8eexzYiswcZoUWhsxTXHtHJOCzVmncq4QIiIA/xPAF5n5rcH6pzDzd4hIAbgUwA12/f4AHmbmkogOBXAYgHum3nFBEIQ1jk8CrT+Yzf2TegKloWHbd74v2JnBZZD8JmPL9L7xdgCJ6BOGeoWl3JWqh3pliItKOGPF2Txx0QrSVZ6d6pqMSAMAuqhy/XCnsglAJiEzkQn7ohI+FAxM1mPf2AqsCOWCq+5lFgA27CtI9JwTgaynT6fQ6BQaC6EAZEUhYX0yCxts3u0vEX+E8RCGeMDelOfcRcdEd8u5djZCVe6dzGBtByttFqLqJi8SfgBs/+TqwpzcYDs20veLGShLqMdXwJsK7PbQzuZj1wm+ChZM3DeUFUsC4aB+UJ/PmAv/msRnMTSobB6ZKL9MRoCBCgyf0Piz3ixk2wPZMCignpy4Tbz04V0UvG9kc+vYsLlAeKIVgElBkTW0bNJpX77V7cdG3TEVO6r+9LWZgn54TycFK8pU7tyR/ZmISKHw5P+OzhbVgaeQDx+r+pUmjWQiH2Y2HWhSLsf9eC6AEwHcRUR32nUXAziMiFzpxj8DcIt9/jwAryeiFZi55zOZ+eFpdlgQBGFiWA+cbY+/r8+OqyeXBDrabiuDbV04ASCF7Tvf37xzWfq+e+8gUljc/cT6tYQDqbdP7CSOq/Dl9guEn+zkjoLNPQgTpp6078uxN00MObuHrKBTVPZPtlCHXZisVxCb9ELEZnKHlbELfbLojqnyFR7rc/xkhB+ltFlsmJcCe+HHiT/d289B73ljtu2FGTMTG2yu7S8Rf4QsubLujqWjL6uSpfoqWqnkb2KBd3x8vF4/3QPPNk/coFVw5VZLBHTMiEFlactCFiBXitIKP6Rnk91/6ZjL45AW+7h8t6kg1j3iQvCC+Ur6fTSgHn/Clr8c/81qWD59lrz4F96AD//dxdCbCy+S6AUFkDUYUkPBef3UylK1iBK50umDkAgFkYjkDKciEH6KArygfHiXMWaC/RJjyefOsYaU6aaqtB3r1RYlmG6qVKUQeRn5UDkF7znFC2Rn4apZOSqBYqdGuVmh+IEGlbpKjk5k3u8yEKOa3ipGVYkr2eYTONoGVGn6Wuw0hpwtABZ5DrqThX9Ltv3x53RePM4jKw0F855RDFYKBA2GmtnvwLRg5o8jL5cCQM26ZeY/hXFRFgRBEKZEq/AD5xVkZjC8txAPOH6l3j9JuFeT6GMerR3TMV7NuqNqEzOhrVrL9QMz3usF53UcTHz5Nqga9+1Ln9TZThrpwngEu3Axly+Iba4fF9KVXkpY5Yv8fu6t4MjrR9kOzMJLV1h/zLv9NSeBL8KagghwFYPSUBxgijPqiJI39758rRdSUlxCOn8DPcU+Lh57BRaPvcIKBG62pKrGtPjsK7D47CvQ+/K1JuFvVL0IRrAoTfjSuJm16AMAL3rBG8GKzGNHQW8yS5XcGXGCQkZN2Ml6n1jBwld5S4yTfiwdYz3Dws9MaG9RUG5ehRW0FPSC/W50gjCvjhWCbOULuMfou1OJI1F+HaCqUpUSGnFEgeFUhXn5ClsLRvTRCwS9yT4uELgDlO4936Tiill+Ns4KlwN7+sCGucELTaEHlw95U+jbZi33dfC+ZY3XQf7OUwp3ZACaaeyLIAiCMBiLe5w0s3M7Lx/H8cVv+lCw7bs+UNt/66aXYeuml2XbqlUOC+huObeqNuorewW3eZGdEAg/KlmcF3NHWXumwMrmAuXuCitPKrBrjwIre5jX5ebC2DihrWMFJpf/ULvKnqHwAzeBFzyWqGwg5wFkJ42cHeErhBUwk2BkGwo8fZwYZFZU64sg1Csn/Ji3gvFLt7+q8T0W1h5ig9URzx8hS+/+6xu9f7LloLM7Tlhg8e0Tevdc51cvf/5qU51JW68Azh0zORaffUWUcNd5SUWhKyoRoIiw+FNXGvEnFakUR5UUJsHWn7lq6kLQi174RgDwnimA/Wz5ECnUq1JkPH5ywk9+3eCi3+Kzr+g7/xPn17G5fqz3T+R5E4kWFBk2OaK+2/1JBcJT5nMQGVuBCIRg9sy5aEex916AISgF6NK0TVqBVqok2WCAYMIqqSlfjjPWnFjn3L1VuLiwMeeJg0jIcZOAWf8iG84VvU/WW8hVCfMhYG1hXeRcjARBEIS1QJjLZuSQe0Uj5f4bBzvK22q5f8LXPgk04AWbrZteVvfwIYVtP7gVi5tfHiWt7h7y6npVLyAu7w4ktmmyr33uRZtNRtgpd1NG6HETRtZjWJWA2sUodtrciiVAK5WdFdo/pnoXbGh5JfQQEAlALoUEu3SDbsJM2Tw/BVDuBuhN4XtiHkzeP6oLP/YSO4VGYQWfgjQ6NgTMiUDuhl4z4ZdufxX+5nmTqeArCLNGxB9heFzOkEJFg0qtSg+A4597NXb8w6XjO7fWRkwJQqeyhoAGqCytV6kZqdKcP+Nm8bjXmYFzoQhina2XQ+GnH3y/SSNjiBRVCU2beJdWtBGAVtZ+mMqLf+EN3vOjlstHuc+R3dk9hjNDVvgZNjcfE4G0SWrcPfwCQGv0vvaWaB/n6dNPZIuSIIahXnaWLPS28WJPeD0AUk+muH1r+9mcOCaESpn8VWW9qaiamKJ6rqRAjNKFS5RIKDdRVG3D5f4pdhqLTO1k/P/svWuwbdlVHvaNOdfa59zmkZQrJFCAAhSCklQSopB5CKFuSXT3PRKyQggpygnxj9hUQAgCJSS1utGj1Xp0S2WDediFqaT8qiJxOTah4N6WLIEQKMZAQKgkVQwlKAPBdmGnyhWC+py15siPMcacY8619j6Pe8655947v6p9995rr8dca+975ljf+MY3wpQqxZT5ahG4IuwyNGjMXT1UWZTVP0b2KJlJMyNFIZ44AIii1lr9eivfH+OPZKxmEk3qIXQSbuciydQWcxfZdnR0dJwZN/7wRzMBdPDF3396Akhjrcvw+9mGNQLIkImf46BkUNut7Ma/+pH8+uBLf1BemOrHSsHXVD/NsxE/HCWWSZuQFcPzHmFWpTBYw3FV9MRDiVeC+vkBsnzeBPHniSSkzYg8R5OFtKr6kbbx+pyTXSV5lAZg3le/n8hII4vZM+pTKddKEmchJIzDjEii+BnDnD1+hlDi6m76fPeix2A1OvnTsRW7unyZQsOXhFw5mMlv47FzEca/D//Ft+cOCtIhCa78xWVdMqGhN/ZrfI62tYR1ebJ232M893EDl1v6Zb8XT/xYOVS7XjUPJz4z8QOg+LuYKoQIB89+A2787lMAXInXiXeoAZSWfEHL0zhnqRzx0/7XaNVM0HNNXF4DJV3lmQwtAzSitSV+atURStCX/69SzqKVVqlyzADNziVRB9GAQvTMfqx6XG867VQ/+RrEQjjlen9HhJEGdX5bsuuzKzvL7vehCp/K4HmFhO7o6OjouLNx7k02rggq1c8OrJWIeWTSx+BjT6A2+vCv14ifaE0iyvxtJVezqm5odsk7VfPwUSFuhPwBpn0t13LxUKX0McJnZdrO9xjm8zOU5+ocuIR35bzkcDGIsse8fnLLd42tjPRpS3le/ZHX4ee+6ceWg+rouMPRyZ+OU8PULJWUdA1E5274DKCof3bg5ifeKS3UQzMjXIB45qGvf1zVDqGofPKNvxIBQD1RJVMvUCGnbALWFtjS3lsILEa6MMXSZeEVD7yrIiaM+PFtxwEUybApUk6k4jjhIMz0kN11Pw2cTDqXell5l7U9DSvj2UL4VCRXe67bhucIIKwQPLksk/yykj2rHkr+QAVxNEjHL45ASmqgqP/fjyVUnN9QyjX6UBIIeSzEhXACGqVXw3WtH6e+POSiyWw1fZL9XBIYd359eEdHR8edjKf//O/j4WvfebuHsVD/tH5AGdrI5DjCZysar59FrL7WMVRLx71noHkT5tjCNW6g7OFDYGKEST435Y505Srq3yoB1MQ9mQyyxRYPaILI4ok0Wsm6WCJYadjy/CEkj3b4ispIWUlY2+XLliWmqgSs485Hj8GW6ORPx6mQiY7c4rH+XLoBWb3vBQ5ECaAbf7ydlZcSlQTMIfvmkPWOPAc89LWPlxaY5K6JyWuzB4usX/mVBPmDtO0GlWaWlpVzUvVFuOPt2XM2qc0ouZt+r+bIwUCyUh6uiJJtpjwtWSTERxBPmABgCKAtpOWxCrZMqqgxt3b0Ks+OeMnBSxt0lQHmT1xJmxlVy/ItP5BoRKEcy0q9srlzoFx+Jd0yNAgbKJd9pRFIavDIkN+kxEeEMANAACWp6bcxrppmm9JnkOPMm4C0IUx7atC4UTIp5NVBs5JNQdggjsjWBhJUUn69+jX4IDFfTyP0CJj1Z2Qdv24zE5Tu9P+8HR0dHXcwrgLxY1gjfN5/9DN4aPyOTPY8NH7HsV3Azg0+QeoSPlWjBZfcsVbslrCRKbg0eqiVP4R5g0z+tA0uWtIHcCpgr/oJXvUj5V5MhczxsO5e0tFLHqb6AXp5172IHoPV6ORPx+ngVAVbVT9GeFxA6cXWUrQ16I1g9im5iC5fjcLCXxOuXrv1oTelOwgMqBqjlBfhQrp9XRZe/uB7nOIHq8RPhid+tsELhdauYbutKrKICUhBlFQArr/gsULmHIdGPs0hLIgeT/YtsFbKZKIvR2554ocS6t9s+/vKpWfOYNp10zLix5d65ddG/OTfWlEDpQjQAIQjF8y5sqp8DczUmaz9KuXMXBrEG8CMpTMZrBlHSnD/b2zfzc+hvZatWgiOKGIleqyG7bjfUEdHR0dHxxWBV/mcRvGzKPcCaqNnS0AlAN49IEE7ZvkJVedTVTKvxqlGDMVSLs4BCBOkjN/m6Shkh9JcAAAgAElEQVRlX2wmzQMWCl8/55O9pxIvWEwyb+SRRgaPLOcRvHwI6u8jiVPp6MUYh1mMnR0hdBoVSC/96rgb0amwjtNjtYSFXZvIcnP2zS9db71+WaCZgXkWzxffQesWiZSHvtZKvZqyJVNuqGGztcbO9cx6/J2JB69qiOVaP/3rb72lMd9OSIcpp/rxGSWT/SZry+6W+e/Jmyfbpjvm8OxNQ6bMce3YNwN4GLJR89a/hAuVSyn3kt97Kfey72ph8Jy4ED++vj35c+bynmV9Slz9nurzbgif3E5VFTim8hmkpfu8R9nk2aTTDDRkHHJdfZFrB20LH3K7ePt/niXgoyh95k3AtE/5Me8B0zUN2vaBtGdm0+VYPpNYEcqZTGsea6Vr9hhMfVSX4bELJNvfx2VA/tzQuT86Ojo6OjoqUABihDWkgCnTrUz8BLB27TmpszIX5znazcG+NGveCOFjz2njlDu2fVjuA27/NnenUbf1XUqt5Eu3MbUPeX8fLfcK2ub9OOXPNlLo1R953Sm+gI6rhh6DLdGVPx1nwvImvFYk0FVLuXvT53Oo+hIfHi8/4VyyxJbDILeuXp/cgVLJAPY3u1zW96a+l92C/bxx/yufkjKlxnjYUBk5c7lGFWHicOa/uUG6ZiHoNa5qhzh76ezEWobMKVey0fcONZJvVe8VTuR+m7vIwdxBztXlZ1PxSvFjJo1a9jU400aTUK+QaWW/jNwtbNbsoPrqeHPrSvFj9f2jBHuZaLKSL+NIA6TMKweR4hmQr+fa9a4GWi4QN/+FcvbQL9yybUdHR0fHPYBAePrP/t7tHsW54+BLfxDZ38erfTzpAxR/wFXvn1I6zd6uwCVlTClcxTrslDoEwDwE9X0aNA5Q9U9WETslcQaX5aTxATX+gWI4rSVfgbXkS58JovpREsiUP3IpUvH6aQ5sHj8tuu9Px92MTv50XAxIZobVblaXhcTZGyXf8J3DeKylu+wXrl0lN9mMHROH3eTrpMtwHYrcGD/4oUdufcC3EQ8cPAXzvSkZoyXxA6AQP215lA8ysq9LA9qy3CGbDEeSVVPTFcoRQEtfm/XvMkuTPRFkYwYWnasWHcu8qseOexJuIpdeIhtMiwy7BGpspIzrkpFf++xdtd9aYSPdv0jNFVHYFaD4CpnqaKDalNGMGRuSiRzpUxM9y3Nci72yL1SDTMd6Ao5QEdG+Zf1logeRHR0dHbcHD3/Wf3e7h3BxoLAgfTh3IK0TlMc1aCllYij+lduUti7BkpBD/qLaUcVO0nItBPXomUnWbWNxFxNxgBBJKLELG/HTklBu+JZzldMoZV6GXV4/a3O0X/81v/K9+NmX/Pj269dxpdFjsBqd/Om4ZXg5KRMJoeH+xj74kndeTNev4xCUEEjL//Q3P3EO5WisN5tVCRln/5gPffBNWzd9xcvebavL9YtYTIa7tr9TINkgISDawGNV8ZMa8qMhU1hlHatz+AoBRErIcSBkD6WZC9GjJYB5ZLnTmBJDzT4rI+/FuVJNWCjhRWsEEOyca8LPVHOZ6EIZT74OZi7e+PywltXNo1PhRCBtzPBZiR2TTSv5ktVHdonM94cJNOtAmRACVWV45uE078kxp30xdzapd9orZBNQSJ9E8prN88erjPJ5byGnbPka/wdV3UWLQnUpEwpp1ZB9lwDpNNErrDs6OjouGw9/9l85UXLoKuGhzV8GOB3f2v3LXl+InxDAQwQGR/4Y5pL0qJRAhpy8siSdSyIF16nLe/RRmYvJElBAJn44ujLvkV3pNed9W8dTAFWimN3rVvWDKMofcuOQh55jfhaVz0lIoE4M3N3oMdgSnfzpODewm0CkBnfLXdptxq0SP0//xtvw8F98+2L5acqzPviLd7ai58Ro1D6ZbFjDNuLHK6hyuZyuwvXrk0Ckx/LbZAhZya0KqDqH9cCgEDJUe12ZAievpwTQLp8pNy9xotypClEJl7XSNw3SPPGTLEsWS6lXFbg1suxyjlhc+7w+a7kYGKQGkFkdZIofp/TJ9fn+eHngKBLxxXUu4/A1/4vVnPqouiZwhFmwdCQvy1DNRPsOuhno6Ojo6Dg9SJNxN//D/3ybR3I8rv+FvwZA4oWnP3NC4kd9fbKX4RhzYsgaRlBi0JRkFtyinLbGERZvcVCvxlHjiLHM8zmBpKjSnzbvkyl/OCt2SCVCnCTpV22X5LzDpFO3JYui7EPGIfsqZWrNwRVtC/f6VMvybSVfa/sDgG/91dfin3zjKZrOdHRcUXTyp+N0yDdNjujxsJvI0GxzRXAuih/U5ssPfcM77nhfngtDoHyjzu65Kvc6ZvuqZMiraLgmB0w1kjuptVA/JoIoTSidMRvojRPNZ8eVGflztnHKuiUzZuOr/v/kLJqOUhU5HFG6flntvdby57ar2bDZjJ+X3bbSgNLdy2OFWLJArSr/0sCMbR0tK5vHciwzjM6P1iPA/j54oqwheRaEjzdTPwncdTYZuEjYIaV+gc+l/PM0mNfYqo6Ojo6Oi8WuUqfbiIOveCMwzbjx6fcJkfPMM6AYwfOMpz/zD3dv++U/VJJi1tAiRvAYkTYxq4Fzw5FZG107JTy1iuYcT6iiOFJWTWf1jZvXcxzh4ztysUFQxU8u1WKnisZSka/KXGYhrUwxnMvHI4tCPhtnstvuZGj9foCaAGrJoN4S/u5Bj8FqdPKn43SwNs3s/vi3ZTAkMrtcE3ybcONT776U4xjxc/15Utp2XgTTnY77X/nUsrOXh5diG2ni/X7MJ6hRjuT2oztap+9aVpVUZVXScsO10q7KNFEDIwuUcscpXZ5PkyFtyK30bG54jDWF0yzZujCzdqwTxsRUVDyo4mcMWtIVJEiKpC1V9dnKvaz8ijz5Vv4fU9LlarQoSh8ZnAV6lKScy7bJmcFN6e5hz9Yu3suxmVTRFAEcrXxPcGPLhJH/u6KEc3bIXn4/zEWdBAKQCHNghIkQpqRd/6Rj22X7/nR0dHR0XDLC1Sv3uP68R4FxwM1/+SQOnvMIMOqt2OERbv77v3PyHZEqdaKUe6UxIA0hxyFW8my9LGhSc2RrWGJJkGzyTMXvx4gfTfJk7x3nG9gSP0UxrGXcRvxELqpecPER9KeiWZvcCZTdvtTkWdrS7+bzWIPNxFRVvu3Cacq+uvqn425AJ386TgVimzgUVd2wu3m7B9FJn4Js9JzJFVSlReUmvyh1cnkUyjoVCcB87O9r5+e+w9bK8q3YUhtfqX5UdcNqkOjHYj5FMLUTESquKatgisKFiGqSyG+bj1nX5IvpcnmujBK9CseudcoinKpjRy7L0k4bEjjKmK1LXSG+moxgJnyWl7F0utt9uSusmVR6c23/kf6eQI4EIkZI+t2wZjNZMqK84gV2ERCesmedOjo6Oi4dV9Dvh+/blNejSFxu/l/vOfkOXMk5h1ASUDGUxFDQ6ZONEFEKaEaeA3P5VI4rLLaBK+0uyZwcU7gYxwifTPwEljjA1EFG/FhGJgC8qPnSwCQREBgpUkky2fEitMPXtotaPkhMEIEvZTLIcJyaZ60UrCuA7mz0GGyJTv50nA5W9tWWfm1Td9zlOHjum8sbF2BclurojgE1z3C/FxZHFkpCKpaSKKAyUM6KDl3PlEKtJxAZ64Ji3Fy1VrcDaACSu2w15UC+tAs2FgleEMzrJqj6JWQlTA6GbHO/z2xQpG9X/HeICTQBYWbwESMcMQJSlkmbzw4PWuI1qtHzxil+BjFcNtPFtVKvrPgxfsUCuSTLKQEU5T2yUsgRL1n9IwGaKYwW8CeXSpy3Fk95M2wrj/PlglWg6X8fVLYjrfmixKCZkAZGPBIjdiZCiIRweJk3BN1ssKPjTsf1F74FACpF6NO/9fbbNZyOkyIQbv7pKdQ0F4yHX/S27Mvz4IufAN23Qfj/Dk+07cFXvFFe2G9wiKXZSgxC+mTSRteZlUwh0lUTaLbScjcHakJLYiEhkNKoKhpXPp6VOXBzcuRc7gUjgFriJxNAWBI/zFWch8ASnql6CEGVP2v3GFzmck4kY2EgpYCZrNQrYojz0uhZk1qnJXe+7aPfg3/84p881TYdtxM9BmvRyZ+O08O78t9jxM/1F76l3DSmVCZL4EpmmG4btrQV3Wb0K1kezfa4sp72xn6BsH6MHEe478PP76SEBjGvEz96fP+ciZ/KdweaaRPip21rDqwQL+68WmNjYiVdSK6fkTOcnGmxI0HM0FlKrahW+li2znfosHN35JN5++ThAcUzx5M1KF+BfZ4zc7E5b8s4+tNOen6e+NlBAOUxoCZ+2H0Hi7JAtz0lAgXIwzjBBCQEZCVVR0dHxwmx2imp40rj5p/+1O0eQgVR6oQ8977/o2850XYHX+m6v2q5l8z5gxg9R1XVONNmAKX5QVUuzUvPnzw+qubaeUMlnjACqI1fjBAKRgJxjlOM+GkbTJR4zDI9Go9YSRopiRQZPAoBtKr6MWIJyGbOzCR5wESYKSCiED+7zKA7Ou4VdPKn43S4R2+YHv7qt8oL0kbUdh0C6k5RnQDaiiqz034m073e8HsZTCOW2XFpfVetXEZFNQEknS/02Xd8ar8zZ6rcln2xtlbNLdY98dMYVC+UTm3AZESSrc4AzYygARjNrORMHZzlErPc2YtqsseXYqlKp2xfriPBAi7//dgHZd1VlTbceayZSPtEnSqsAICm8rmd87Fwx7HgNJ/rFoNtSnLtgv6ewkQgTqAjALhcz5/UzQY7Ou5o3PztxyUO6MRPxxnx0Nc/Dh6Dlh/zct48CYz4CSF7/eRYZGtnUp0iV8kTTW45RW0aLcZR0icgdzTNyaccx3D25rH3ZV23zB/f4g0mqx9wip/CDLEd14ifXcGCI34kt8NKApXHSc2cT9IFrKt/7iz0GKxGJ386bhlrao76hvvyxgJoJwTFjd977y3v7/oL3wLf4UmM8hwJFIp/SDeRbdBcjkxiLH4zVJQ3rRQZZbkFHF6F4nfBACiaRoazsbEpPSgBSEr8zPqcUq36iVpHb0EamXmiDoNQautHyoqbFKkEUK4mvs2k+W4Z3ijRSBaaCfEQCEcaIREBnECznkdur06Ytf0qD8gGz2a4bCqk7MOz8p0wlNgxskaNFk0Z1V7fCkYKedLItqXmM6CUkjEqFVDenQsoq2ut1y6ZwsoIr9FdT7uGfmyJ8jHDESFMjHgYpYzuiIt/UUdHR8cxyAmgjo4z4BUPvAu4Ntbz5BnBIQjpMwSkMYKHsOwy6nBsgqVKWDnixxI7Pl6Bj1s0w5PjHs5kjYzTrYMSzjnNUVb5UC7VdysoqUTBZZIqObHtd3mCpv4JGt8wL6/PWvevjo57AZ386Tgd1lq738HInj3MpXuUEhQ3PvVuXH/BY9ItQpUgGaG5s9XJ7sbH33UJo77zUBkaO3JkweIwkHNBnjgwHmTbXO2VKHYoV15F7iCm+KmUP4YggRVrYJVbntowNWDLyhsld1aND3NHsJr0SVoXb89VydestoyDXACRWjPCkZxcNkG07htRO3w5IqRq5+5IkcZuqCwz4seRQGv/r9vvA/5RrVi+1iqmTI5U2vo9ypYluLTzLMRPGtXYeqyv65L8KY8URfnDxAiREIOQbJcB4Rnv8D+UHR0dAu142tFxGvAYsjKHZgYH6UB5Ehw855ESqwRyCaooHT8tVmmSIIuuqIuETj0vsZWy+ySVLx1HHQcUgoiF+HGlX3kAhIVqh1T1wyjL2f7xSmRikFccbQEzVTGexR5G+pjqw57Pq+yrq3/uDPQYbIlO/nScDZ7CX7spTCfINtxmXH/eo0W906oAiKQdp5nmWXcnh5VEQofil26+Efe/8qnlBaL6Rt1fQ99yvPpdeeKH6n0ZlqVWshOyQD3pTrcps4zcI2mfzkNA2gRV85DL1pl8uXTaao2prWOGZcx8KVZWrqyQFmawXE5K1qUZSkBpZsyXmtl+vJrIMnUrxE/12n/GeslTObbHwntJ/49vVQnx8vvKZMzk/k74fZOQM+Svo16fZF3FBlH8FJ+jcl23kj+TXFce5BhpknVvJfPa0dFxD6P/7eg4Ib75pe/MyaRcTh0JNDP+2YffvHW7qpmIwWKUGMFjlIYTG1/25VZV4kfmQU122dzqe6C7WAYBEvOydg3V11WcorECqxont2GPEJVOZA3BLFaCe/ZBQcqhmvfqga5GPuBYBNrr2alMApESQiSlX8yEozmCiFdLwG4FnQDquBPRyZ+O02Hl5nlR3jFrScWasuKC4Uu+kBgHX/Z63Pj0+xbrXX/eo+vKjxbm+wLU9dREICTZPBEoJdz82DvO4QzuDtz/yqckO0V1xqgoY8q1zL8dXpvkUQgGbQuPoPKepjwskwgWX5DE6DQDIcmByBsf6nb2HUuARkh7EfMYMO8HKTXSsimakT14cllSGxSZAsjMEbXbVooAq1IljcjlWAvyZwZoAwx/rkmwSc41TBA/IzXSTlruNW8KGcJD6cphUmxfSmWDXHj7uOvM7rVfJyuJlNShSa+llqLluM7ivUbNVZ3fCjnss42JNOBUxU8agGlPz3PU8jZ9lnPmSkGVj5+QS7/Ckf4ODuVazs/QpZI/vdNER8edjad/6+299Kvj1OAoypwSJ8jE96EPvmnHVrpt21AEStzoI3f4Co3qR5NU5m/okzVs8ZM3ec7JF8qePzl5ZfGETxZZfGExTAR4SKLS8SVasoWOX0kenfhpiyoITOBUE0H13qiK/XzJl/UZMeLH4zRkTzeEvvvQY7AanfzpOBtcq3eDz+YXY91LHpdhh5/H9ec/evr9VSVfUFZBJ6EA3PytTvwYHrj+ZCZ+dnX8alWYkrNZIReBYjyshjAMnxlypIsngEAiQ2ZIQJJIslVq0F1171LFTxoC5o1k0+Z99dZRNQ4lIQ7CJCSQLLSTKf8fOGfSimLFiJlKpRO5VkElgIgQk1f8FCIpTHKilbFzbB7OtDFfvHwhfTlVQwrlC9lceBubljUSQ/yttOzRWsQzXKKP633Z34XcYW12ZJE7TtW5S9/nFrNa5pVGIG30eY/1M67PuTkmzRLwyjPAR+X7vAwwJNPY0dFxZ6O3du84KV7xsnerMqY0dRDPwUIA7cKqebM2myiNJ1YSPHkHkDic3fHI9qtjsiYM7vO2fH31GMSqYmYgsvryQImfmvwpJI8+Bwapwtde5yGzBBMpkb6m3O3Uzsn2w82carnDlvhZ8wPahbMQP139c7XRY7AlOvnTcSrQLHdUNAdwYKldjuTmBNYuO1yMda8Qrj//0TL5Hjc2TxSnBApas22+L0SgEMQwuAMA8LKHn9SsENlMLCSNSpBruXG9rXV/8Mit33NGS6974mJW7EimTAIxpMU3yVBmBMRs1pCAOQCDlU2J4mceA9KGMN0XMG8I076aCsdy7HhICEeMeEi5m1Qea0N2pkGIinkfWQFUdcWIhVTJ+1DCJ+YOVXJS4Qj5enKg4n0zolIYVaVfFrBZDb6pY9SEcedcWGX5yvXnZIGVEmgarFm7eCGHGiLIPTIB5Px4ssmj9zLSczBl0zwC8zVR+8z7QNow0iYBA4MH1wnEgkXYcUhK/iZTABFoIqRN/V11dNwtIKLrAH4UQn3/NDO/p/n8AQA/C+D3ddH/xsyPX+ogOzruYrzigXdJXJGbQBDMZ5CY8cEPPXL8Thw5I++V+Am+EcWWSdw4GJt7W6/C4JpYMMs8iTpp5JstwJFBJdkkxA8iC+kT5WDkOnu16p4QGCFKuVcICdGSSlqeNSvpQ4HA+jo54odd0EguLqzLxrgqOReiSR5rbd5P2gFsDd0wuuNORSd/Ok4PvbuyiaP9o2yqn6tG/AA4OfHTYssk+/Svv/UcBnUXIon+VqZiDS7U0wekrUOxotZoCSFAySPOwUdWcnDZvgpajLRTcsF8hXJNO1vgBEgJlZR3pb2AeSTMG31o9yweUIgLyDbELCVZFmi0pz+gdMhwwVJFyrQ18Szr0EyVl03eByOfjPn+WPnYKvFjJI9/H3gR4K3CZ++oWa5knhE21TWGxrnu9PLuktutJ4TseydklZWZWnviJyt+NkL4YOTsMVCuoXV4o+xLQAAwADwXwV4pAbwc9DajHZcBIooAfgLAgwD+CMCvE9H/zsyfbFb9CDN/y6UP8Iw4+ILXAgBu/MlP3OaRdHTsxoPf+ASwFzPxYwodmk+5I7IZtbwXU2dT/mzZronNSdXpbNsHqBqJMvFDE+d4qvVPZP8wxbL5/KjRsxA+pSuXkTEUAAoJQZfHkDDEBCLOz0agJBCmOYBZnhOCdOuCVqyl2tR53SKAqsDDrDojMWJICCgEUEvc7CKFOu589BisRid/Ok4H5lw2A+1YgAQgqupn5jLx6Prv/+dvubThbWvtbuZ5pGNaIJAQFsEyIC7DwJw3IffZ+//F5Z3XHQdWlVhuc26RBbYqLtaIiEwoaEkYQciOyhjaVkQhPux1rm838iQCZMQAkXj8WNv0jX+g8tJpjY2lUxQjQH//+gMhNx6vtkltSZbnSh3JQuzIIi0bC04JY35GvCCW6mVZ2VORQVyPrZFnLy68f24/MwWRKpEIEMVPuy0vH2vloFKCVxaa19JsZV72fYwaeBrxk/0F9MLk8TIsVGQLRmMpK0zApZI/HR2XhK8F8HvM/GkAIKKfAfAaAC3509HRcQH4wK8+hpc/+J6cpEGknAxjEuLlOFz/qh+uF5jKx1q8q3rnJF3nrOtoigQeCfNISBvKvos0M+Ih51J2MaNGFavkWGPkXHYOjTlISaBM/ISixI0xgYKQLUNMGIcZQ0iI+hjcJHyUIlIU4ieEiHkWc+Z5DiAtc0uJSgnYtvM19Y8SPmOYMcYZA6X8vE3ts43w2WYQnUCZRPr2j343/tGL/9bxX0hHxxVAJ386Tg1KCTiSNAYFwGYgskzDrHUXl6j8MXLnxifrVusHz3kE2ZvHwyt5fAtN+5hZJhn7g2/doqJs24mfdfzi028EIIbPYWLp3gTkch7hSki6LwGFSNiCvI7dxRunGJziximG2qxVGoAAsthLfgpR5CVG/EhpEWHak1Kq6ZoaCu87s0M9TgwAH8rbeKStw2c1ZkZ9bCNvWH1pcvlYPjn3+wqandNzs/6m4RBIs4zLVC0SQBY/nFT5CTkfIVP5ZCLKjoUl8cMrY3LnUlgU3Vf0Mi0lgNTPIO+v4WOc12N5TY6cgvNK0nOSEi9g3mchgAYGNskpfvx56N8dKuMiiM8TQ8r0pEUu5xK1ywADvd6847LwhQD+0L3/IwBft7LeNxDRxwD83wBez8yfuIzBnRVd8dNxR8LFDtYp9MyKeCv1ipTLvrYd05S3pg7iSOJj6JJbop5WpXHQkmgNlNJI1f6yijlofOIfPnnlJvighJCpfcZhxhgSBiVgYkgYggQMNj9OTs4UiDFnokdUQMRYEl5b5lYr9YqBMYYZe8OUiZ81Iuc8lD6dALqa6DHYEp386TgVbn7sHbj+gseEMJlZWlNXTv0Mq20GcHmqn10TqrUA2IY1cqjZL6UEDgFP/8bbzj7Gewgf/oU3aPZLr7uqMyiS8Br6nbSd4hZQ4sGXFcniouJY3dx9p1nKHAAMhUBKXvUz1h46WfVj9e6A+A0ZmTOJ1RNFArOSCa2SxBMva4PUYCb/8ozIYCUorNtVVvVIBrEt+SqqHyV+4grpY2Mws0R7bRfIOJ9tAZCpayivKOSSRZqsX5IZc6fmnL3iy/+5yOPyweWKubMRP4OTmXsjSTdOzmbsfvz2N0DHHvkyueneaaLjsrDlL02F/xPAf87M/y8RvRLAPwXw7NWdEX0XgO8CgGc961nnOc6OjrsWH/qAdPK6/1VPqfelkD+5UcQxyHE2UFTo5EifbfGsKdhNdQQAsSS5pmum/JHEFDEhTDLnxihdMeWYK3GZJZScgjkPw3NFVIgXU/zsDZMQQHHGGET941U/SXdErlELaQOM8l6COOkE5sfFlfmz+QzFwPooip8hpDOTPLvUPx1XHz0Gq9HJn44zgVT5g0MAQxCDtnB7VD8AZMJjllbvNoHEIDLZlVIuQ9VG04+ZVbECykRF7/RxOtDEpUZ7AtIYAE5gCghHEoCwux8HlgGH9wEyFVAmTIw82lZHRpRLndjYI+MqgsigZ20hPu8JAVS1EY+18oeSdDY3WA18fEYVQFM5F1/fT6m5+2rJD0BIDVOzsCp9KOKIAZpFjTQAOUsn7Vj1fCIkKBtNNVSes7mzU/tYcFYNSI2SVy+lDpIAVQ8p8WbKuAB5HRiY5f9ZOELl8ZR3oO+NuLLlvmTNSu3su0j7SYifyuOn8RdwGdZMAGUiShVLWTa2co4dHXcH/gjAF7v3XwRR92Qw839wr3+BiH6SiP4TZv7TdmfM/FMAfgoAXvSiF/X/OSeE3bhnMOPmx995ewbTcel44PqT2esHgMSTFhufgCu4/kJNmprhjZlGbwMBsHbvrqmGJY1E0azkz6Z4BIKBMAMxkDaaQG7eADS5ICsl31UubqtqrBWCkD9G/OzFSQgYcFb9AKrKCPI8UMoJt+ACwgkRzCxhB2FB+PhQPjiTZ1MYGfHjCZyLUIP0zl8ddwI6+dNxatz8nSdw/QWPqacLA0lu6GlCMVO2CesScPCVb9JjbjHx2NUVwbCFrKKZF6VkHSeHZXKkLIhBatQszJqT9GzBWhWS7BhOBrRDudXsy36TEhAJ2TBvKKt9OIrKxEqPsloGQmoQlLQ4Kvsq+0Q+l+T+suaEQ1FEy1sjP0zNMnD5MJF0sWISzyGo/w+KMgahBHGiUuJs6mxZOk8E+S4cy5Kv4pFTL3fnD/fdUfnqGPoVWMBnBJgdzpeC2QbO8LtSMFkZmyl/9lj8BSqPn3XiJ4t92IJB+6D5nV22kSP3NqMdl4ZfB/BsIvpSAH8M4DsA/GW/AhF9PoB/w8xMRF8L+d/47y59pCfAnWL0fP15j+ayHACrN+rXX7go8c4AACAASURBVPAYbv7OE5c8so7bgspWALnrFiXGP/vwm0+3D5u3rYUpJC7Nnj2WbyWLQaiYMwfx95n2ocof7Zq5QZ4PwxEw7QPDZwCO0s3UPH/s83lfh6RxSY4JPA/kE3UsJstDnBG1xMuIn1aBY3PjgAREYCJG5ISZAiYOQuBo+dYRRcyJkFKokn7MruMwMYISS6N6/pjRs5V95fmYyvHXSKH2s23qn3a7jiuGHoMt0MmfjrNh1gkgieVZNvtw/MtllHwdfOWbTr6yJ6NOYPbaSZ9bwwd/8RE8+BKX7ZwBDEoIMRUFD1AUM7wiN7bPbwFy719KxXI3KW+YbCVdEfJbcZ45gOhdELSVeBSuMYQSZBHzulxax1/xLT6DFjh3xaCoXlMDAzMLEaIGizToz9bX31vAZ8ST7dMIGt13tby9mPmGpXTKWqzFtg9lb9SgmVVZIx5MlA2ujQwioOJdWMfvX3vj6jTq+Zq5s7aSzaVeAVuJn/xsxE8+VxnzcfxvR8edDmaeiOh7ATwNcaj7n5j5E0T0P+jnfxvAfwXgu4loAvDnAL6D+eq15jz4/O+RF1f8P+715zfED9Dc/HN+f/2rfhg3P/aOSx5hx2XhZQ8/qXNymfSs5Curf86CbFhY4hd5rW3brYtXpHx8SaSIonnaF+Jnuk8TLE75wxEIh8AEeT8wZeUOoIks459cU4ZdSZQQTHkj5VemuPHETwCLYbInVlQRNKWARCyEUBByJ1JCipLBI0q5BTwzVUrm7PMzzKX0TEknO1ZFAJ0CJyF+EhNe8yvfi599yY+fev8dHZeFTv50nAnEDJ6k2jX7nbiAh8MlyX6sxhkok2Oo/6hLl4Rj9tOoR2586t3nPNC7Gy9/8D25zt2DDtUYPBI4BqQhgBIhTIw5qsEgKCtJFtu7UqTK4Dl/xtVn1T78/YyTqJSsmBJARrBsnOJkYFHcGKHCJKVErErsQZ+1vItSqVsHAWHS7JrKqpMrQTOiRlquMjAm0JAQNzNClHXmo4gZjHQYMM9ixgitYmQqYzUzaSnt4kxaVcRP9vzhZYmUvmAz03b/D8r11u+Hkbu2EbGUejGEUGMlv5hAQQisTABJvJaVTplfMtLHlEvWsj6ytHOPLIqfoKVeqvzJ3USqQfofDelPSj2J8o8Djiy6vHtdRvcF6Lg8MPMvAPiFZtnfdq9/HMAddWdy8AWvvZLqn+vPf7TcmDcklamNizLiyvFrHecMSeqY/MUWMpCgnj8JD33DO/D+/+OHt+2ilHwZWvKTuSrNKi3YtSPWUN7PG1H8zHuleYLEDVy2n5UsisiNGII2tahsUqr2qjq0UM+tosBp1iFGdEbLvs26EUCAI1YYmbBJTMjdhMmZQTOQKCCxeC62lyuEVNq7HzPX7/r8pP5AXVVytdFjsCU6+dNxNpgnDrOYIZvBhspOL70b1lr3rl0ZQxUr5QCNuRM+Z8TLH3zPzs9pnsHSYx3xMxPSMAIbyn4w29Q/lY/vGgm0Cy2BgWafSkxUrUz9Qztn2bpgIRw4yURPUV9b23n9+ds5WNlXkXuXY+bj544ZAEVGiBKsMBM4SpaLI4MHyeLxXHjOyuiZZByV4sdl7kwBUxE/cJ+zBGje36q5mEr4WLLRf0Em73FEj9+3H4/rdlZd56DZyKhB6WCKn5rAshp+U/fk03CvOWcteVnIpmO5TOLH0IPDjo7T4ca/Ft8MK/26aqhKvXaUljNR1eGpq3/uTrz8Fe8BRosn15NZAEQ1vwUV8ZNJJLe+ddRkUdomIulgGUnihUGInKTeefNGvBXnPSV+NqImrppCOOWzdVQ17x9rNrEsE3dYclMLVO3UjfhR9U1oZdFuHXmTFjYSCYSZJHzi5kKTmkx74ue0Js9nVQZ59c+rP/I6/Nw3/dip99FxMegxWI1O/nTcGma5SbPghkGX3xHLq3+Axc1rbtu+Q/3TS7zODgtujQQyBdD1FzwmlOAYQSmBDhOm/b1C5BgxwshmzscZIhY1ypLcsffH/o1fISZq4kdUJhw5ryNBF8lvPTGYKJeH2XZG8nAbKOWHECa55EuPFUKqWqImFsqCQhDyJ3LO6JmfTin5MsK1JXYaksR91pIfDMtQKwEELt+DL59yJj+llEvJItryxelYfc7Ql6pVJs+RS0ZSTay9d1F58FYCJ3v9OOVP2w3sileRdHR0OFwVxc/Bl70eAHDj0+/DwXPfDAxBSB9TOVt8cYKS8o67D9KkoSRQqinKxZ5navXuu16xc7vRudSIH0kYWem0Ej8bp2o24kfjh6wSjpxLxiyhQxN0/kWJWXZgTfXTnupJyZgFIRQSiItyaE4BkRgzUyZ/zI+neASlrDi6SLSkQicZOu4E9N5nHWdCpZJhBmapf3n6N99++8Yhes+ciVPbf/nITKg99Ab05id6F45bgXnecCB86ANvwsNf81Zc/6oia6bPTKApyfeRWOTP+QHNYq0offxr+5x1O1PTeHIFO4ifZv7PRsMNASFtxVn8ZvYSsJ+AvQTeT+C9hLRJYkK80fWtZGwopUu+U4aN08ZKjEx6IIrJcxgYcRDiJ4SEcZglcBkSMCbwwDomyeDNm9IRi1Ud44kRdq9b1U9+DuURVHUUBkYYEkIU7yEyZVL2CzJCyV3rFaUPU319JQOpjz3NQurzvM+Y91k6eu1pudcmZdIr+/u4ci8jc/x/8+qhZBoFIAxyLmFIiGPCMM6I7nEZYEhAeN6Pjo6OS8QQgb0RB899M9gTPwFLzx8FMdc3+9oQ4/rzH63Wu/68R3H9eY8KqdRxx+GBg6dKa3Ugf88W2wAAD0HWYcbDL3obAPGsbH0rKwXZjrbu5u2TopA1mfgZhPiZ98TIed63zpn+d4iSgNok4LNm8OdMmD93xtF/xHjmPwamz9ZSMSsja5Jmi1yPqnA4EVKiSpEzp3Kruav8xpeGDVTMoYeQsNFuYfvDEa6Nh9gfj7A/TNgbJmziXL3eDFPVUn6NAPLlZ+cBPyfbHP2qX/6+c9t/x9nRY7AluvKn48y4KmoZI4AOnvOILmmUQDvQ26/eOiSgAaDqn2GMWuOeSgc2rgMPI0Y4K3+0tAgrypn8mjMRdCxWOoBV87/6wljmzIhA1qwYhrr7Fll5UxLvH44MtrbrEZXJcRUYcf1sGTRT7Zg6py5dQiE53BiztxZQytKCO94aSePG4kkTuyALBU1mbVT9k4oyqDofL7Hysp58ffV6piIgas+FA4t6yjKRUcgm61hWiKbdX/hq2Rfcd+euZVg7546Ojo7jYOVdUf8+muJnC+kDoJn36mXZL4i5tPTuuOOQ27o7tB6ErPGG+PIEhMNJvv+h1EI//DVvFRJR7Qjyb0h/X1u9K8kRNDkRZ2XUpYtpUTETkEvaLQEliZAUtNwpBUwgRPX+yXHGGtjGyDkRx3pz3JZkya7K/4mTlFdZpy4zh7b1p1RMo/0+gnoM+fbutvyiURFA3WOm4wqjkz8ddw+07p6McFhMyFzdyHbi53yQ1L+HZrnZn6+NCCGApgQ6mrULlnw3YRLVDE0MqOFzbtNpfMJKBZE3e6YmSF7UpLdlfyvrs2bKfICURgaPLIHRJoFiQvBtTWdCChEpmnQHCJN2/9JOXBQakimTWzYYZLl17sKl55+YQExauuROPIr5dHJ+PHV7d6733ah+6ouhTyFVpIgRIjlYswAuyU45AWmWkyNbxmbsbGyVHjdIwVWKBAoSa+bOaXbp9H0urYst6aM3ROBsKunL2LwCyJ9bJrjyT0H+x4eQEJ1vUHWul4A7PUvU0XHPI9S+Psc2kjD1h3+/hrxP3uob1HGFYXOfJsCqj9rcSiBRACVRjlls9PDXvLX8DgIviMD8W/PeUta8glDFPDkGMALIklouIUWJ8txLQVSxFBhpSJhA0shCApTiabim9kHZJzRBxqyDcOcew+mYzewHtOIVJLldQoiMSddryZ+2w9cuhY83nT4rWtWPx8Evfz9uvPRHb2n/HbeOHoPV6ORPx12DG598F64/71FwCLj5qXc6JdDVUSndbXjJt71PSDYNDERwFaSLl5FvmYyT1qPyurR6p4TcCWoXWlJFFrpFTRBUrVftqFX7oCh4VAZNpGVQMWWyIJFImqGBE6vMmm38rASYqVt2BUtuOYXkGoNQfq7ICSVYWAkj75ljvjimKmovwdLoWcunjAyxdfQzZlJPHwaREkAICEjgpFX9CSBQ7v5Vrj+QfXWCeBPYGCvSx4iv6M9nC/GjYy3n48fbnGdziY3siYEzAWQ4oTiwo6Ojo9ysg3Dz4+8sN+ym3sk+dFzeGxmwVnIO4ObvPCEl0r0T2B2Jlz30JHioJ9ydApNAQiKO0dyKAaBqPCLraWKFuSJ7oCQQa6lXPp4aQBclNepky5ZYhAMjBEbUknMOBE4B0x5JMisFwGKancSPex1UHd3EMLdSYtWqdjI5FJbKHwCZ9BlWun0FSki8i7U9P3TCoeOqopM/HXcV1vx7OvFzPrj/1e8FINmkj/zTH8JLvu19pWMEACLKSSuaA4gSAqv0Y62LlAtYqvKoC5gvvQw7jzkAqe3wZd4ygVUdI8GRxjRIkcEpAQOBZ1W3zIX8ycp+I5cqNQ62B2F6HRJMVVNn8nJZWTZotNdc77NV/VSkTyFO7BHy62o07p4lSEZQ29XDfd85g2jkTNKDhJIIzNfCjz2bVMMpghzx04zdd/hqzZsX3zOc+ke3i/o9xiBy8OLJeTmBGa8Epx0dHXcODp775nwTfvPj78TDX/1WKdFpYSSPET/63vv+MJG2r6bijUckfwNnxsFz39xjliuKh1/0NnAIuZvtL77/jbj/VU9lhe9W4keJGMySAAtQiXBD+vG88lsBiuonEjgGbc3eEEBqq+g9EMt+7EUhh3KiJogydojyY51TwDxK3JZmRsgHQf1c7bicijVdYC7kx1lKrtYIn/Z9Vv1Qfay2rfxllHx1XF30GGyJTv503LXordvPhm++XwJPM3GWOnVIsKtqnpf8l+8r9eVWT86SkaJR2pPTFBCPEmhi0NyU4iUGBapjn9U24ztAjlhQ1U+2oWlNof1htHNWNng2k+eBgZElCI9C+gRVjGTCYI8xhShdJgiiigkyGBoAnpAJrGTdwHIrVS6kTShRGKeAhIQJsZQkJVPclK4hvrwtl0s5NU3lk7PtMiqZRUHaoQbiqiSquk5mbJcIcwzynEIeW5qCln0ReJaSNSYGZhQCKI+b81jL98VFJWTHXlH82Ochl3/VpJaNO3f60PXse5OuHxIAGhF0mSVfQK//7+i4E3H9eY8WQ2c44seEAyudRVdVQH4doFZz5A+USJ9mHDz7Dbjxu09dwBl13Aqe/o234aGvfxyAmTy7D3PmB+sJHk2eEEnsQVo6DaA0vgDACKDZNSMIAMcI3kSkgcBjQBoCeCB5HyQBpVsCRxJHhRmgGbnhBFtJuv0c27kX0PkzYbw24QgyrzNDEniOQCrePtUJ5v1yEgWR/PwJUwrYj1MmZE6L1rfHVERJ//+0N/a+1Ks93kWpfnb5/Tz84f8RT9//Ixdy3I6TocdgNTr509HRAaCQPh6VT5Jldmzi90oQfU4DQLNIQwKEHFF3nK3SdstanWpObv+Or5FGOs5q7idUpBW7Tl3iO2MdpQDzkDFiRAiDJEFX1OeBASbQ5Dw72R9njfipx2818pzKcs7Gy9vPue3y1QZyi0tGhTixICzGlMkRoA6UkmXvAiEkRkoEmhkzqawpMpgYiSMIrHVUGtD6YMzOOTjfAe/jU51fOSev+AlGTq2QPqb2CcErmcr3Zm1f7bOwM0Xb0dFxlXDw+d8DALjxr3/y8g9u6h6dFDLx47swNSqfrSVcvhS69W+BKhGDrpPQCaArivm+ES97WMu9Akkiy6aUFcVNqai2F/KPRFby/XNQLz23g1zyReITlDYB8yYg7QXp7NUm3wAhkHSepkniEhpRfA89MZW3oapEi0jmeknYyBh82XUeX6Jqms9JqmZ6vdUGCwvFjzeMhr+my3VOQjSdlBQ40b62JJUSEx78pR/ABx74Gyc6VkfHRaOTPx0dHavEj1fiZKmwBrDZF9gCEB9QKFEi5V/yHJLuwwgjW50X8dLpQIVnyImnHff23n+GA3K7dGinKWl/3mRqHaEABDAnzANjTgkYCcwBaQOApNMUGfeRyR/tauU6WVkZFyBZMkDL5Rz5w161lIkdyoqZfK1bpc9K/OE7fWWFjBI/o5W3NWVVvmNHgJE+NaQsLIERpDW7fRE+0PXlXm58vuuYL4nL1zugGFOvKJOM9DGSKJM7jgQy4sfIHwsKL7XjF/fa/46Os8CIn9uB6y94rCJ5vOnuGtZUPlXXpuD24xHyyuV4RIt9dVwNpFHJFyUGj/vLbgRQJlFM1ENKADFQ6rUcSQRoDCHEz3QtYt4LmPdV8ePiHTlQIaAoAWEGwgTwkXotmr9eOz5V58yq4k0p6PzLSJElNpqpOo515qjOnZtnh02cz721usfafo8ja47tMkZ8bNnaSef1k3Q167hA9BhsgU7+dHTcw3jwJe9UQqTO4gC2jCplj5SAUU2gkCNVGFLORYwwEYgDwsRgTrmF6an+BmtMZMcn7FYIVYFQsmBISCwbr5V7zZu65IsHKfciZY98Z6hcFhUTYpQBTDHiiAAeWcqiJsqqpzx2JXw4MKAKIIpW1sTl/BKVzll2Cqmof8r5lzbxp1H92MUhLfMaHPEzxBljmFcl2VZTP3PAnAKOQsQUA46miIkYc2CAgvgfIQgxGBwj50q7Fl97Tokiq36yCXUs5WktKeXJHnvfEj7ynaVc6hU19dlr/zs67gx44ucyVT+VD4/NgVvKvCq0Js+GNbLHmfduXbd3/rpyeNlDTyqRQnnu3oZTxTmtSbgpdbLqJ2K6FuSxT5K0IuQuq5Q4l3dZ8otmiPJnEhIoQRJ1pB6GVrZlZdysP8bKqFmTWEjI20i9u6nYds+nNk+f1XR5bb5OoGNJpFsla47bz1kQiHv5V8eVQSd/OjruUTz44ieKDL2F3a3nrlWUu3oJ+WByY4L33SFYUkg7YmVDZTouTnDHxjKrtWu9FSPp9lyYtPwqUJFMuzaoiKb4WckghZpUQEgYB0nfpTFgBsAbACGApzJm8+HJJU9G+jQtzGVlG3phScw00Z9drbBqBppTjO4z95o8EeNUMbs6Y1iwNCXJ2tn7ORCClcEFIYgsqFQepwjH/D53BV/kx1gbUtv4vcKnVTOZmXPx/kl5+Vm9Bs4DjJ516ui46rj+QjHxXSh93DL5gOtnM4L+2DuKMbQRPIFbfYQuD7Xvj5b4kHXG9Pu/TTj4wtcBAG788Y/d1nFcFTxw8BR4L+SEVzuduKnbzdNU3jNn7xxCLXle9SaMJKqf/YjpsyLm/YDDzyVM17RMHULq0AzQTAiTvS9+h8MzyL6DgCW/hLyhicCD+PpMhxEUS+CSf9pRkmLSyZSyukh8gMr5lVKykvkiVdzOKSAx5fgikPuNO/j27rcyX64SRiv721bulf2Edny+9TM7B12nK36uBnoMtkQnfzo67kE89A3vyBO3tVrP5UpmojdqV4nByBMhTZK1OA+EFIvqB8hqYLX4kc/FbNAFOy4gyo+cDa35Aa/4MZm0VT61f8tN5WOBD9w6HGXc2eB5KKofKcsqXb6MfGCmHNt4w+BR3w8xIQTGtAmYxgFpJvAc6pidfPcwZPUNgNLWPam6xzx+jov5V+awTLTYF8DuerIEm5kkcS3PrSRqE+fcFaP1/QE0qNHysKMUEYjxGQLmOeh1YgARnBhpFn8n8gPlxYtyLqb6MeInFNWPL+vyXbuyyTNKpzJv6OxJn5bUuh1BQA88OjpOh8tU+zz81W91N+72BwXriQV/7xrEBLiC367d3r/P5V6yT0rJKT/Wb5AvE530qZFGKnFKNvSWz4T40fjE4OKcXNpFnLt+5e31OyeWbm8AsslzujZg3oja5/BzCNMeMO9L7AKGJJuOgHCE7CVIRBJzWULO1EFzGQsZD5WA3F1Ux5TjEKDEGgFgNl8id1KW7fEJJwIoaiImMPaHI9d1a/vv2s+Rx5Zsrah/zsPfp/UT8uuftmTNE0BAOb+u/rk96DFYjU7+dHTcg1j4Dig++Etvzq9f9vCTlXKnMkoO2s1Kb94r4798jPq5In0Gk6CUjdjvJ+9k2/jrfeZjV8SLrhuUuDKlj2XCjHRyXaiKMsaZIoekh3KGwYqkCiAeZ1AgpIrk0n2FVMgMd1oWZCWSzhhIS3PtE0EDsZoA0p2sfM12HqMSPkNIFfGzFkQFlSD5z2NIeswAkGT6gCBGlakEyJm9O0bFJWNz6p88Vi3hCoXUsXX9WO28BhICqGQaucrm9WxcR0fHTuwgfrwny83ffDy/9u3gAZSJZAW53bsSQNkvKEFKahIDnHDwpT+IG7//18/nnDrOjJf+pffm+CdPOc2zT5xV6l84rsTWIaih81JBBECUYWPAvBeR9gLmDWHeA9JGytW9kidYDKbkTiDx+7FxlNIwp9oxWFm56+ZVkjmyA4oa07CSW/mksIwvcszDCNZMIqRFpy+bf1vC57h52ZRBwMnKv6pjnYL42bXMlrf788qlPFa3Xi8577hK6ORPR8c9hgdf/ER+/YFfeXR1nftf+RSwCUvix5dxKXlSGQ6385t9FkpbU0SqVD8nbLaQs2ut3L6sYBGXW2Q+P5mwKl2+2KmWjHQwvx/ZvcsCOWIkgMXB2g6pf0VnCkihtBE300Rpp163GTeDxZS0zp6SeOYwq3CH6mtJyuxsix+Wp148JDOx4syRUZdGtY8WQbN8dv6Un5EJMfFzKu3mC5G1FiWuYJEkb4ycm9IuW8eCVRs7tedzgu4gFwkGdbKpo+OK4uGvfmttsuvhjZeN+LFHKJ4lB895pJ6PvF/QLvgOYar+qO7Ou+nzlUCOeQBkdTFDO1wq3FedFdBuuZXDQ02eGaLQ8epX6+6FSGIsvScdvuYNZbWydSgFtNmYJa1md6wgBJCNw/yAFliZ631XTYJ0QDVlOCz+aqd0kn2xI34CMUZVFUtpeRmAECXL4Zx3YmaN+FlrC39WtOOtiB8qJWB+DAGMV/3y9+HnX/o3z3zcjtOhx2BLdPKno+MewgPXn8Sorz/w0ceq5QBgHj48em8cWlEAFeJkF4wcShEg63bSkkmxvF71sqFaXbyWTW3n79LVS0rPpNTLlX2Nrr17NmCWbdqSIyMXyJUSRQCRtGQqzTiKEVMKmOZyQ2CEzxjMXHnOn00cMM0RcyIczhHTHDHNAWkO0mbVAjn38J4CcpIo4h6mOuDUl9lXyJ1bVMPnMcxZ9ZNVMitlWT6blcvGOCnJNSNFwgTLdFlwxXl8nGvPVjKGGjTmbl7UmDcrYTbElEvvWvWVfflm7DyEtFAzAXW2cVfdfkdHx72DitAhKVblRNIdyfn7kJVj6bKbv/341n1W8L62Xjm0QvJwJNz85JM4+NIf1MERDr7kB3DjD3qL6NuBlz30JNJeAIai6CGd10SdpStagstIk5YYMuIoscQkaMIY9QOiKKowHghpL2LeEKZ9QtpIvJITVjqvJyql6WRKbJtqm+RPBpV9cEDucFqRPj5vgwRQKFN42pKE0rkcgREiYxxmDHHGJswYghBAhouee3e1XL8ItDHGaun8KcvGOjouEp386ei4l0BUkT4GkzNbSZa1MrXuWJkUssDBkTSW3dyZPSWoX88K8WMKoGOwTSVUSs+9KqiM1St+cgAVIRmthdqkVsgY4dMikwpJCJWyfSGLzFB5L07ZV8cwpYAjSpi044UFWzMAVi23CGbUCNQCK0/yuEziNh8kG5M9l9r78hhCfX5rgcxatkyuEVXXKgeArUppJRPqvX680fNy/MhjXmtJn8eEWu3TqphaQ8nLDMb4goLOjo6Os+P6C98ihE72WlFFjyl+9JnmmvhZBbP+mSNZlwgUghBJioposv07FuDmx9+52G0nfm4PXv6K94BV/QwY6SPBBs1cz2+hxEcAlC+higBignQJg6p+ZgZFfQ6EQEnU0USY96S7l5E/815R/dSqZYlBUgJoIkSNd0hbvNv0x4PGPgSkUUyceZNAIyOMM+KQSsKruQ6JCWkmzDGCpwAkAicU/x87t8CggRE3M/bGCXvDhM8aD7EfJwyUMIQ5d/haxBPnkIzZZersPzuufftJsebpc5p9vvojr8PPfVP31bos9BisRid/OjruIXAA7n/VU5j3lXRIkDahRsBoq24jfTxRk719jFjZJmlvVThGGKl0ZUH8aAlZ6x0kAzS1T72s2r/KmqES6syJkDtOLOdjz8gkliMejCjBenDAWqRvnw0hSXBkkl7tbJHNocOMvUGCn02c83ZTCjgMCYezFO/H2QWJAOYJoBT0POwmobk+Wwigta/B7JW8YXJLjBhhsgueUAnEmAHEwGBOYv688v0RSincwvvHEUH5PigTcHBkjz8XXpVb+3IvW+afz6OTyFnRVUYdHVcL11/4lkzC5MTFrDfPzFmxKDf6XBQ/awTNp95d7/v5jy73DVT7AYCbv/ME1nDj9/86Dr7s9bjx6fed+fwOvvB1O02bD774+8vx/vBHz3ycuxVm8Fz5GTIWKuMSDyETeRy4EECo4yYDByn7Eo8cIPvlRVKVcsB0Tdu6O7U1awcueS8ZH0qm/NFEnJWzm/Gzkj/zPoNHI34Swpgw7k2irHW+ekAhSeY5YI6EKTCmEMEzqfpHgzPzCIpS7jWMM8ZhxmZwqh9VPQdKmFLced3PY47eVeZ1ntjm6XOcl1H3/7l89BisRid/OjruAbzs4Scl8BgDbO4VsgcACKy1YBwIadT68qGUeEFWawwt9ZmL6mc1MIoiT5b9y7IUHZlBbjw+QMrLjTTCIoASebUEOWFm0FwMGY3oSWORTc8bMU0sWTTtwmXkiStBooZ08MglUlRMhCcKmNUHwsqPNmHGUuiqKAAAIABJREFU/jBhEyZswpzr3hMHHKaIKUV8Zh5wmCKGow0O44ApBfz5MyPmwDhKeuIpMz01edISQO13Q9BOYwlBy72GOOeSL2vzfhzxk4kULt47iSibPqdACCEBKYADi5UFG1lmBJCNqfxw8vWurnk9Dq/2WSV3dD++dG2tbf2aIWNHR8e9B0/8ZN+dOQGBcPNj78D1r/ph8VABdqt9tuDmx9+J6897VCQZNn86geXNTywJpBbHET8HX/BaIMby97Qdpy4/+OLvr8idgy/5AXkRbV7pWAOr+nnr9QUsS2SZlVL2pZkYFe/K5i4hlY9hhs2JkEh+jxwIaaMl6tF1VHXNKtLAgMYvAAMzgWfWsZC0cddOq4CU3ac9RtoT8gf7CcP+hGFI2N87wibO2ZzZkxXiTRhwlAIOdZ5OWp7OCUXVRkCIjGikT5yxiVP2+4l6EeYdc+5J1D+n7ejVzvGt6sfHEGfFWmv4lgjqZE/HVUMnfzo67mEY4UKgUiblPHgqo8Mz3CubTw07wmmhJMLaa0cO+ayXkUUmdtGW7mESgikoyUCMUu4VgGSKH9/xy3x+VkAuOCixH62uX5cYiReO+c4IASTKnzFYO/WU5c8+CJnU/Hk+GjEOs5SPRQYnNVIkY3rai2zXo5b+kLtW0jGreBZtK406DcTk2beQZ2kHa+Pcqvrh8r5R+hz3G2uJISN+/JiuWqDF3Immjo4rhcq4GbnNNRILaRNQDJ13KH524eYn3omD57657Ftx45PvuqWhZ9j4tipwZdwLVU9wygtlB3pXsSWs7H2xnIqiByhxSZXIAooKWV8bOZTVzgZV6Egn+OKzmCqvxVr5g5GBgUExlUElQjoU9S1NAE9QN2iAB0baMHgvAZuEuDdhb2/C3jjhvs0h9uKUk0EeEwcpUU9RPPdCQkoBR1NEYsrkjyVxhpiwGSfsD0fYV8Xzrvbu527wvFLm1R7vNPs5DSnk122JoG3Kn2/91dfin3zjT5z4GB1nQ4/BlujkT0fHPQT7+9dKlCVAKYqfFIvyZ/WG3O7f9T6fQXXr0qzUodIRlcryovIphIondpgKUZPLz1x3Lpj8OklXizQDNANhImlryhoPja5DxsaZPY9cjBNpOwkE2D2CnFjrm2MwtcmUAoJmzzZhzo8xzBhoVrNoYa2MBNqECVOKGELCZ6YBe3HCnx3ugTRomACkROCZQFlqvfJ9NEQa6bmFmBBjUgNGIaE2ca7UMW1QtGuizD5B2qo4sfgTzYEQmCSBHmTsMiwpoSBVSlXd0HJ5V3m/hsSEsfUmQq0GWjN53oWrRhJ1dHRcPK4//9FCmKinjxEyB89+g3iZMEH1i6cmfS4N1/Zx4/feK0oe8yia0/ElXMGpWazDZGIcfPkPAQBu/N57L3bcdwpcjGTIySyql7Vl2QRo7MN5/eJBSDkZBghRIN0zpSMqa+m9T45kqEkzBgaGhKBePVBfHg6MFIMofybKBCAHAJsE7M0IY8JmI6TPtc0RPmd8ZitRM6WIQ31EShjjgKM5YhxmTHOofFRMWbw/iN+PxD5TVv0AonhOOFvnpePm6+OIn637bYKpSjmEs3kDej+gXcqfQIxv++j34B+/+CdPfYyOjltBJ386Ou4B/OLTbwQAvPQ17y2kTyYLSsTSZpkWwQfglCaoyR4lgMynxwdJ+dl14arKu1zmrGrPHiE179belNwxWQgfnoFwVE5DZNQNgbQHZ5Yo9elwHb7OijXvmUBcyqkaVUpE/R5IiCAgzNjwBAyQErA4Y5MIhyGJ9DsEIX62qX/aRUpoUdDuWdoJK4a6zGu1w9dpzj8bMfv7KQ15jYHzy9ipd3Jw696vn93WUq9t6101dLPBjo7bj4OveCOICDzERenVwZe9XiaPadab+eFE5Vm7cG4qn7V9K0lzakPocahJDSV/jjW0vodw/6ueyh2+fCmX5V5a5ESXXVZTuGoCJCe0jPhxRFFOiBDyznMVN9fLOEBilyjEz7CRci1A9pESYZ4iOAFpcpk7YoQhIQ5C/HzW3iE+Z+8z+OzxEJ89PoNr8Wg1DjjigClFTBzwmThKZ1IOOJwjZg6a+KGchIkk5M99wxE2Yarm45nXSR8fQ7WkyUlxFuJnKyFzC+VnVSy441zaxGHHxaPHYDUuhfwhogjgNwD8MTN/CxH9BQD/C4AvAfAHAP5rZv5/LmMsHR0dyJkqQ0XKWKmXBRvtpsCCALLlHDTb1AQtWd1jpI8zUqxKwLREC6b4GVS545U/enxS8se8GYIGZomQjQ6TkkYplocZTdsY1qYEmygSkzXoqJYbtk3qu9QnpviJqoQZMCMgIGk3jE2YMYWAOQYMMWFOQcq/wNJlYwaq1GNzAqL6AXIL9SAlWTGwdt1IC1JqF1pyC1zOz2r4ffcwSYTKDyQ3/WJHAK1gm+LnOPjj9iCqo6PjJFgjdW58+n1Z/bJtnduNg+c8Ag6hLksDyjKgEDvaRODp33p7tQ8OIXedKoohBk0A5rmXgAH48M+/Ad/0re9bUfjUUy8Ap6B26wIakHBex8dBHpn3Cag6aJEIhJc+iqHM64EkueMJoHmYkVIQtbBLvoQg7dfHYcb+eIT7hiPsxwnXohA1LRITRgAI4vUnpyRExibMmJT8ycPSpNcmzrnU3ZREQvysd/o6CbaSLWfI3J1UQXSW7Vs/wbYj2GJ9jVm+/aPfjX/04r+187gdHeeJy1L+fD+ATwH4XH3/JgAfZOb3ENGb9P0bL2ksHR33LCr5sZEgLjDxPjmtL4+pbSrCxH3Ouo4pPNCuY8f15E87Ht+OfTDDZlHqpIgcCYk0HwhHUuYVRkKYgHDoCCGy7UX5k0YWImlg6Zjh1T92fTSTxQDmFESGzcAA6epFxKC0m2zwJUiDmjxX9eAuSjQCCJByLNm+qIamWdblRJgnRkKU6z/rBfc+P3otSTODcUzFgHGcsBkmjGrAuFbf3+IkQVAiCTzt2oSQQCStkoXskYwpNA6m5prlFvE74ANYYFnu5R9bz+W2Zn3OJnPv6Og4X9z4l0/u/vw2lzwdfNH3qRJH/jbf+BPxA8mqpHHIxE8mfFR2yUTlPSAkQUpibj3PQFJCy7a39ZMoRGX+ZoAIB1/+Q7f9WtxO3P/q92blT12WTivkj37uS+RF1AsfXNSNM5bHlI6ojuxhVgKISrJtZTsjgKwpAqvCRn5G2tVVPxuikDOl9HvOsUls4xmLSwAxo0YhfyaSurU2RrCYx5TPQCF+fFfUtJZVvEWctaNWW9pVdfBqrslJ97mmZqo+XyjAOy4WPQZrcf7/AxsQ0RcBeBWAn3aLXwPg7+rrvwvgv7jocXR0dChcMFMbO7sAZmuWy21LWGxrnSk8kZMfo1Pz+M+1A9e8J4+kz/M+I+0npL0kXSr2kjzUuJBHzoTOtgc3xyukD0QZsyr70dgtUZY1zylgzs9igjhpW3d7GGxiN4LI17zPWwiVUoolQX82jFavnhgTQkygkEQFFLxnkfuughBlFMTrJwQWvx8t+8odsbZ4/QAnI0oWZVg6fu/dk4kdfwy/6xPOxd4LyJd7rY19rZPXVZj0M6l4jo+Ojo67Bwdf8gOi5iGS5xBw8IWvW65oNbaRMgnEUd5zDOUxBvAYwWOUrmBDyH5HmfgJARh0+yGAxyGP4eDZb7j0a3Cl4ErgFkmy6B5OlbxIrrXrmUd3M3W1f86z6kcbWtTjcO/12UquxpCwN0y4Nh7h2jjh2uYI1zZH2B8n7GkXrjHKc8D2BFYbp1hsMuhjPx5hPx7hvniYX+/HI2zi5EredyeXACxip7PiVlupr5EzZyV+1ta3/bX77cTP5aHHYDUuQ/nzIwDeAOBz3LL/jJn/BACY+U+I6D+9hHF0dNzTuP/V7wWF3AAi159bQOLNCKvOWgqbpnJyS4OcSsXjP7cNW3Ip1NtmImhkVfwweBASA2OpbwcVlTqrAXKa1NwwBqSZQJuiBrLBmtonbZT4GdiZS6uSSMuZACF9AoCZCIlZ3gcuHctYOnEMlBZERKCiJBpCyawNobR82U4Aif/PRsu/MEAMpDWw+7NnNpgiYzqM0olkli8zK8ujEC1hlNr+cZywGSXQ2x+OVI49V8bIx2FrUMW1/06i0vVriNLxDDHJ98QAM+fIeO2o5htgsNc2wTJTTTQ1r9eC2KtA+nR0dHRsw8Fz3wwmAqUEbDay8OgIZt6cFUDa9v3gOY8UZdBMWgIU5O/soAqgaOoUEhIhECgSaEqgiYCUQPMMDjKPAAAoFtIpEuhoBqYZB89+A2787lOXf2FuN2YGNSbOrKRPUTLX80sVLzEWM1KZOlXRww3pY9vbfJ6AXI1FSgRZrJXEqNtUPokJQ0Bu1x5XiBebS6PO/wlUHpWcuy311jJ1YkSa293q5Vqfa32pV2v0fNz8vMv357iGFMB2L51tiubTdPhaI7bW1Ewnazwh+/pvfu2v4R9+3d85dv2OjvPAhZI/RPQtAP4tM/8mET1whu2/C8B3AcCznvWscx5dR8c9hsQ52MvmyZmIKYEOUwlkbI4lY3VcwJLJG6cWYnJBjxE8linzpWSu/EvUQFw6cI0JHBk0MigkhFEULBSUEEhibMgkAQXrucn4pGNGrsOPXIilwI6o8qqfUjZlZVTM0p2KQaLeTkCiIPE2WEqbQsnoWCgwuE5fpvpZDxR8cNVkiLRWPlDAJs5ITLnDRkoBcUiYOeh5uu+GtLPXULp7jWHGfeMhxjhjP06V2XM5fkJbj98GSHn5StBFbp9G2lAT2RppB9K+X63C3LYDsmooy9lRPA2IdquWToLLJoX4Nhyzo6Pj6oM3EoJzEuUNPTMB4yjkTuBM+hhufOrdAIDrL3hMSrRmgFMCRSPWbcLW+Q8sCiHWErHIQIx4+jffDgB46OsfV9JH/14HBjiAA4NOoNy4FVx//qNXt5OaQSatqvtW1azCQFgQOdX0xDm0qDdrCSDU66XoXo+6gT6Ydb8uEUOaKForhTal8ho54tcTMun4opB2e4sZ5hwrrHv83GrJ160QP/bZab2C2nhpfZ0SR9k6u87V76crgC4WPQZb4qLLvr4RwF8ioj8A8DMAXk5E/wDAvyGiLwAAff63axsz808x84uY+UWf93mfd8FD7ei4R+GJHle37v9W5tfkHl7JY1497uENm/PDl4BtgHkjipw0MnhkaUe6SaAxIYxzVrHEmHJWy1qXU2RQTCBVCtnDWrmnkYt/kI5z0dp9y3xg7d1ZTRMTE2YlnWYOUv6lj4mlFKzFGtECrAVDS+nz4CTWQ0hZqm0lYBRZ27wmuQaqjgp2rbS2fzOozDvM2ZCxkCfL1q6nQaXAMR8euJIvQNVajhBqsSPooSZ4XQtWW9XPaUrWOjo6Om4nrCyLY5QSrmuq/olR/H224ObvPIGbv/24vAkAmEFTkiSIZ9atRCwQeAhyHAAPf/Vbl2Px3kGRwHsXlxs++Mo3AQCuf9UPX9gxbgUf/oU3gGZeLc9qY6GcyHLLfCLNQAyYj89JkddtknKmVLbyE/P4AYrCx+Z7m/OtlPysaH1x5BjrMcRxyaRqXa9Acusldx6r2/Gy5L4a7woBtnYuu5YvO7buvn7t9SiJvOXDH8Pwnb/2V3fuv6PjvHChyh9mfgTAIwCgyp/XM/N/S0TvBfBXALxHn3/2IsfR0XG34sEXPwEA+MBHH7ul/Rjxwz6YaTNS9sLWaevandLHGzlbaRe0dCofy3xr1ICZRsl2xlFIjTikXEbkiQNWIoYCYyZGCqq8iQSmAE4MmlWCRCiKn6ElftrITs9RTRLzp0kUKL4ECYPE2DGoySLJMRJbxofyJO+NFOcquFnPEkWSMqpNmKS8TNVEz4QBMTAOh4hn4oB51m4bep6BxN9nb5wwhIT7xkPsadvVU9XhZ1PGYzJsetwhJEwpZHWOqJKSBKMplLa1SV7IZlsURCGJnUVI2esnhkIeHedXdCXR3I91dHScHw6+4LUAijnynYKHvvZxYFBDXgCcICbB1zbAdLKb9EwAAbj+wrdIqRKCKEOCzlcEKeUCwEMQxRDECPr9bvuHvv5xWTlC/lYzH2uQfWYEAs0MTgnXn/foleys9uGffwNe+hoxvTaFTq4OX1H6HAs/CThSp8XWaW3HMZhl3mYmJCJQqyzm7dufpktmnYA5pmFEQ/yslXydVoGzTYHsFU1rWG23fowCqN1fe76nbUe/6xi9U+kFo8dgC1xWt68W7wHwvxLRfw/gXwH49ts0jo6OOxvnrWTctT9TBHmSyJsd+u5gC4JIiZ7I7nMlZSKLX42aFFNICLG0MV1TjsQA6cQVGMxSHsYcZF/KhxQ3RDnuAms6bCwnCStZIs20JYZ2txJPhQAs9rOJUzZ69uSOdfeqA6E11ZAU+A9BurRswgwMdSAVQ8rdwIwwCYGli0ecsTdM2FcDxkGVP+WYu4+/K5u25gNkD1bZeQokhpU+ajYpkBJA/vqCrOQLuXxMPEllTSOWthE/a+d2kpasl4WztKTt6Oi4e3DwJT8ADAN4bwPeDOBrI2DtwIcAzJLQ4AmgAdnv5zSgI/VkIWRiKStGPAF0mETh04CJcscvEK2WZh180ffhxh/9zVOPrTqOb02fxPvoxiffdUv7vDCYYidJcwxPAME/YxlSkJZmWbVW3p+HfQ8VObSdrVltUqFILMRPQD0HbiMqPOmQk1QEAGk1LjgOvrOX7OX4RNIaTrr+caSPx1oziOPWLe+XxM9p93ncMQzf+Wt/FX//63569bOOs6PHYDUuvNuXgZl/iZm/RV//O2Z+BTM/W5///WWNo6PjbsGD3/jE6TZog5Jtqznp8tZHQ/osHqYGym3VIcRP/pxLGZY+SAkC3zFqDfaZ+QCF3PGKtRMWdN+oytjWroO9zu79PkDLD6pUP8ylLKzFUiZ88kyZh3kFGXFjZs1jmLEZJuwPE8ZhxmaUUjB7SKnXhL0oxM8mzNio1087zhZnMldEIX4iJXi/HiOjiHhrCVjpDFbat/t9+Fbwa8RPz5h1dNzbuKMUP+bFM0bwQEiDlmMF0m5d+jzGU+/65m8/DjqcEA4n0FGSx5RASf5GMkHMoEPZvy+7ev8/fwve/y/eoutSNd4WB1/0facenwdfG8F7o5Bgm+FKEj/3v+opIXMSI0z6OGIpB0u8SuZsq2ymJIwRzShdvNCoh5p9ASiNKxguVrEPy3ophdyVlLmYK09cdyTNj6bMKjqvwQjGmBNG28uYtqHaP7cmz+WWc6vx8jFESqv+OS3xcpIuXGXd5blu6zJ62ocfQ0fHZeN2KX86OjrOAKvVf/q33n6q7R64/qQYP/pgrpJf1DXlC1mzrYOm1Mu3OjVSiKBdMdit07Qm1+es+iEhcvzNfh4m02IZKbmQEoEDI0Qp/WJYGRaBEi2CqeJWLWPK5UfMWva1sk1iUDSyh/OYAN6aoLNgIjrPHysFk/QhcFx2LRIDYUZgLvX7IeFwjvhMmLPfEFC8b2JIQvrEGfcNhxiawMUCs/L+ZEbP1bmtlMt5L4FsKv7/s/fu0bJldXno95tzrara+5w+3SCIRuMDLyCQCCgg0NANDf045A5AxRvj4yrq8IXXFzRNAzaP0NB0t3A1xgeReI1JrokjxuAd9suGBkVMo6AitHqNj6G53HGHJkMMffbetdb83T/mY/3mXHNVrapdtfc+Z89vjOqqWrUes2qfrvmrb37f92OC9TG4cGpnAVPhY+TIrqZda/suOyjuXjJUNK2y8nccoX924bisOhUUbAsXBQFEBDQN+OyOW5Sg+LWgvLDbVw1DPv/4m0CVtgHQrWMN/Jwv53ftumEqgDPrv/f89ptWfWcLcf3T3oh7PvZmXP/0N+Ge334Trnv2Pw1B1+SyivxrJwpevcqwWUoKzj5FoWFGaCAxLNSJkSFuBnd1zTA8gnrILTyRUAqRm9uYO/VPY7raAOgCn/22XF6O3df0VMoyzDiFYQUDCqqfbvvq5M7Y17Y5j8tMxKOErGO++cFvw8898z1Hev1LGaUG66OQPwUFFwl6IY2uSLzvN16/8LgXXOeIH9V9+clMn26VD8NFiedEUoUPIbSKl5Yvmzngn3N8Xk8uKY6ep8iRPr1heYUQebsXR8VudFlOCC0n3yZXuPkOX72xrDBnDAUMakEArQLtirEKgFKOvHCLwo1S0KLA8wTRrGpE0GNXwBhWowiQsWOM3id3Y9DKWFuaYwOZrbfeW8CkZL7L9bEqIase6qxfWvVJn3WwCZl2QUFBwdogN1Eqa3uK56L4++2ejyRz/Qjc9cfvCK3gqbVqWm6B4E324c8kHqvVv1fHWr6uf8abbW0x1bjuWW8BTypc+9xbwRPddRE1Ofrp5IBa91kCQMtQLk8JIBi/yIQRBBB3ap/u5Isu7GoYYae35/Esnji1Uyb7ebY1KnrN11BeEQQAjWFLBinVtTiP5kgvTVK9xaK0pkiRtnRftG/8+npKoHWQqwOO2gpeFD8Fx4lC/hQUXOS49rm3LiSA+rYsW/iFeU8ofVg8DuSQ2yccX4miJMn5Cfv551EnjP5kFxY/vY2KubNfEYcgw8Av5c7htnNoMQWbnQBXUzOFS/uVM0tmEYKBn7ySxxFA7sSpPakbt98ubGiwBRV0rKDxxI8Oxy9W/+Q6ThhitEyYwZ57onQnr3YfsA91nqgGlWrF9WT7VbLjZLVSR44UWRuZgVVgOYKK3bUUMZpWQZEL6pYFl7IET13Z8da6tYQPus89J5deRfUzJNM+Ogx3JCkoKLj0cf4LfgBQBL5s13X2Et8HzGBNoNb+qF6H+AkwlqxgxYAxIKXsJGhi9Q8TuXDozeP6Z7zZ2ssmOqhAAdiaQ7m26QqWXyBGqxXUfjt0umPDB37lRgDANdfeFrgQzFuYc5W1fbWWWGHVtS+QCxsRkm3dghn193OLVMZb9KS6CL6M8oQPQhtrcrYvKANunQ2MVH7+Q6f8ablfq3gYHq+YlVk/cttJxlAdMNzOfaTK2P2xhmqqXI2Xoqh/NolSg6U42f9nFhQU4PqnvTHbmlX09lx4vC22KEvuGE3ZLl3B4gWxXWboyH39PoiVPtnv2ty21EUU3la8syRceqeljogBhvfr28DE/Yh53efRpPBKFW9/Su1WylWPaXE1FgoMTWx9+LD3lWpRkbG5Pv55EuycQ66d6tLrD/jVe6/BfgbeguY/K5/9o1UX4u2JH6v4scRPrVpoMsHuVQnlz0XT3SuDLidqc7dlIKK/T0TvJ6KHiOgTRPT9bvtTiOjDRPRxIvoVIjonjrmZiP6EiP6IiK7f3idSUHA6YVuu2wmLnCKEGu4IhkPgrj+6rfuCMMh+cfivUZv/s9mfANc96y0wEx1uXCmY2t1XClxRyB1CWIg6fLfSbYNaA+XykyZ/O8dv/IdXu+wfq14i6zm3WPbdvGTK9bZ5uWAXai6Ob6HVu7HEjzGEeaNx0IpbozFvNVqj7D4ik8cvArXix7GC6TWrWARv+ToKHMUP+GV5RtljBrKDsjlCRfFzLDjqGuyk11+F/CkouJjhvoGGwp+vfvHtQrXjVpI0YrWOt29JUsefICF+pN2rt5olny+QP+ch2abufmWfrngPg68vHEe3XyCbXBZRek7KESEi46cXloiuY1UaorgI/vWUAFIkSCBHBHmrl6Z8gCGwWgG1jHRJW69L65e3bfm8HhnqrAXxU6u2y/ZxhE8liB9/H645QvVzMRNFG0QD4FXM/EQAzwLwSiJ6EoCfAfBaZv6HAP4jgBsBwL32dQCeDOAGAD9BRKsnzxYUFASc//zvA4zBXX/+LvC0BiDmShvSEvJb7v2tWzZzUXbnDCQQQlCxbV0JsFIh4PmwuO5Zb8G1V74V7axCO6tgphpmotBOLOFjakf8OLInTE0KuP99N29kDNvC++57Le5/4HVQ+w30XgO1Z1VKem4DoFWDEAAdMoJ8/SLVVq7uysJLeGD3YU2uYQZgfG5i+DdjayU2FG6tUWhbhYN5hYN5hf2DGnsHFfYOauw3FQ5ajblRaI0ji1wmUGMUDoxGY3Sk0pEEENDVLIssXysHL49Qv+SwKQJIhlePCbK2x2TqvSXFZKhXBkOlh4//5ge/beG5C040TnT9VWxfBQUnFNc98y22gPMSacRBz/d96A0R6ZPav65+8e2u4LLFhNHkignqCgotigtp4YJ47u8HWrpHSNVAUS4M9axfrg51j0msZsGGN6enJ3nfBUQT2Xbv5AoSZgAKIFgvfGT/WlA7dB3H/P3wvh5S8XIYLCo8wmveLqZsARoVbBSri7zCR7Zf7VqvxhLtddpgpl3NohBJBRjuVEiaGS3Z63tCj4hRO8Jn4kKqvXUt58k/bDvV4ySEjiNskJk/BeBT7vHfEdFDAD4PwBMAfNDtdh+AewD8MICXAvgFZt4H8GdE9CcAngngw0c99oKCSwZiEmGlwLXKTiybImJghr/nyKmBAgm0AVz7nLdai5cisPaqJlFHEHp5N+RIqffd/9qNjOGoQI0JndJoziD3Xi04KKztDnZTyFhi7ucjAr2/g8xSNBph0S1a1HIHs7GqH52xZhnWUM46X8FAUVx/dd3AXGBzpgZQxHbuRnpuZxlfo25YF/33N77Ne4ojD3MeIIjKItXR4ahrsJNefxXlT0HBSQeRDWzO4L4PvaHbB8CLrroVL7ratU0Nqh1H/Giv/pFKoG6/oPiRhE8m4LmXCSTVNj5ccOT37MZiByixfvmxuHbw/rlcicsGUSMhfoRixSNXM8t25KvKetfxxaey7Fwx0zJliZ9NINcuVb7mO5NJC5d29i5NbrtXBiUqn9TqlVMWrar6Oe1FFhF9EYCnAfjPAP4AwEvcS18L4O+7x58H4C/FYX/lthUUFKwLOWFoGj03Hgre8mUs0RI6Q22D+Kk86aOiXxTEEGoYDuHJfiwXG/Fz72/dgns+8kbc95tvwIuuuhWqZSjf9t3bvqSCB4hqpKjN56ZtAAAgAElEQVROysEvsGkK9RmUXJzj3uIZ3KKWMcL+1VoVkGldq3Vh95LwCzUNK8yN7uX/ePWPb//eLcjE9YqvMdaZY8fWSpu0e61L/ORUP4cbx7jji/rn4sdJrL+K8qeg4ATDd5MAgHs+9qb8TkRRgCBrsnYvGRiYqnZEkGAgdoCI2JGhzlHxsgwj9snN5YFgkemG6XEcE0bKEToR4UNkCR8G2NjPhFyKIify6nCu3Jgzk7PvnuG99nLcMVFxdCtL6bVkAddT+DCtRTaNGodo3W7H1XUga6CsDcx9dv4z87awSpme6ifFyrLyE0L4MG9t1elRRPTb4vm7mfnd6U5EdBbAfwDwA8z8aSL6VgA/RkS3AHgvgAO/a+YaJ+NDLCi4CHH+c18JaI27/vJHASA0W4itT2TnqU3DkT4ciB+xvd3M/9aRlcuBONHsEmymkVPB3H/fybZ5LcP1T38TaFL1SB8y4u/KifIJsLWZ/Dp1xQcrijqRpgtuof7y1i+K/55e1Rzdwx1nANYsYqDctXo1QbdIJOfwVESWKn6OIutnE8TPYeqxbdQRo4Ojj1ihdKniOGuwk1p/LSR/iOi9I87x35j5WzYznIKCAo97H7zFtkh13wnXPest2UwA9quJrpuGqa1SyGjAVART2fuIBBK2r1TRI/cJKiB0r/vHAenqlt8mnkdKG7ckSEpsE92dgnqIydVVrlV4IF7EpYlBZOW/RgGKGUy2A4cke9itjFFguNLxe+tYN65Y7WOPMQqAUWAVy6ylIsV32uo6U5nRHTOGsErRNdTFaystU1PfvrO/+YJSaUZDdnW0IhOpj3wotCd+/D0gOoxsYMgngQTaUlDlXzPz0xftQEQ1bOHxb5j5lwCAmf8QwHXu9ccD+Edu979CtwoFAJ8P4P/Z9KALCk4TfGv06575FmBiLUPsFiRY29bhv7agW+cqOP+419jFDmPs/KfdYghawNmVQrD0IdU/1175VqByxYFh+36c9IeU674J4P333AQAeOEL3n7i832GcP3T3oh7PvZm3PDUWwBNIGboCy3aWkHD1Vmh1um85X4KY8Da0E23vWehBwIJxMrWbQzA1PYGArhy1jFXNjFTPyhc/NA1AEhRWKxqjYLW1jLesgLQwjDhwFSY6qb3vpWzixmO64l0gWkVrFIL5dRKy/aXlvHDzv2D3cCWZPcsGueyMeUIn1d85BX42Wf87MLjChbjOGqwk1x/LVP+PBHAty94nQD8880Np6CgQIKV6oIbh/YRxI/voNFt668kRe1DxS16nvjMo+/NzHdo9nU/ySWEUCR99sTPAlWRVNsAiEgZwBUTsAopUuxWtux5PeNPypJIbAiQ7eTT8Q0gfPyGYJQrLMQwetYkcCSVDvvBoMXmMtyGCq8h4mdofwXeuH9fkSXevJ3Lt6OVr+cUP9E9d+/hsATaaQPZXs7vAfAQM79TbP9sZv7/iEgBeAOAn3IvvRfAvyWidwL4ewAeB+DBIx52QcGlCU0wVUJob8h+FdAaQLaR1xWobcG6AlrubFnmcIqC6579TwFt28i7+Dmb9dMa3P/A67LH3P/+i4f4ecH17wDQEVc8634q8aSytRYAMtwJlf3CUoKIAHJ1jgkLbMJ6L49RsPmMU79Ix+DK/f1IdBxlcUNf3UDE0WuKjMsYJ9To5tPK/xHhcn4co2Sgo9rBEz9DYc9xJ9F4EeqwOOzi2aoqmnWJn3XOWXDp4aTXX8vIn9cz8wcW7UBEb97geAoKCgS4IqAFbFjxgBXKee3ZWb6g7b1X/fjOEcYXGkIBZKSs2D02Vaz8WTi+DLGT2sOYAPjcHcXWuw6/rcvkCdYt2JqY3A9/BVurWnsXhc5REkpZeTsNFAidish1yGCAjXJS6e49yJwfeayXU9vMRIOWVI+M8N22KpHDoxNSI1fALG4tmlf8LOu0kVP7pMdsmkzx5/P2L0/4KOYkbLpbkfPEj28PP1hw+XNnXk/fw0kJeZbY9G+8kbgSwDcB+DgR/a7b9joAjyOiV7rnvwTgZwGAmT9BRP8ewCdhO1W8kplbFFxUIKIbAPwoAA3gZ5j5tuR1cq+/GMDDAL6FmT965AM9BbjrU93aqFfCcBJ0Ry33mjWsDdPaibJtgbrG3R+/FQCsYqUCGKqrIw7rKGEGtZ4AoY2pl04C5JRyzQtvAznyp7l81u2jnYUKQcwcHnNyjnCMW1QztavJKldnuf2l891UTvUTVNqMaMWJYRf4GE7iI7cjUjf7Dl+tIZAmpLYvj6H5shX1R2olD+cR8/smiJ9DHQtbh8RKoLT+WdRgo69oHruv37aoLpHXzzXtyKGofw6HY6jBTnT9tZD8YeZ/v+wEY/YpKChYEz4fANwrGiVYqHyMsHLJgGep6AlkD8XEj/SZp4qfwd/RuWG5LJ6cPQxAF8Lstue6awXFj32DfmsghEIrdmLXEK3LkllEEhhjCyE2HEISpe6axMpa7Kd3z4l6pUDa3n2qGqcAch24YNBm8vUXETC5YEW5ffC4EcTPouOXYVnYsiSAInC3j79fFt68yniWFVunDcz8Gximb3904JhbAdy6tUEVbBWuNew/B3AtrIz8I0T0Xmb+pNjtPOyq4uMAfCWAn3T3BdtGSvxs+iuqdT8eK427/vgdYrv7+V6767sQ5hueegvu/t23rH4d5qiD132/+YZ1R3wi8cDdN+Gql96Bq15yB2hmAxGff/520EzbwOyM1SoLEi+7eqitCWbSET9Gd68FFQ855U9t76E5LNJ1JA+FX7QMl2uYuba/vjEEQwoNbMOIhhV0JmxKZ2zqfvFmWfOIVWuKRWrjZYtT6fy+qs0rpwY6LOkz9nV53ZLrc2nipNdfowKfnS/tRgBfKI9h5mu2NK6CggK4yV6TdUYNzBHvu/+1eP4N73C2L8ugMCEKeY67fCGQO0O2L04LDXSrWtHYPHnkFDOpfSvajvgayBEE/jhH/IBtYcNuyMwEpUyPAAK6yZYEgZMrEHxnjKa1hQxRvBKWH5CQVJtuJU2uJvguVaFDhiM29CGXWKXHfizxE20bsnqJ4mpdy5dfYRvCMhWOtMlty59/EnAcrd4LTiWeCeBPmPlPAYCIfgG2hawkf14K4F+xTQL+LSK6gog+17WmLdgm2MsyxCY1PLevgvOf97/ZB0S468/e2d/BGMCIFZbDLIUbOOUu4d4P//D65znBaB1RRs4iTmxVWmruO3x5mc6Ik5FfmCO0U1jyx2X5+DrNnyuof5Tfx+X8RGpkd9rAKtmQ7VQRbfe14zcAWmNXABvDqF0GkEcvv4/iLp6tq3ksCTQ8n23a7iXHs845F5FCm7KDyXMsykAqRM/xodRgMcZ2+/pFWF/av4A1oRQUFBwFVKc6Wfr7XHdZPuysX8Hu5W1eGtbalSh9ekHQTiWUIpr2MuSRJISQEkJOG03iGPKt2CEWRYNCx17EEznGn9uo0OVLK0ApA6U6NQkFAqZrJS6LmIZt69OmVWjZ3RtlFUDoJgmbUQO0mYI9/hNxsHtNVIOK2qD6GVxFW1AgyeIh9diPJWuWZfwMX3tzE2T4zDMkXLrPKsTNkNKnoKAg2y42VfUMtZQt5M8WYVuuAzAcVB42D4Zw32/kc3JWgsvxkVYzj7s/fivOP+l1TkksyJ81CaB7H+w3nrhU8NyvudM2yJh02YlwfztqCFozVMOgefdDPiyWoW/3CgrsCmhmQLNjyZ92BpgJB9sXAKfIQqf+IdiQZy0Wykx3AWbYBhUKCASQyqiXndrZkELjaqVKmSxZBACajAuEBmplsG+6zJ+tdgxN5vbc83UJoKFr5Z7niLD+8XkiZ5sET7F+FWwKY8mfhpl/cqsjKSg4xXjR1W/Dr32gXwD6riC+UHzR1W8DgN6+D9x9E656yR2C+OmTMSkxE1m/0s4TFBcx2RphiepnFWQXI5ls3eW2E9lsH5BQBglY1Y0BEVDrFkSMWrVdpozbvzEKjVGYK42m1dY2ZjgogoKix6jOSqYIvu+pVO4TdR2ulCSdMpYmu2qmouf2fiC0OfkwVyV+hrZvWyGTFmiLlEGLxrPcMz9cCJ4kFRBjhLKsoGAzyP1DS/9nGLOP3ZHoOwB8BwB8wRd8weFGVtDDpr6mzn/uK5fvBFiCSE62RYjQA4d6SDTGAIGMa4zg2rur1i0W1eT2dRmLvuFGOBcFlU87A9odoNllS/xUbC1dfmd3bjK28AmKH1cipP9e7Nzi+8FaRjFkJ8raw9isQ59Z2ChbA9Wu3snN0ZpsZt8FU3fn4X7mTy7Lxipq1lcWLyJ9hrMTV/ufaUgRtCrxoxdcd1FX1oKjQ6nB+lhI3xLRI4nokQB+hYi+h4g+129z2wsKCjYET+xEcEHOaVZAFm6VyhMyPTIn6eAlLV4yDyh9vXeN9F4qfYBQdKz6XRuIH+5ubOA6dHXtSuWXuF/h0spAk4FWjFq3qFWLqW4wqxrMdIPdah7ud6s5ztYH2KnmmFVzzKoGE92iruyt0i0qbaC1Uw2FYGq4W9edSrvVM9/iPXT5cqqfHAyrEKC4jPhJi4c4VDF/k9fpHqfKo/UmwkUF1qrnHJP3s+kOZMcF3sKtoCCDMe1iR7eUZeZ3M/PTmfnpj370ozc60AKL3KLPqvBqn5zqJ+zzybeBWu4UP4X4iXDVS+7A8152R3jeq6MCIeRU1ZW7eZJI29dlreUVP+0UmJ8Bml2gOcNodw3MjgF2W2DW3XhqwBMGT+w9Krax7X3WB9IitnRCYNfowljltKwB5BysM3Py+E5WJpAim1K/DNnGN9nUYbFNa5j40W6RD7CEUXqT+8jbYfGKj7zi0Oc4jSg1WIxlyp/fQRAgArC5Px4M4LHbGFRBwWmCVPO88AVvj1qihmJCE/T+YsflB//TjXjuV9/pig/qig8fKuhXsYT9K9jBKuQVQAgK9e5neFoUOUmyzRJKgp7T3+7sz5ZsFkVMIHfcNlLsG1vY597apRhKWQKmdvauiW5QKYOJajHRrb1XDSrVovbdFUCYG40Do3FgKhy09nFjnB2MFZgJ89ZvI8wbDWNU+BwmdYO66gimiWqt9Uu1lgQKCqBOPm2gMDeW+AkraAvIjdTulQtyHsI2fPfrWLPG79/vfFFQULAyPgLbTeSLAfxXAF8H4OuTfd4L4HtdHtBXAvjbkvdzREgsxJvs9LWI+ImubzY3JwCwdjI/hk9mFrBOOF5wvc1LpIq60kQuilFXtjADXNkahTUAZtdgg0Lb9tB4oyJAWeKnnTrFzw6jdaSPqgyUdgwOW2LGKGX/PsY2pICznkdY9hze3ecW4byS2T0Gc7SA1jVeyBM2/Y6liI4dgj2fCsqidRdypAoo9zi377qQqp/RpNcADeC3p+/bE0BFFVRwnFjW7euLAYCIZsy8J18joln+qIKCgo3CzRHLVgif91V3duodBxYkzJDtS65sRcWOOEePsgmqIR60itmDIQ62D5hHuMPExaTFi8hKnJXyBJAlfiptyZeJu59Vjb3Xc0wD+dORZ3OlUZsKVWtQUYUJtzhoNRq2cmjDBK0M5q3GQatt5pAxYSx1Zcml2hFMlbJqIw23wgOrREoRumU44ictAJYVBqsQP2OxrCjbvk3sEl+CloRmQcEWwcwNEX0vgHtgNQP/0rWQ/S73+k8B+FXYNu9/AtvqvSwlbxnXf8UbgUnVU/BuKux5FfhW70yEuz+xXmOZG57yw52CyL0nOkyA9DHhmhfeZhtqOPiMn0jBIxfBRN1ktN3aZSuKxTRNoVtXMxWKnykDuy30tIWu2pB3yE6ZQwowDVm7vyLXXAKBsCNZT0nFtVgYS6dzu42CTIhE7aSVcZZ10+UURp2oGIqNVTOTAUJA8nK1zGFyeiSh4uuT1PrlrzHGurUpSNWPvM5QDWNYrUwCaeKlxFDJ/lkRpQbrYWzmz28C+PIR2woKCtYAE/DCF7w9y4qw6jZe88LbANgOX7lzBNFMhtQJZI9Obmnr91zQsxyXX1GKWshzn2hyj5EcaosZ2J8mI+BDoXXlcnW0wbR2Cp+qQa3aoL6xip8GE9Vg6m61MqjIkj++sGlZYd9UmFca+6ZCYzTmrNAYSwAZVkENdGAsAdQKr3vtlEVn6wPM9Bw7em6vqbvAZ4kWCi0TWhAa1pGqJ0a/a8SYVvA55cyQ336VwmhpO9M1VspS5DpujCO5hvdZVhReKnaygoIUzPyrsASP3PZT4jEDGBkSU7ARKJVkwXStuY9S7HjXQ2/H+SfejLseevtax1//tDfa3/2Vgm8XD2Un9bt+/0g6FG8EL7r6bXZRSxFCYk7D4IlyuT2inpIrX54c0hzqMq/yMZW9Z+3yfSY22LnZAZqzDDM1wJkG9U6Dum6gHQnjf5Q2rUKrGKQIplEwrQLIkYMEa9lK6ymntra2dHcjZ01XgghSbbiO1gbTyRw79RxnRP0yVQ1qantzpLe018agWUHBY+ffLv/HdhwbVi8vawoRPv/kmKPKMhyCSsgyD1uDdHXZkPopZwVbvghYFNIFh8NC8oeIPge2C8QOET0N3f965wDsbnlsBQWnEpLgCcQPM15w3TvsZD+0UhhWreRz9HJ/5IpW1x0MMWkTzulXCZPrYAnxQ8mE7balK1XZ9yALLfuWoBT3iJ9aW9vVRLeY6SZYvKaO/KmpDQVN7fN43GTsVUCKrVJnTi0q1jCqCeRM5UihylgbWSPIH68yst29OnLJZ/3kVT/W7uWJn1yg8bqTenrcQmIEi9uzy/EsfP0Eu55PUuAzgKw0v6Cg4BQh+JaTbUesmFmX+AFgiR//PnSnSrnnY2/exNCOBCFb0b2P9997EwDguV99p7DLi/omgbXO27+btNWbyql9qi7c2UyAdpdtvs9OAz3xWYIc7Ote1VzBqRPctYkZ3CI0myBfC/q5zdVUoWMq2YUy5Z4rYigV1yFa2RrKEz+7lSV+ale/1Go4WqDL87HWrzT02S/iyIUXSQABCATIul27hhRBo44dsZ+sjRa1iB97vV6Nt8HFp29+8Nvwc898z6HPc2pQarAIy5Q/1wP4FthAwB9B91X4aQAb6E1ZUFAg7VwvvMYVZgq45trb7ApbBte88LZI/RMsX44AsiQMxatXCQGEhCTq9ou/JSMyCYIIcp0ossSPVP7IbdS1eu+Kn+TNJccrbazyR5tgt6pcqPMskD9zTFQbLF5TQf5oMpaYIStfDlBAzS32TYVKK9RsHDHTYM4aNRkYTdhvK2cHs6ogACHfZ6bnqMmgpi4EOi0YujBmJW4UFQAKvLDYWLdYGDrusMXHpomfo17JOkwGwTookuOCgtOLez7yRks6pLYvAugiUSFe/7Q3WosUOVuSJ61GKnhPArziB0BkWQMA1q5bl8vu8TVUz85G7nekI4pMZW1evqMXa9fVawa0U0Y7M8CstcRP3ULrfIt1cmSNYQ1SBuTmRA4uq4708fYupTlS+fjmE0SMSpuwaEY+cNgtmu1Uc5yr97FbHWBH9VU/KbQgc6LmEULJY2sYjUq1vVpG5v902/Kqnc5K1a+jJI5bxTumK1j3molqnMOO/ZK3ym8BpQaLsSzz5+eI6OcB/BNm/jdHNKaCglMLdsUIOwLHry4RyBItoOATj49DWIVicv5zZ/HyK0kmZ/fyt1SdAwTipssC4p4CKJA9EZHE/dfJcVJhhcqANIeVqui9+Lambn/ffWtWN5hUVtlztj7ARLXYrQ6sBUuQPYoYMzUPSh9P+gS/NhgtCFM3IdeqAeC6cIUsHluotFBoWGNuFOasA4njPfK1s3ilK2c5cqGFJXw88RMVM6EgXfIPZAQ2EfK8sJAZGOTYlbJFbWKPEidZuVRQUHBpIfq6Z7bEgpvjX3T12zbS9WtbuOEfvh6o7M8FWaMQcOTKpUOBGQS7KHb/A93nfeXL74SpRWgzJe8z5CQh1DpeMW1qssqfCdDWANcu4Hnm2rlPDVRloKvODi5zDCWI3JyoAOYu5zDKPXQdR8ktjFmFT0fy+CYYmmznU98J1TfCqJTBTDe4rN7DRDXY0QdhkWwsFtUwqY3bkzwhK8i9ba8AkhgifuQ2X2cE4ihTa41VNy/DsgW5w17jsItQJfunYF0szfxhZkNE3wmgkD8FBVvG++5/bbB9BRVPAk62Pe+r7oytXc7CFeX8KAQSSNq9EN36nbpssRNvj9Q9ibKnI47kKhWcLx1O+cMgzVbR4wge2ZkinMKtYtn26zbfZ8e1afdKH1+4pLk+qdInVf14AsiHGAKAdscAMRE0NwaVVpg6RZAsCLQLSaxFzk+uIDBu1asVRVOQQgupdK6gyBUHY5Qyh+2ukX1tSbGTs7INvea3LVvhuxRwMf0+Kigo2CyuvfKtQJ18Z7tunGgAMifnC+L8E5I8Qa0ATSBjwEpFgdH3fOSNxzDC1XHtlW+1DyoVkWxXvfQOtBOFdmpDnkPejwt8BgCwe+7fN5yq2oc7O9LHTKzyx+b8MLiydi+qjcj2sQ0v7DxvIZtZ6GDTsv5+Vl2nLl8raaf0qbRXQbssRGWg4FQ/gujxOYgVmbBQZskexpTmPUt8m9QWGgaNk3cpMjBGixqG+os5ClBMXddTcKhtAONcbB0JJNFXC3Xo6qUMQSQIpbD/Cspqe/58DRZ3GbPEVssU1FA5u1sO63Q0leHPm2gTf5pRarAYYwOf7yOiVwP4dwA+4zcy83/byqgKCk4xmjMaH3zvjXj+De+ItrOsRwh4/g3vwAN33xQROUbbVS0fQMi+mEkUPwCCTYy9fUu2eBekD2un7JGkDzpiKJA78FxVX56cCyL0RYxW+RUnIg7FzW59gJlucG6yh5me46w+wFQ32FEHEdkDICJ85HOJVhYGYr86XFzsp+FIH6v+AWyBFHXFGCBFWlZo4YOb85N+F+zsiqvMilgktV5QPByWOFmmxFl1teswwc3bIK8KCgoKjhtyAYcVgczJUP+cf+LNwy8S2bxBEmzERYaI+HnJHWinKli9uqBnCnUQMUS9Q9GCmc/2MRowvp37BOCKwTWDJ1bdbOsfdw4gkEAGHYHgP0pmO3+x8jYpdzlvKU9In1k1Dx1OveW8ciTQJGQfmsgKL5XKY9Q+Lbp6ozGdxy8lf7waZ2GzBeqCkAMJJPdZMJ7UOrUKfN1y2ByfofNmX1uzFkstYZL0yV3rO377m/Hup//cWtcqOL0YS/58q7uXHSIYwGM3O5yCgtONq15yR7j/4N034fnnbwfQFSKx7YrCa3LVylQU7FpS+ZN2AMsSP+Geu3sNSwQpSep0Fi6g85v7QimQPgnhI/3oXqLst6WoXSvSWTWPiJ9z1V4IKZypOZQjfyRSwqfNEAm5LlNA0r3B7QdqYZx1TLbvHAu/etMRPXEnr7Hql01k46zSaSN7/Eh1Ul4BRUv3GTpf9PqahdWm5OCroCv4CwoKCjrYlt7cEQ3HiPNPep1dgRgCu75YDYM14d4HbzmqoR0a933oDdHzq198O9gRP6FTl+5IH4+cBd7fjOvqZaayu5dV/LC2t07R7G7G2soipbP4w3cqILs9rNMpEzJ8JrrFrJ5jqhvsutqocuodRRyUPJ7wkQqf0OhCKKFlbTS2vvAkTyP35+41kK+vks6njtzqwprbUTbwrk7KE0BDAdJjyJ5V83OG6kZ5vUV13SISK+qemqlT4tDtUlOMRanB+hhF/jDzF297IAUFBQ7iO+qBu16Dq198u9veSY/hVqGe+zV32m4QjgDqdaqQBYt/LlavpDUsUvsoAJrtc83WZy6tXog7TPjhBVuXJ4FE1wlyah8rb7YyY78thS9itDKhwDnjwgl39BwzNXcZP/OsssdjWWEjrVcpNAxaqM4aJu+HrudJnRGqlXyxsqiwODntPUe9v5H7bJKMOZGqH+sTOO5RFBQUHBe4v3gTFCYg28mpOeYQVys7iQkgb3cyBMC4UBqFe37nzcc2zMPi6n90O7gil4Hou3VRVDMB6GxJsobSgHEWelM5y9fEKqwl8ROU0ujOxWwtXIYBcuofUKcEkkIqmfvja6RK29yeWWjR3uBstY8z1b5rOOHsX86KHmcRNoH46ZE+rKI6SZPpWb/8mHzLdqCrX0IdQ7FqJSIySNrZxGeLeM4eqhliQiVvB7Nn74glOb5ettDKhE98DntNk7ViLWo9L/OPcgHQi5VPdh//99PE4e/2PR/9RvzEl//rld7TqUKpwXoYRf4QUQ3guwFc5TY9AOCnmXm+pXEVFJxKfPC9N+Kql94BJuB5L7MqoNDtHQCIoiIyVvwg5P3YlaxuWwh4loQQWUsXKydVVrD2rcqqfKiyFatyK1gyaLBT9tjVQE/uBD+2IHt8lwmtTPCABxmzkylL+BUs71ffrfYxVQ3OVXuYqgYzNcfUkT/aFTl+wm2hwqTawubqtKEYUNmiRpOBAgVlD7yvGwoabmyEiADS1EbnzcGHRqe++FQmnUISQJskfA6zUjRmBW3o/ItUTXIVcJWxjLnO4PHHoP4pKCg4vSBmF+BrO2VBfq37387GZtOkKpVN4vxjXw0AuOtP7xzeKSWA4MZvLElx9++/ZWvjOwpwRa45hgtq9lZ41dVVkd0raZYRHnvbV+3qJ0n8yCYWTvEDsq45HfJ/7MfcPY8VQAoINZZSrh7yuYeVzT28rN7DWb0fZQ7aeiZudiFt8d24VFYRfVgsqjN6JFBy3CK18FC9FNTYG1DDLAx4HmkZW640igkgSfykBE9EyommJeFcS0dTUJDHWNvXTwKoAfyEe/5Nbtu3b2NQBQWnGR/8TzcG4ieCqw96smSn+vH3pnL7ZlRA4TwQ2/w+rnihyliix7VYV05uTIqD/9yrd2S79tBtAt3zSredFFn40WVoX9oevSN/WteNwrYi7dq3d8RPsHtR3EZUEj8yvBmIAw21CHxGovDxBNCmkLVGLQwgVMnz+PijULkMkVaL9lvltePCUbeHLWGDBQWnGK2dP11kXNfNE91zO/UczZLGcYQAACAASURBVPfS+ce+OiKAelk/fsUpkEAMUgRWF+fPzed+zZ2dtU53LdpDuLPqygDA1VWOAAqLaFV370mgQPzUjOyUwuTIn26TcRIf5ZQ9rYmDjD1kneUVP75F++WTCzij93FW72NXH0Q2LnuufP5hGIOsjZKB5wKfDciSSKpF44iWoAKi/oKOhKK+Qka7uq2NaoPuutH5wKMJILl/R7LIz6VPoOQgF4hkl7F44c6qf/zCoCRvoveaW2giP5422i89R/oDfSj0WcHgNb/3tbj9Kb+49L2dVpQaLMZY8ucZzPwU8fx9RPR72xhQQUFBAiUmO1+MMTA/q7N2r6z1KyF+LGnkVD9e7VMZUMWW9HHduJTmKJh5EdHj1Tz+3rcX9QoeRYxKeJbtfacG6t6ufTxVTfCte+LHy5e94idFWtTMTRW1bge6AEMNA8PatmdfQAD58y7DkOXLCDXSGHS+7q6gWdfPfhgM5w6lEujtKorGjKmgoKDgpOLeB2/Btc9xHacSkoHYbaNY/bEtDJI+0neU+aV010Nv3+awtobnvewOQNv3ZptU+ODmzurFskbykItjUu3jFtc4ZCEmxwDOZuK4EUeQMJNTgNm/MwMwRgWSRxIhRHCKaVtH1brFVDeY6QYzPceOihfElhEacWfRxQ0oAEQ1k6+XlFMUVdQt4EkyJJtRM5Bhk4YZt0xRrbWOise3ks8RUenY1qlfDqMsyqmucq9L2x5ga8doP8T1s0dQqBcUjMRY8qcloi9h5v8CAET0WADtkmMKCgrWxK//slX/pDkBvoj54HtvxHP+8Y8Ee1fwrTvbF8uCxW+j5F67VauJAWYtdG2gK4PKtVbX2rYGrbS1bFVkQhtRQKh2BpQ8lesyUZHBVDVZWaui/mTmC4LKkTw2tNCEfB+v+JGtSX2RMmcdkT5zo22nLqhklUkUHkYFMil0DvM2sJTIEZayRZBjapnQwrV5HyWJHo+4DenmiJGc4gfA1q412B0E41Q6JzLrR+KED6+goGC7IJ/6C+oFCwcwb9X6lbV7Lera5Sxgd/3RbVsZz5GBIUifzgbfy0CU+7vXTK6WSnIUo+OAoPjpUrwJJOZ3Fq9zwjzZucwe55U/ExfuvFsd4Ey1jx19YIkfV1elNqFA8IRz+lpJh9dzeYheIS0Xy+S4lMgWSjOAohpQqFh0hhjKdbRK67MhLFMe+zEFtVCi4Mmd7/BdUvO1m7RqxdcXTUWCXa/LagqvZX5m6+yxpljZl6F8PBHGkj83Ang/Ef0p7FfdFwJ4xdZGVVBQ0IeYn658+Z3gmsLqlfSsy3yfcJ8SP0pk/VQMXRtUdYuqajGp20D61No9duRPpcTEn0yqktypXJHg24x6T7onXNIVjKEJza9qWdKHUVOTncR91o8nfmxrdgrEz9z0V7tMGK+GAaFGC0B08pKWsOhaCyxOPbKIxM0WVquqgI466HmI+Nnk+Zf64rcwUxfVUEFBwbFhke/AT3+yqcOWcf6JN7vGEUJxklP8XOTEz6//8o147lffGddGygU+e8uXUEQHpY5T/Uj7fKipUis9gC5U1hE3LP+UMgOIbP6TywFK4buBkauXKt1iVjXYdTk/3gY/C4thHfGTs3EBHemjwYNZhSnxk1reNTFqMjCupjNsPzvZ3j29SeRU1NLSdRjkgpRzavIha5YkgBbVJ+sSRZLgkffhdb/4mNTFQ1Z/v/Ap36Mmg1s/8T/j9U/+v1YeX8Hpw9huX/cT0eMAPAH26+oPmXl/qyMrKDiluPJrf8Q+qBU+9Iuvsu3fA3HTFS0+sDCofnxxg06i3BU7ECtWDJ4wjCd+Zg2qSYvd2QFmVYOd+gAT3WKiWnffWPWObkILUSDvJ08nuUpYtGQQoT8uPUfety4kse6x70jROpnvnK3C5+F2CsOEfa6D0mYeVruSidS2WnEEU7xKZEBQrGDEWBdB+uRl8WScGqlxZFQa/iw/s9zzMYXGJkiN9BxjLV+LM4vy51h0zJB0fJHnf4zq53iJHyptRgsKTjuGphCWqqB+W/JNI+T92LRhu9HFlzBZaxKIcNcn37bVcRw5giKaYjJHLoxBiHCkfT6n8lmCnqJIHBusX+5ivuW7LUN8hy/GpGpES/c5zjrFz0zNgwoHWJxxaN+Kq2tEHZNm+6TEz1C2jiK7ENgI1besC7ziO6h/kqDibTSz6I+zI08k8RPtk6iP0tpibGOIoX3SrJ904VOONapxo3G6iAL5+YH729ZQjZ8ulBosxVjlDwB8BYAvcsc8hYjAzP9qK6MqKDjF+NAvvioQQM/96jshI3+CV12QOqFlrJckV+K1JP8ndPdyAc80tXavnaklfmbVHLvV3AYM6gYTZYuPilpn3eKoswSw2G8cWakSsqdP/ORXZXLXCfk6TJizVfrMTRXInpYJjdGuGBpS20hftYEhBbBxxYCCohYtK+i0LaeYaBf65rmzerVMkeonWu3i5QTGqitOmwo0XhzkuJkV6nXPM/a4obykI0WRHBcUnHoQA2jZkixhm7WpUGvvr33OW3Hfb26WADr/uNcg9Bn3z5WKO48JAujuT9y60eufBHjix3f3Yu3eO2WIHepUPj4Yujel+vnHK34y8xG585Lv/uXPwQTjw739YYpA2tYWlW4xrRqcqQ9wtj7AIyYP47JqD7vqALv6IMr5aeEUzqywZ+qsagdAtAgnIWspT/rIrJmg0oaBIsJUNaGOaViF+sqPpwq2MBO1oPfXWAdjFEJS/WOvpcI45D7+fPLcAEJIdIpFC1462Z4SPqG2FTk+qdp9kZonCoTOLETmwqRv/+R5vOZJd/W2n3qUGizC2FbvPw/gSwD8LrqsHwZQyJ+Cgi2ACSBXqHVSZArPYwtXvIoVnmtxr1l43W13Cq4YVW2zfaZVi1k1x049x6yypM9Mz1GTwY4+QK0MKmpD1o5U8KTodYsQLUf7BJCJJkOZ47MIvkhpEVu9/C0lfrKFg/e5EwOs0DJHRJtf+fFj0bR4xUpeQxZfhpW7UbRfP69HIbeCswnr10rE0Tqy5kyY4ya89NlrHYJ0KtavgoKC48C9D96Ca597K1i74F+i8IOEDAcF0L0f/uEjG1PXwt3BEUCXIsLUKuqnKG4nWWSLFs0WqX4Gt/t5iiMCiMVmqUYg2I5wShlU2mBWzXG2PsDZaj909qqpjRbSPPEj65/GKZ19hk4gKAh2cYt1Vl0siZ8of4dUIC6Colu1dp43br4XdUul2pDzM2Sz2hbiEOo+6QP07WBh/xEE05CSaKGaOUMcLSN+crV12tFt+HqX6P/ABRvFWOXP0wE8ibk0Syso2Cae/fU/YgtCDQAUPPiRPFmEOxu3ehWkya5YMbXbb8JOCeS6UmhL+tDEQNctprMD7EznuGy6h7P1gQsUPMBENdjVc1TUYlcdiC5b3CNtALlq1EmPPSTxA/Qnvgk19nmy4pG2ZveEigx39oXPvqmwzzXmxo5h7gmXcA4h52Xfxp2gidEYDagWiglz+8GH/J8WkvTRgxJfOdaO5PHFVEdCNazQGEkMdV55e2pbfcvwxJ4lKwkyHBqLvMZYSN/7WCwKc1y04jdUkA1dY1U106LsoiMlgZIiv6Cg4JTCkTww6EgDA4A5m7ezCZx/wmu7UGc/9fjnzJYTELk/l6Lqx5JrHdnW38HeSetXqppefAFxYhLPh0gBPydwfIwixmzSuIyfuSV+Kkv8zNQ8kD9AZ/Xy9Y+vh1Klc5ptaGsNoaIWdVWuMQZgaxlJANXUAqqbl1smYWtaTvqkCug21B3Di1yHzQfKZQDJx1mFsFsATGuJ+Ph+ZIHcPjiekcRPev4x5M6dD12PVz/xnqX7nRqUGqyHseTPHwD4HACf2uJYCgoKALdCg7DiRL4wI4S27pHyJ7n3rUiNz/1RlvCBQmjnrqoWVW3DnWeVbyHa2Jwf10J0SnPUqhVFRxP5k+MxKyi0MKFMsKtSOWuXfR6vgIyBn4DnXEWFjy96WqYs+ZQrLAIB5CZyX/ioUFhZC5giDtYvICZeIqVP6p8X12wFobKIXFl1hWysJ30byMmnx+x/ElDUPwUFBccBMgbUWpUnYO+I2fYWINoaAWQvTvnOXhkC6FIDsbiZTk0tP+1IAZQof2QmUHzAen8vT/x0WT8MpRh1Ze1es2qOc5M9nKv2cKbax64+CN1OJaTaOVU8eygQNDOgWsBZ20HxAhTg7e/joIjDOQ0TKkpeS8a5rDuqHUd/TOsgXTDLNScZOk52CVuGTt3EKxEzi2reIeJn6HlBwboYS/48CsAniehBACHomZlfspVRFRScdrjig9q46AiZPwnhI1/vbF8ciB+uGVAMqhikje3uVblAZ90Eq9c0uXnFT01N1F5domXbKt2vIGkYR2C5rgsJ8bMKpOon6ujlPO6y8LGKIEGwuBWpIXgCyJIofhuF7B9N3SpPz/qVqJIgju/GLlaLQJHdq5MmJ3YpRmQ9W4aUAFp3ZezwrU77MvJRPv0Viud1V/623b1sFE4O91VQUHBMoMZAGYBrhqmV7fjkwp7JGNz7W7ds/Jq+W9f5x98kBhJ/D15y4c4JyFj1DxmAWrJN1bQjglxWIhCrqyGs8xE4eSzVO/JeKntcrpN/jYjBIJC3hGlGVbXWgq8bPHJ6AY+afAZnqn1cXj2MXXUQ6iepet4zNS6YCeZGBfInnSMVsw16Nl4FZBflvJJniPSJ8mxE7o+Bsq+pFhWGF7Ki7aILWU71M4b4WWXuT1XFOaVOdO5F2Y2J0jo9l1S1LxpH/5rUW1wcGuOQ3Ut2ektR1D8JSg0WYSz586ZtDqKgoMDiw//2VQCc/YsAUxP0AQfSRwYR+qBnIMn/0S6ksAZ4aoCaoeoWpBm6MlDaYDaZY1q1uHx2AWfrA5yrL2BHz7Gr5zir9zBVc8yoiUifwR/qfqJiAKQEsZEEC0KFAqYjaHS3PRNE6AsdSfrIVu7e6iXlzkNWr+5xR7zY7Vat1BJHZZAns1qGGLfuvadF8CqkuOV7TAQptsVJpUw8pkzA8pA0eRUsI0AWqZJyVq1F41xE2KyjWsods8jmNqS0OnoS6NJbVSeiK5n5Q8u2FRQUOLQMar1lBjb/xxETWVXOBnHXH78jen7+Ca+12x96+1ave2LgiRrJSbjpPLLVJ5mJuUW2oBpKtqc2L+aBb36yGT9QgNIGSjMmdYNzsz0X8rwXiJ+Zq8EAhBonyvlJiJ/egpdbiEvrmzGkD9ARP0P7aeLsIltQVGeIlVyN5t/fJiGJn0WqmbRF/PJwaRPOnbO4yfeRfp6yDh469xhIQmgRCVTgcel9Noepwca2ev/AkgF8mJmfPeZcBQUFK4Bsrg9xR/qkK0zBpy6OsUUMg7VV+qiKobQNd7bS4hazeu7sXvNO7UNzTJ3Na5Fv27daB4Yny3TStzk7SRi0WM1Kf9fPWQ+qfUJ7d6MEuZInfoYQBS6LVamWOcij/etDJE9OwbPsmosKi5yVyxZRo05/aFyMlqjhf38nhfi5ZPHPAHz5iG0FBQUA7vnYm3HDU28BGjvvkQ9bbo9+Wdorgk4FjGV95O9qT/gEYidZQBsMe04fE2LLmDs5MdtwZ2/pc/O67QDmH9sFuco13djxIc/6ALvqICzAhcUn6NDgYl9k/Ujip0+2WCV218UrDm/OYYjwGULuXLIGyzXfSO34i+bldRS/ccaPCWNcVhuOuZamuHmJ39auUQ+uYomXXdWy43JxCwWnBmvXYKu0el+E2YbOU1BQAKsAevbX23bvrIV6WCXFSPo9TwA1AO864qc20BODyXSOyhE/E93izGQfu9UcV0wu4Ey1jx09x+XVhUjx4/N9hqxeHrboSNuFeruWKAAS1YwGR0GCoShwRMvc7R+UP8Lm1YgVL1lUDE3sQx2z7OTbPY4KBO+PzyBdNTO8WsEUFToE6zUX+UOp9WsTHb9WGlMGWfXPQOGyaheNw0CeOyV8hixf2xxPFpeQ5JiIng3gOQAeTUQ/JF46BxdVX1BQMIC27bJ9RPAyq+1+v59quAk1TKGS8FGdiqfrjupuKfHjkJsqexFA7Mg9BfgWX0QAKQPlOn/5nJ9J3WA3tHX/jOuwKuowsdgm7e5SSSyJn3guj9XNYJttKEOauz3Xz5TxlrAUkvhJcZiaZqiuSBXJkvgBhpVKi84rzylVP37bMhVUimXqH2B9NY88rli/BEoNFmFTs80l9LEWFJwMeAtYJC0WVq8hsKd0CbZ1qLYrS1obm/EjAp6n2ip+zur9oPgZCnaWuTXyedqNy0N6vP1t0esy1ydW+XTEj2EKxI9hZVe8lhA/qyImCVRU0KTPW+6um+63LlbpgrXq+bK2MaalxE96rlXHdRzB1CeG+Ln0MAFwFnbx6DJx+zSAlx/juAoKTjzu/vitgDGgeWsVQI0BWsa9D24+76cAeP752yN1T9rCPWv3EsofiVgl5O34jthJp7iM/YqUtXhp7TIX6wazeo6dem7tXm4hbuqyFmUd5uujQPwIS/wiyMWxITWscpXNGOT2S7f1VT1dzo+smeQYx0JBBDi7x/IGDBM/HkOqJ1nf5M7pzyezftJzpUTT0PtcFBmQs3StCo1+8HbBJYND12CbUv4UFBRsAVIB9OH/81X4yv/1nQBE0eKRUQBJ8kdrg1q1qHSLWnVBzzvKFhqyjaiKJq9MOF6k5umIn0Xt3sOxSQv4nDJIqoY88eMLlxYqrHDNV7R5HUY9k13ROgTZNJTfI1/vbzPw7eajzKAVZMPpdccUXUfdqWvdLmZjbF7HRvxcQjWYs4F/gIj+D2b+CwAgIgXgLDN/+nhHV1BwEcDAEkAwQK1x9+++5bhHdMmCKwJrgtEEDgogst1QddokoyN+InGu+P7u2cVyIADKNtwgxVAua7GqDCZ1g0obVMpgUjXYqebYreY4V+/hitqGO+/q/ZDz41U/MuS5YY39topUP8vQMkXZhl1r9mF189BrqconVx8tasCxamevVbuKhiYjmcUqXwOkKp3OTtV/L4H0cYRPTcbeqy4Iuzu/WmipW7VmS8exynbDCu966Dr84BPvXet6lxRKDRZhU+RPWUotKNgSggLIIVrFIrFC5f4vDB3CXNFRaWO7eblCY6YbnK32cVm9h3PVBezqA5zVe9AuZDhn9RpS9/iJOyV9xkhVUxuYPZ/q5M3uHHMj7F+OZJqzQiPau0ukE393vc19TaXnykmoAYTVIUXKrRyx7b4BileZiHsFgVzd8p79HGk0JndoGdm0DGOCnle9Zo7kCaTWmgRQOE/O9pWxhx0JGHmfwMWPtxPRdwFoAfwOgMuJ6J3MfMcxj6ug4ETj7k/cihue/Hr7uBA/W4XRiHJ8TNXP+YmUP6m1Hv08RW8Xk3k/0TlD3qLPXDTQjviZ1bYWq1WLWdVgt5pjVx/gsnrPKbBdkw0Y20WVY0W0zzrsFscy1qeBuXdMmPAQqbNIGSTrn5ZFvk/Gkr8p+/qw5XyY+EmRs2nJz0hHNZrd7okfNUCeDdnfFpFp20JpDe9QarAeRv1fSERnHKsEIno8Eb2EiGqxyzetM+qCgoLVYERbUgBx4KC7map7TARoZeyNDCaqxUS1we5lb3NoGNTUYkLNUuLH24R8IPOcq6jletfhqn8bfF/e+uVVPs5ONje6s4M51U9nBVvdR56GWI/Jr8lh0crOGCwqSOSEve74NoXjvv6q2ESb2ILReJJbZXoZgF8F8AUotUBBwSjc/Ylbcfcnbj3uYVzysCofr/5xXVI9yQN09ZNKFtIkAdRbcIstX6wAKNu9C9oRP5UlfvSkRV232JnOMXPZPpdN9nFuso9z9T7O1RfcQtyeJYH0Xk+B7Wurfaf6CcRKmk3jiAn7ePl8nZIRvsZqmWymounIpRwpJC1cOTuX3XeY+FlnESa3UGa3m5WIHw/tMnvkrfbqHnRqH+W2+8eHCcxe9r5bULgtQ0RWDVz3R//wRUvPU3BRYu0abKzy54MAnkdEjwBwP4DfBvCPAXwDADDzH6w64oKCgjUQVpm8fNk/d6+7junUAKwZxhAqbUDE2K3mmOgWu9UBJi7nZ6bm2FUHQe0zpMTI2boAxGqfRLEjsWgS9oRPeOyuE8bAFIoSGXDoC6DoOgPqGf/ZDXVjULArZbVql07sHrl9/OqOggFIwZDBVDVojMZENfBfuYZjZUu+mBFeczAaVqhUi8bYBHCpHgrnHHj/ft9UPTRGEbRN0idV+HhL27Yygo6r0xeffN5sHdRuEehlAH6cmedEFwFDWFBQcCpw1UvuAE+os3KJW7Rw5rcpoaZ2kDNGRPLIfd021gwoS/yoqoWqTCB+duo5JrrB2frA1mKqwY6e40xl1T6X6T2Xu9hlLvq6y9u95saqnYds9R7LLO65Od0TOqZH1HSESpp3OLjYkrH+j1H8DLVMHyJ7Usia7DC5hLkFOC1IoGWWuSEcRv0Tkzw5lbmJ7gtilBosxlj9HTHzwwC+GsA/Y+avAvCk9cZaUFBwGISAQu9Xd2ogVjbs2dSAmVqv+WRilTw71RyVMqGt+1nnKd9V+0H1U1MLTZ3laxHx4yXIvu2otWT59uvaFSl9Qkh2CfOvS3uXJH46oqd73nX60gt/yK+izPH71pliwhM56W0IXeeyuOjJWbxyt8qv2gVrlVjJE9vk83DtRcTXIZEGPW+KEMqN8TjCoQvWwk8D+HMAZwB8kIi+EDZwsKCgoOBIce2Vb+1ts0QPWbuXto8DaZOqeaSFHvnXpH2MFdv9NVu1T2VA7qbqFtW0xWTSYHd2gLPTfZyb7lm1z2QPl9cXcEV9AVfUD+Py6gIurx52rd3nwfIFdN1TpbK6cbVPLutHS2LCERVZoidR80glj6ztfK3XGB1UQP7WWbv6N5n1M6TQlhhW82Ts8InCR96AOBB6DOJQZxN9brULdrZKrMMRP+tCLrQWFCRYuwYbq/wh11rsGwB824rHFhQUHAECKSRWtZRiaMWolA0YrMigUm0IefZtRHPBzkBs+Qp2K6n6CX7uvmKnZb8KoaDJBEVHm5nE0uBoAJlVJneNTI7L2MneTtzdqlgnkc75vFcjeQbDEUNBoYKKJ4zfKXHk9ioUHwuu71U8I9uoB0VNRv2z6BqHxWGzhta93lFfdykuQT6LmX8MwI+JTX9BRC84rvEUFBScXrAmvOjqt4VQ5/vff7Mlfir7mg9z7gU9J63dgzIIEEQQdwtt2j2uOLZ4uYxFXRnUdRPUPpdN9nG2OsDMqXx2tFVb+xpsV+1DEWNCTXgvXcBzFexe+6bCvql6eYdZq1OY+kzYRxO7x627BgU1j6+pGqORtmY3YbGJoIV8oqsD+4pjmfWzCGMUPfI9yvcZ3uvguT2BlmRCDhwjIwF0utCWqMG3SfzkMixbUBjTuh28fvwPr8H3fun7Dj2+ixalBoswlkr8AQA3A/iPzPwJInosgPevNsyCgoKtwdvBlLV9cc2gyqCuZGt3W3yc1fvYda3dJ+RaimZULT5oUK46WWVPhX1TWxmyV/r4VSnW2DeV86VTpxrKWMJ8to9U/HilT+o9lyHPgLeC5cN8h5DKenOKmqEQv+Fz5tVA/rlcQfLEW+UfuwymSr6m2jAWuaIVVqOCcsjuH7Zl2p+OxbKg6E2hp1Q6gtn4YsgpulhBRN9PROfI4j1E9FEA1xz3uAoKCk4nLHlDMLWtN6Tyh4li25cIdw4LZj3lj+3Yxdqqqrlip7BmoGKgZlBt1T560qKeNphMGpyZHuDcdA+XT/ZwxeQCHjF5GI+cfAbnqj1cXl3A2WoPu3ofZ/UeZq4Ok/Nh2tbd11hdNqIgZ1guQPWzbnKLSKGjaqTioYj48fVZp+jpcmjmIcy5I4ByGKP6WYZlxE+3uBbf5PGLF9Li13VSD/YV1UOLfKvXGvFiZ1cnR6r5LQdkF1y8OEwNNupfFTN/gJlfAuDH3fM/ZebvW3/IBQUFq+IZr3gnPvIvf8g+YXsL3+eMIFFuZ853rjgEPXuCwdu7vLQ49wM8qHmE31wGMs9ZB6VPStr4QqL1JI5QA0kCKLWByUnQbo+LCln0NEZvLMC3k0hvdmKUiqDOKx6TPLHlqyN3PAGUIiWAuu0jV8IGLFtHqszJFKcrHZ8txuL3dSKLnOAd2ODt+PGtLmzwOgCPBvAKALcd75AKCgouVVz/9Dfh+qe/Kfvar33w9bj/gdfZYOeacNVL7wCIerYtT/AE21dKBAU7GHd5QNrm+cTEjwEqAz0xgfTZmc5xZupsXpN9XDG9gMvrCzjnAp3P6n3byt3dPOkTET/c1V3y5hfAPCGzDAr57EJJ2HS3juBJFTsxCZS3e2XPt0aNNqY7VRzCPF6Bk9t3qLlGikVqcFmTjKk9cp3A0jiEsZDjTzvxpmMEgJ/4o1MszC01WIRR1i1n+XoPgLMAvoCIngLgO5n5e9Ybb0FBwcog4Bnf+s6upTtnlIy+kNEMpQ1qZTDRbbB6TZVtMarR/xENpFk1hDlXwQMuSR8g6f4liB+/DQCcAjsrDc5NclKCLImfFpQtJnLnXYa0vee222EqMlAg1GQwB6CY3N8wLjwkqSMl3AYUjVn5P7w7h88Uyrd2dYHPA68NWaRW+UyH5NXpdcLzVYMYB7IAxtjWwr/Dkfa4beEk8lEbgP9AXwzgZ5n594joRFREBQUFlx5YjfhhTFb9bCIip7tJgicXAB0RP2Efa+9CJVq4O7VP5RXWdYOdeo6pblwnrz2htD5wYc7x4lsKaffyi212MU7Y7ns11uLJJUcAtSEfIN6WtmWX5zDiGDmX2mYZauN11GE7quaQJ4C66yyyVCmMI4rGImuXS5pdtKwGIxly76WF6v27OpGLYceAS/RjWLsGG0sx/u8ArgfwNwDAzL8H4KpVR1lQUHB4EAPkvddsCx2wKGIYoMqgqgxm1Rwz3eBMdYAdfYBdfeD85vPQ1l3m1/ji44Ar7HGNPa7wsJng4dbe9k2Ffa6xSw+JvgAAIABJREFUz7blaMM66cS1uKV7KwuajHLIQ55rHgIHdVD9SMlx/jr51/zEGuxUI4mIXOzzGOhg+xIEnG4wUQ0mqg03rwiqVRvGldq4OvtXrACyKiKTURP11UFDKpnVyJ68pHxIdr3o/IvCr4dCILPjWPC+hlRSBYfG7xDRvbCFxz1EdBmQ+UVTUFBQsCko4LpnvWXw5fffc5N9QG6RhTtyJ5QFhK5Rhu62c0r8aGf1qhk8NcDMQE1b6J0G0905dmZzXLazh0eceRiP2v0MPmv2MD5n9+/wmNmncUX9MB5R2UDnqZpj5iz26Y/zYH9n7axeVdfdKyy6ddagtMupr5Ws2jpZxMl0b00tXF2wcxwiLWu5YA/LLML1ngsCaV3LUo74SYOZl2FMbSEzfiTxk1rNViF+VokOWBaN4Ikfrx7XKyqecmM91eqfSw9r12CjQ5uZ+S8TQinvTSgoKDg0/qfb3wUA+JPX/CCe+r3vgmqsiobYr1zFEy65/7ACzMzY4EFtUGtPLnjlzzyyfOWCi2OveYU9UwcZ8hBCASKC6XL7LFKiAHH7UBksfdSqDd+ScxHJs0rbTkVswxIJqNDaI4WaJwprRFx8yAIqpwCKg5wXq3CWjVH+jQ5ro0rHIv/2G+sWllH3DCma0tePDM6ieQni2wA8FcCfMvPDRPRZsLJjAAARPZmZP3FsoysoKLikcO+Dt4za74G7XoPnveyOkPcDZNQ+5MKfxfao9bt2ip+agYkBaQNVG1STFpVuMZs0Ufv2s/U+zlQHmLhuqlPVREof++O9yxVsocK80Fnsq87mBWmjsnb3sMiWKG8WIad6tXNyvsZIn0tVT04RtG30u5qOI35yWBaWvMwG1pFF8Rik5WpMbbFa7Zhpab/g+jn1z9BxpwalButhLPnzl0T0HABMRBMA3wfgoUMOuqCgYABkADUHnnzzu1BpgA1gKspLF00X9Gxqu6mattidHOBsfYDd6gBnK6v6mVEj5MdNdJpOcuy7S9hQ5wttHRQ4gCMysLgbVQo/IUW5PgO2Mdkq1BM/c9HeVCJVtPQ/GlpaHPXGyv0uGH6c6XVByyfxUCCpFsq/1yUkmIQiZ+0SFrCucOsKSP/RSBKoG3tnDQufB8nXYwl5tvBZO6cnTwJtCosIIHm99O93orqBXYRgZgPgo+L538Cpgx1+HsCXH/W4CgoKLl286Oq3AQB+7QOvW7jfr//yjXj2P/mR/guC4AkBz9SpfkL+j2an+rGt21VtUNctZtM5JrrFbn2AM7WtsXwzjV09x5TmqFUr2oObQPwA8Txk0C2oSeLHhzz7VhxjEAgdWjxX+5qoR/hk7F7y3GlNkc8T6pRCqyJryVqD+BnCkLInP5bYfi+3bQvG/aOUnXElOvVP10zE/1vy24Zyf04t6XOJ4zA12Fjy57sA/CiAzwPwVwDuBfDKdQZbUFCwHMHK5dU8NaBbe08twg9+rwQCgHZmCxbsNtDKYFJZ1c9UNZjS3JE+jevw1QxdOpAvc+NsXY746YoF4+TUqvfDPrey4lUYuYkptXsB6BE/aSGxyo/2VQmLMNYB0kd+ButkDYVj/bkWvJVsTs9ABpBs+z4m5yfdtmj/bWPVgu4w3S/kKujRWcCk3+BU4VS+6YKCgpOB3tSS5v2kGUAkiJ/aET+TFvWsQVW1NtB5chByfXb1AS6r9zBVTWjfrgPZ01l1JNI6yM9nkvjxnVZD8wwR9Dwm+zAlD1L1T/p69NqK86s/Twh+3kLQ82rBzv15fQzxkx43FPK8CpGyTD0++jzB/tURP/I+JYGW4af/6Gp85xM+cOhxXTwoNViKsd2+/pqZv4GZH8PMn83M3+gYpoKCgiPCR3/6B2FqEU7o4WXKCuAKUJXBpG4wcdkyIehZhg1S3AlCdviyxI81J7VMgfhJuz4A6/8QTzN74sygmPgJ2wZUP0PIeeAXjyktyvqdLSIrWvDh9z+DITWQzwDyHb681zxHmg1l68T7pC3m8ytV41bVlufsAENk2HL0c4BW69YxdB67bThT6ESAt3A7+bg4RllQUHDRgDWBFeGFL3j78n3l9JQhfqIgaOVUP474wbQNxM9sOsfZmW3f/ojpBTxq9hl81uQzeNT0f+ARVZfts6v3k3yfTiHt83xkAw2b80M9xY/v7uVrizapYxZlHo5V3YR6zp17FbXOJu1eg7XNCvk+QxjK8lmULShr47HWrE0izf7Ryedglfcmui3sVFZUPxalBoswttvX4wH8JIDHMPM/IKIvA/ASZn7rhgZYUFAg8Mev+8Hs9oNz9n721116PRNgKtvi3cwMtGZcvrOHR84u4JGTz+BctYfL9B521T5mIvMn2K58gZG0GN03FfZNhUYEDgIIqp/W2b9SAsAHEvtzK2H3irKF3LbGWOmzJJn862m4YXeNxXavVSDl0mAFk5zSK5HC/l5dwwpzA9RqqHgxPW+3gUqkxG13bs4Xev3zxuofWxR0FrpU3bJI6SMtYFlbm7jmEFbp9LGpjiDeCpd9baCzV8/2VlBQUFBw0cHUCmo+ci5xGYky68e2bk/yflwbd54wsNNC1S2msznOzvZxdrqP3WqOK6YXcFm1h7PVAc7qPeyqA9TUYqrm3dhCZmF/0ci+LvNZusWkyOrVs8IL6/ugNcuuAioytrYS9q9Fi2CxynmoY6dTnoysC2RtsuycuWPXhQxwHrpeztLV2xfpQtX4MaVqnJz6x59/6Lxply9LYpmO+Ek/OwZAXQ04ZsynT/1TIDF22fZfALgZwBwAmPn3AXzdtgZVUFCQh6m7XB8PX8yYGsDE4LKze9ip5q69aOMIn2Zhi9FO9aPQqW8S0iMziadERW5Clx2yfNeIuVFdiCEosZX1iZ8o4HCDq05pUSTfj+yCAXTdL2S3jDDWVMo94NU/qpWkMQRHj+AZyPsZc67DWLG2hWy3s+NSAp3OVaeD4x5AQUHBpYX733ezvX//zQv3u/Lld8ZWLk/0VOi1fgecvV4DmBjoaYOd3YNA/Fwx3cMV0wu4vL6Az6o/g3P6Ai7XFxwBtL9QhRFaqAsiqKstVCB+pNVrqIPqqpaqXHeuaGwjMweB9UkZqfAd6gbqz7+tAOlleUVpL9f4WKEKWsXyJesPcVxK/OTOKcmdqPOYIH5k9zN5njHq7VOJUoNFGJv5s8vMDybdvoZDQwoKCjaOx739XSCXDyhVP5744YpBdYudeo7dao4d7QmgOWZq3l8tAODbu4fnvhU74jaf8nWfd5P6zJepOroWol2os3w+pPgZW/AMTXirhj7Hq3SL25Va1UvrrpPvEDbU2UHm9izDWHJlUZDxolU4eXz0fOBzy3XsWkUBNBbLusOl+25yv4I8iGhhiDMzf9TdP+toRlRQUHCa8P57bwqPr3nhbQCA993/2ngnoq7bl7DGB6UP0NnniW1eoquhJpMGZ6YH2K0PcG6yj3P1Hs5U+3hE9TDOVnuhccYk0zTDo2tcobJq3q6+UkF1Pdj8An3Fz2C9w536JyU5FtUbudpgEfGzqoJ2UW0wVlG0KpZmCWXqsuFOYYerbXLt4hedUyFt7842Tyq164MBMlYtJBT9Y1DUPxcnNlGDjSV//pqIvgSO6yKilwP41MhjCwoKNgECqAF2/1/71Gf8tDOg2QX4XIMzl+1jVs3xmNmn8ejJ/8Ajqs/gjNrHlOZ2ZUV0BbAqHEu6HCSdJhrnRQ8rTq446excFKaYRe3dJeHjz9OCgtUr9Zt311ue19N5wvvXTomIZQRQ2vo0GktuHNIqZjSgLAHkpbdpC/ecCihXiKXEU3asK67+LSaE4rDo6LUlBdhYefGqWNRiNbam9cms3PvJtX4/8pWxi2OVaCx8C50ZgKcD+D3Y/xO+DMB/BvDcYxpXQUHBKcHzb3gHyIQpt4coyFnFt3QKDeqgyrZyn04anJns42x9gHP1Hs5Ve9jRtmPqrjrAjOa9H+Jy/oxbbw/nI/r6Kz1GHutDn5chCnwWBNA6iNQmkYJl8xPZts6/LBtwmfVqGxhD+gD2c9CC+PGKff/5yIXcNvPvqiCDUoNFGEv+vBLAuwF8KRH9VwB/BuAbVh1tQUHBeHzJO98JMPBfXvVDAID/+7U2B+ip3/uuUNAYDZgJYKYMPbHt3T//zN/iXLWHXb2PM2q/C3heMOGkLdbDyhOGlS+eMKmXrK5I9YzM9Rnymq9C/CyDXP0aOudQ61N5jByrbQNv/wBB9cP9LmHyuGVy5lzYdO61qMBcUthlCZ0R6h9/7FhEpOAh1T/bLsRWURJtDAxcSp0mmPkFAEBEvwDgO5j54+75PwDw6uMc22kGET0SwL8D8EUA/hzA/8LM/z2z358D+DsALYCGmZ9+dKMsKNggCODMvH7ly+8E1z7nh9x+6Gxgid2LNZzqh1FVBjv1HGfrA5yt93GmsrddNUz85CBtXUM/0G0dFDePyDa/WJBvBwwvgNnXVpuPc8TPOqTMGGXztomlIaxK/GwyNDlnDTRRfWlCxzhP+mjYx/716Hxk7D9ip/5J0UINjj/nBrgkUWqwHpaSP0SkAXw3M7+IiM4AUMz8d+sPu6CgYAhf+J7bQS0BDaE+0L3Xv+wH3wVyxUo7BZodYH65gbm8we7sAJ9/7m9xRX0Bnzv5W1yuH8YZtR8rYJyly3bxqly3Cbttjyvsmxr7XPfsTp1yx+mnRUDyHEDtSIWu9Xu82uVJJR8eLRU+4RqZjhYeaqBIWDR5p6tfiwgYqQxaRrB4QilIsd3nIIOi5WcuSSFZEKVqqPQ9D5E+6bgGybkkJ6lTvcT/Hhapf8YiZwPbBlIV0zIyK7UnHpvy59LEl/qiAwCY+Q+I6KnHOaBTjtcCuJ+ZbyOi17rnNw3s+wJm/uujG1pBwYZBZH/PMYPYKoEA4IG7b3IdwRK1jyd5hA3MaNjuXhXbrJ9Ji13X1WumG1xW7eNctYfLq4cxo8bm+2SIH0/i+Hpq39Qhx8e/Biz+sZ0uSLSgqNnGurmHYwOXc7k4myZkhmqwTTWUWAbDFBp0jFXhyH39OVKMsVsp4ojA8fVW62owub2m1pE/NrPTK4HCuZImIsuQI4D8+X7mj5+Hb3/8ry89R8GJxNo12FLyh5lbIvoK9/gz64+xoKBgKZgAQ9APK1ADqAZ48s3vAgyg5gBR16XCKn5gO3zNGjzm3N/hXL2Hvzf777hMXwhBz0BfUiwnDMNkixVT2W4TgpwZKxteaP2C8K8neT52LMOkzyKs+gM+54GPrjuCYEmLkKhTGLouE3HB1a30pJ9njvhZpsxZ7Nu/dFY3xqIjHEcomo5D+YMuo+sSw0NE9DMA/jXs2to3AnjoeId0qvFSAM93j38OwAMYJn8KCi4NEIHBtjhy8IqfQP5IxY8khSoGVwBPbNaPrltMdIuZbnD55EKwetlmGV2+T79W8O3bq6h1e5vUOoDqWXZs84hU+as6a3xyjqFGDatCzpeLiJ98zTMOfrFrW0HOh4UkRHIEz5AFfZ0a1Yc1R0SOU+xEYxKqn5raaP91G4aUdu+lBksx1vb1MSJ6L4BfBBAIIGb+pRUHWlBQMAJkCGQs+UNtPD+wsgHP7dS2d8esxWw2xyNnF3BF/TAuU3tOnnyQKE1UVGT4Dl9zkffju034kMEhSNJDJdvlj3FJ/BgIKfO6hE9G5pwqWfrj7PYZa8MatqT1wxSjvKDkbXRkEPWKizHEzyJCKrf/ScMQ2bJNEmZMcVaUPxvBKwB8N4Dvd88/COAnj284px6PYeZPAQAzf4qIPntgPwZwLxExgJ9m5ncf2QgLCjaEB+56DQDg6hffDhBFP+46gofizl5+uwZMzeCaYZzqR9UGddViVs0x0w0mqsGOnmOq5k6J0Z8zZIeueZKbKNu2h2PZAAuUGi13HVBTa/wYjLV1L8Ky2mip2jZREB+W+Bmr+lnU5n3McUPbxubrLFL/eKuXJ3Jk9zNpC9SC9AndeanfgeywSBVoRf1z0WLtGmws+fNIAH8D4BqxjQEU8qegYIP4i2+/EQDw2He9E5NPE2jeET+srUy5nVrFT7PDMI+c4/L/n713jZZuK8sDn3fOtapq3779fQcOIODxnAMHLxhFAhg1mvbWrSRe0zqUJMM2GmJsIx4J0q2ODngHzgU4iVEEu00aTCRItBVN64gBjVcQtFUUEZBWaEXUc/m+veuy1ts/5mXNOdec61JV+/rNZ4wau2rVusy1qnbNdz3v8z7vLdfxuIOHccfeh/GEyV/hUN7AgTgCkDYaNh0m5nWJYy5wXJeY1yp4CTNNIdpERkMEScc7xyV+rNeP9RHqJzFasuSwy0HU0C8emKRIIKAJToYSK145mdnElrEF46LmPUMQxa6P3XeCcBtU5jWA8GiTMInrFTHI7pM+x44Xe55aZyhS5I57LoIYYH0eI8d9IriEXBMzHxPRDwB4EzP/wVmP52YAEf08gMdF3vq2Ebv5NGb+gCaHfo6Ifp+Z35I43nMBPBcAbrvtttHjzcg4cRjvHgLe/NOKEHJJH9f02ZR+1YUmfjQBJHSHr9lkiWmhiJ9dudTq6cZ3Rdr4wczhwsZMIfGzZGnjr5qBgipFDnDtJT8MYVA7ibdQ9ROLC/zy93Zr8HVIoNDjJ0W8bINksvtKTI5jSR9gPPHThViJntS+OqkYJKawcUu6DPFjjJzrQPkj7Pu1oxTaot/QzeLxE0OOwTwM+u9l5q+OPP5x33ZENCOiXyei3yKi3yWiF+vlLyKiPyWid+jHs8cMOiPjsuM9d3+z/bGycuVCKX4M8VMdrlDsLHG4c4xbpjdwRR7hQB7hijx2ghRqtW1X0wnZwGVpSB9X9aNLtFJwy7j64AYuLvFTW0Kov1a66/UYxDtujM+wtfaLNDnjdvsIiR93+1iAF45t04BrlFfAmv4/p4E0mdRHGLL3yFgfRPSFAN4B4Gf166dphXDGCYGZP4eZPz7y+AkAf0ZEHwEA+u+fJ/bxAf33zwG8EcCzOo73KmZ+BjM/49Zbb93+CWVkbApByuNHOvMVaT8fPV2G/j/1lFHPamBWQ+ysMNldYlKucDCZ40o5x0F5jIIqa/Bs2my7WLK03j4mgWaInzmb5wLLWsVJK248HE1bd6MMWpl1WVqyZ1lLj/iJJzzYznmS2D7Ue3XrEb98fjv30zReTiH0TOx6AIr0kfDPeyhiZsumPCt8mHX6xlWKCqWoMBUrT8XjlnO5j6lQCrMZrez3TZV8nR7x8+p3ffrWjpVxOtgkBhuk/CGiV0YWPwjgrTroSGEO4LOY+REiKgH8EhH9jH7vfma+Z8jxMzJuSpg5mJpSr7rUip9ZDbmzwu7OAtemRzgsj3BY3MCuWHi16S689qPWnLBR4sT8eDZF2Co+XL4uwoDFoGLaSlZqne1ta3GtflLjaBshVwFRNLSDV9eYxnxmY2rWw2MIG1h272NbxErMhDs8Rq/iaQMj64xO/Eso4uC/AgAzv4OIbj/D8dzs+EkAXwXg+/TfVmzmNu3Qz/97AN9xqqPMyNgijLLH4FOecy94Qn6pF5rn9YTBkoGSIWYrFGWFabnC/nSBabHCTC6xK5c4LG7Ycq+JE1OZUi/1IJtAM4TNUps0G/UOALhdQd3e9LVOxrmxV9MUo038mDk4JGjCOCilZk6RItskfsbMtX3HG1rKte0Oo6mW6iaW6CJSYtua8SkVGTfqHqohnOSsIq7U922ISmeI2XOX309XfJVxIbB2DDa07GsG4GOgPH8A4O8D+F0AX0NEn8nM3xTbiJkZwCP6ZakfZ08rZ2ScU9z+/YoPnX1IQuighQVQF8BqV5k71wcV5O4Sjzq8jkftXsftex/G46YP4tbiYVvupbpMxMp5hGNOqDJXpuSr8egRrclgLGFgS5oQto1Pt44fgjDTBfg398bjqIsA6useMWZ8MQ8ht3W8LTPzCB//Gq9L+Jh9rYOhn6dLaMX2YcbQkEIDOmcMCDhaip0RJJD57L3xnfG0c0lFRitmfpAoB47rgIi+AcBrY+3Y18T3AfgxIvoaAO8H8GX6OI8H8GpmfjaAxwJ4o/7MCgCvY+af3dLxMzLODGY6a4yeqUUMgVR3L9XWvUJRViiKSpE+xRK7xVL5/NDSmjxPaNWaf5py9jbx48ZdphFGHZgeu63dl7WwpfFhN1R33T5E57jIpmG8sS7xs83Sr/j+G+InVAKlVFAxdJllm/dT3WRdeCbNHXBLu/zx1R7xY2MmVKid1vPqG+R6DsWJvDFoDKMTiumbIEGWYzAfQ/9znwyl4HmAmR8A8DkAPhbAl0BljpIgIklE74CSIP8cM/+afusbiOi3ieiHiehaYtvnEtFbieitH/rQhwYONSPjAoMJYi689qS1Lfdi1FOVrZrNljiYHuPq5Aj7cu4pfgzx45Z8mfbugGv0LBtpsWPOnMIQD5cY1gkQYuU7vglfUJvuyXL7x7YZAdUmOIZOzK12roEaKnyk9mEe5wFdZXkp6bT73qhjdayfMgHP5V0nht8houcAkER0FxE9AOCXz3pQFwiPA/AbRPRjRPR5tCGLxswfZubPZua79N+/1Ms/oIkfMPN7mPkT9eOpzPzdWziPjIxTxad92b32+Vt+8gWqLF4SPvXL77Vl8gCi5IchgETBKIoKk7LCpKi0yXNlO3zNNAEUzjlGQW0SZXGPn/i/simtN89jxM/KKffqi8cE1a3OXG7ZU7xsqSkN6yN+zqKhhDt3G7KkKadS51uKZpl5hGVvmyKm3DHLux4uyeMZNzskliF5zKNZp9nP2uNGHX3eq7IC44ff9bfXPm7GmWDtGGzof/YTAOw5r/cAPJ6ZK6jSriSYuWLmpwF4IoBnEdHHQ7lRPwnA0wB8EMC9iW1zvXnGTQUzb9UlUE3U89UOsNpjVAcryMMFrh7ewOOuPIQn7j2IJ+w8iMdMHsJVeQMTIy3u7CYhsOCiae2uFUBAW5ES1o6r5w0JYwKPGEJPoDGqn1a9d8rYMFLj7QY4fbXfYwObrv3FrkNjvEjOQwV5biePIb5HJ0H4CO/z9ce/zrH6/HaS23UQRF3rx8fgf1fC7+2Zef5Y464tPs4e/xzAU6FigB8F8BCAqAo4ow1m/nYAdwF4DYD/CcAfEtH3ENGTznRgGRkXAJ/2Zffi07/4ZfiML3qZWsDwO3uZn0jWHJD7c08AiRqFrDGRFSZypVu8LzEVK9vhy72pN4h29tLET+jR56o/mlioSc5FiR/4xM+6BEzM6yemKOnaZpNyqm3BJXaEvXq1R/akyt7M9jF4ZtsD5tPWtYx4KoVePjHPJY+cCYgjsx2Ajfx+DKlkjnHWyudzgRyDeRj6q/JSAO8gov+diP4PAG8HcI+uGf/5ITtg5r+Gqkv7PGb+M00K1QB+CB2GgxkZNxPe+w3PV2bPAN717Xfj977rbnChulKISYVyssL+dI79coErxTH25bHNUAEN8RNTohijZ7eVu8lELRMExDpZlCpIt21SmhSDpAQZlJC2jiWAYpN6F+kTXqMhWbRqw8BumzgPY1gHQwgg9frsA9jLCGa+wczfxszPBPDJAF7CzMdnPa6LBF0a///pxwrANQD/kYheeqYDy8g4x/hvr38+AKAuSHf2oqajlwtWCTWqAarUQ8x1ebBglEWFSbHCbrHEbrHAjlxgKpTprrkZd2/CVcl8gWMucKOa4kY1wbwucFRNMK+K3qSJIYcM0bNkobqs1rIhfpxEkeuZ2IdYosN9zz6c5IlNuERinLOcN5UyxlU21Si0/5J9OERQ+ADSsatpepJCX/mTIXmMybR5hKSPq+xxH1b1oz8LnzBatcgtgyGxuEtSusbVY5DVPxcHm8Rggzx/mPk1RPQmKJKGAHyr6RgB4AWp7YjoVgBLZv5rItqBKhd7CRF9BDN/UK/2JQB+Z8g4MjJuGjBw1/fer8q/dhgoa8hJhdl0ib1ygf1yrgOVphWpQYz4McsqJ5ioIoFFbOJzfXTM+u0MSKSWGuP9fdIdKYYRLC7MuM1+t0lyjCXFbBAXKH6GbXsuMgyj0NUm3sWm55aqVQ99ATZpf7sxGJfS6Y6IXgfg6wBUAN4G4JCI7mPml53tyC4GiOgboYyZ/wLAqwG8gJmXRCQA/CGAbznL8WVknEd8ynPuBRj4ldc/H3/779/jdPRy5gFN+nhiH00CcQGgbrzsCqpRiBoF1SipxkwsreI4VF+4HVLnzgPQc1wimeTCL7M3Jd7D1D5j1apdTRH6fPzOAo06xin3cvxxTJxbQcRjThPvoY57XnKsAYeImiJXLHwypSOp6HYaM/uKXcuUt1AfYWWP48S06XV8pVdYQlZ1xECXthV8jsFaGNrtiwB8NoA7mfk7iOg2InoWM/96z6YfAeBHiEhCqYx+jJl/ioj+HRE9DerjeB+AfzpkHBkZlxV3vuI+FbBUAFWk/lsIqEvV2Yt2V9jfm+NRu9fxmNkjuGVyHdfK6zgQxypbQHXvpOB1qdABR8WUNHl2ERIpZhlgyCClPHLbmrsYKqttnrdr0bsyUeZm365jjq8PG5JXQzGW5HFL0QzOO/ETI8bGB5l+wDN0X+57ayvEBhJA7jhPHZcw8ADwccz8EBH9AwBvAvBCqAAkkz/D8GgAX8rMf+wuZOaaiP7eGY0pI+NC4FOecy8wIfzKjz4fn/Zl97bNnUMwAKMA0r/HRIAUNSa6LXchHNUGuQk1FR+FpV7zurAt3AUzIFQclOpOZeYjtyHG2GYYof/hEHQ1eIjN3UMaQmw7kRKOw5R7Ae2OVRK117222ce4xiQuGaS2E70EiEtQtZe1tw0/K/e7pZQ5dfI8Ddxz9WJxh+QK46Cxih/3vH/kDz8VX3XXJbPvyzGYh6Hdvr4fQA3gs6Dagj4M4A0Antm1ETP/NoBPiiz/RwOPm5Fxc8D8MBF0ikrzF6YlaVljp1TdKPYKZfA8o5WuS+/+Vavgd/4yk3Zs8uxCLOtgJMPtSRStdqVd6CJ++gKMaHWfAAAgAElEQVSdrvbjTWvO/oyJi3XK3WKT7SbEz7ow3cbWQVfXh3U8csZsM2Td8T5E/ncymz9vFSURlQC+GMC/0qqVfIEHgpn/t4733nmaY8nIuCj4ldepkq9Pec69AAGf8pX3AoVS9YDbVhzmtVH+KBKIwDpmMY9CVJ7nikFTSm/MmRXxo4yZG19DkDM/UZsAclU9rifiEOJnSNLCKLJj6pZwX0OSPSkiZVvxSyyxFyv3Spb/Jwig9njjMYNusg4grf4xY5NBUi98bcbTbNMec+jB4xI/Xe3YzbYhAQTopCZqgJpW9N521gqhIYkk1S31j68WuqTqn8uJtWOwoeTPJzPz04no7QDAzH9FRJM1B5uRkeHgzpffZzNWLJ2WpQWDpzXkzgp7u3NM5Qq3TG9gVy5xWByhpBVmYmn30zmBocYSUq9HTubBmcRS3aUcMiBGirhlYK5p9NAgoaszU9hCvI+UCRVAtZ4QXQJolGnzBukCl/gJlw1Fl7Q5ekyjvFqjbae9dk5b27g03Fc1naaaZmxmz93uLHFJKZEfhFLu/haAtxDRR0EZDmZkZGScKDwSCMAv/wf1+llfdZ+/YujP6pSAELEq+dLEz1SslIdLWKrldEittEHzshXnKDqhXeYlvHikcuboWDyQIm/GdVjtJoCaffapXNabb9eBS/yUorbEjwwIoE3HY7bviiVjsc+6xI9L+gBdXoXtz8L9fsTILhvTagIIaMq6XOLH/HUJoJsNOQbzMZT8WerSLQasl8/N9+3JyNgy7nzFfVbtw6R/oDQBxAWDC4YsK0yLFW7duY69Yo4r8gglVao23XX1D+qGKyebtGT1r24mPtPhq2KC7FB7DIFL/Bi4Xb4MxhAfY0iXMNBxA5Ywy5VSAG2b+AkxRnXUh6EBWZeKZ9Bx4F9T9XecKeSQLKS//pqdTTY814y18K+Z+ZXmBRG9H8BnnuF4MjIybjIYEsjAm0J0KZin/nGIH0HK82ciVtiRS8zEUpvutv1+TKMM5fkjfNUP1Ny1BCBBEMyoqbaERrsMXjTK6FZpctpbJlUGb8iKMBHXFReljheirZ7t9k9MlR/FlrmKH6O4MsSP7XqVMm4eqFxPxUsVE0AC4La6KFa+D/QTPym4xstG8aOeG3IrrToKCSDvHCA8AqgOytbGqHjCdV/37k/Gc578a4O3zzgTrB2DDY20XwngjQAeQ0TfDeCXAHzP2FFmZGREoIkfU+rFQhM/JYPKGmVRYVquMJNL7OoAxRg9h+jKZhjPnxT6WqMPQcw76DwYFncROX3ET1/Hr9a2WzaX3gS9bdOpHYSFAWOK+EnuawBplrqe2/gOdh1/TEv5rYJP4HH2eDcRvZSIPhZQnauYeXXWg8rIyMgYAilqTTz4bbq7lBFhPBMSOE0pl7CEUWv91rKUwXPaS681rojf4knFXn3zdGyOTc27jeKHPeInjEVOG1Ydb8rQBhI/7jVveRVFiB/v/aAzWHi81hiDhK9L4MSIH7cbWteyS4kcg3kY2u3rtUT0NijTZwLwxbkmPSNjfZhSLxasMlWC1X+W+au7e5WzFa7t3cCtO9fx6OkjuFZct+3dBWpMdHtIoK+1pZItu+1Dpa43rqmG8IKRtDGyyXS5xwq7hRnFkRsUrUOGDCUdUtuGmSq3/Ku1fk95k7tsTG3+JiVfXUhlszYhNNxzC9vE9h137HFiiJmKjzEODwPNc4VzNpwt4RMAfAWA1+gOVT8M4N8zcy79ysjIOBuE5V06pGrdsJGaJwpRYypWQctt3cAi0iU19lc9V4bB+pU6qNMMI0Rfk40UNiFE/Liofz8SbMmrVAOFtdW6jjLK9fgxxI8dQ8Sjpg9hp69w7EPL4vrQZbVgEFPiuMRPl1n0EITlYC6RE8a6rlH0EFwq9U+OwTx0/kcR0S3mAeDPAfwogNcB+DO9LCMjY11oY2cQq/9EwWDJQKEUP8WkwmyiW7trk+epWGJCK0gzWSa8cFQXr26ljwsJdjIbcdIlVrqUCl6GGj2rdTcnRaJEyMDJfSxR0F/qdDKqn3bJ1fbPz1U5hdk911h7m5DkdPVwnpvxZKwHIvpIIvoFInonEf0uET1PL38aEf0qEb2DiN5KRM/Sy28noiO9/B1E9ANd+2fmh5n5h5j5U6Hakv9LAB8koh8hoief+AlmZGRkRKDKuxhUwz5gzJ4BRfwQQ+oW74WobMlXqjX2GHPhseqbTea5aFzWmaDqV9S48WAYG7bVwesk53xVjXCIHzsG8rtiDUFncmhAeZtrxjwUsTg7No7QZ9N7bwvKm3C/0eME8VXGxcYmMVif8udtUD+XBOA2AH+ln18F8H4Ad2w6+IyMmxL699cmiwSDBYMKBgSjmFQoywo75Qr75UJ1+JILrfhh3+vHkXyGGQ9AZUEqR4IcypDVpKgyOCbT06fwqLitoHFVP97yEWTItjIyKbj16KetDtk0Sxbbx2kZMp7UZ5IKRMZ2ZzvPcH0mThkrAM9n5t8kogMAbyOinwPwUgAvZuafIaJn69f/nd7mj5j5aUN2rn0A/y6ArwZwO4B7AbwWwKdDtR19yhbPJSMjI6Mf+o7FkD5iBVSk2roTA2KunkhZo6oFdos59uUcgmpNAFVWTaEKYhpCZ8my8cBJKGJMDLOsJUqhaIEK5LcGHxl7hN1U1TEj5tIbdPpMtaePvW9ixGY88dimszTMSSYZtZVZFiNfjAIoFvMMjYFS8ZJV4ZguXJHjm88w1eTCEEAtXx4WLYsGV/XTLg1jvR0N7mhm1msRQBGPIPcY/jjj1/AyqH/OIgYjoo8E8G8BPA6Ken4VM7+CiJ4G4AcAzKBitK9n5l8notsBvBPAH+hd/Cozf13PMdaOwTrJH2a+Qx/gBwD8JDO/Sb/+fACf07VtRkZGG0+69z4lQxaa/xGs27nXIMkopisURY29nTkOJnNcmx3h8bMH8ajJIziUN1SLd7GERK2zVG1jQqP6McGK8foxy1yoLgGm1KdSE6NZhwBAdQGLtUs3BJAJgrxyrwHtS11EA5kBRNA63aaSpoljDKmDsqRUmRKwudlzymQ5VqKllsfLwbbdwn29rltxSXIYsIbd2dxzXZfsOuuOX6cNZv4ggA/q5w8T0TsBPAHqp+eKXu0QwAfWPMQfAvgFAC9j5l92lv9HIvqMNfeZkZGRsRlMyhoqwUY1bJ1DtaMU1oWs8KidG5gK1TX1QBxb4gfw5+1jLm0sNa+LVgIthhSBAKzXjdNstwlxNBap+MgQQV2Jwj7iR4JRiEor2P0yrxRiJWAe8TaAKEl1lDVKo7Crl4uQxBuC1PnErs8mqhyXKEopiVJkUGoM21Ak3cQ40eSbxtox2NBuX890GSg96O8cMcCMjAxAET/slJ9q3x+SDFHUKIoa08kSe5MFDiZz7BdzpfoxpI/OFETbQqKRJ9eOuXNIxITKEXBDAJk9DSVCDAEUEhypzMzQIOQ0gpw+UmXd/djxRAK8bZpBp7NtTUbOW76F7l8n0VEr6rfk+DOFBNDo/Z8H0ueMVUw6q/RJAH4NwDcB+M9EdA/ULdGnOqveQURvh2oX+u3M/Isdu/0EZn4k9gYzf+M2xp2RkZExBnaacDp8mRnA5LZIMiaywkwusV8sbAONUKFRsVFNC9vpa2zyoda+P0MIo9i2QMRLsEP9sy3E4qMxfofp9RpbAZO8DNu5e+s78YGrtgL7qpiQ+BmTdFNlZ76xcxe2dd1dciVWtjU2cbgJWZNSDV2a0vtTjsFOIfkGbBCDDSV//oKIvh3A/wk18H8I4MOjhpiRkQGxJEv4AAAkg0pGOVuhLFfYmS5xdXaEK5M5Hjt7CFfLIzy2fAi7Yo4pLVsGzzHVD6AIoCVLLFliwYVW/rRLvqRW/gho1Q+Z1pEM1BKSGEvAU/+4x3Gfu6of81r99SXRrWtiyYr4hLqNibZdLtWVlRp3rHXJoiHbxZQy7rVPXS/1nmvKnS51G0O0uW1bN1HhRE23gyyjHRPBI4DOBZlzPvBoInqr8/pVzPyqcCUi2gfwBgDfxMwPEdF3Abibmd9ARF8O4DVQSt4PAriNmT9MRH8TwH8ioqeG5oFE9AD0/RRR+/PPxE9GRsZp4xO/8X6IFSCk+k1ypyZigI0aSCq19bRcYU8usCMW2BULG1cBviLCxlJ1YZNorWYSI+bCsEW8Wda/nZ5zbVv37mTXSRBD7dbj/TYB4Rg9/6CA9AlVMq3OYGBgDQPoEK5Vgmp8Uo9S6Gx83KDcq0/xs07yqys2tMdNlJW5CWaJGj/+R5+EL33S20cdP6PBtpNv24jBhpI/XwllJPRGfcC36GUZGRkj0MpCSYYQNYqiwmyywpXpMfbLBW6dPoL9YoEDeWyzUqHBs0v8KF8f0oFKoZ5z4/Xj/uib5eGEbbIpJoPi32w35V/m+EOyEkMCojCIOXHfn4iJsTnuaSJGAjXXvEv63H3t4/vtCM4irVfV9qfgJRRpn2pepzwETspQ+0RxMl/nv2DmZ3StQEQlFPHzWmb+cb34qwA8Tz9/PYBXAwAzzwHM9fO3EdEfQdWMvxU+wtcZGRkZZ4Inv+R+AMCOvpupnbsaudBPNPHDAqglIMsae+UCV8pjHMhj7Ik5JoHqx/j9GK/EJUsVZ61RPr1pTGNigtR+Yh6MXWMBusc7hvBIEUCx/bvt0k25l1H99JV7AY35tqQaNcvk+l3xkUv8hObVxoC6C33ePwDseRkDae/4CY+f5Hg7fH9S9gProsuL6MLjZGKw3gTctpNvGhvHYENbvf8lmmAxIyNjAExQQqxrzs2PDzUPkgxR1piUK0wLZe68X6pSr31N/Exopfx9bJYi9EeJmzwDTSeCCiZjFWf5zbrtMrBa66Sb5y4BBGzuaeONO5hQt0kErdstK4UuEmJMeVSq/MzFOpLglDdQu11rQm69Bgm0TRNtS4TpXr0X2QD6LMRKpFJCrwHwTma+z3nrAwD+DoD/CuCzoOrGQUS3AvhLZq6I6E4AdwF4T7hfZv6REx56RkZGxmCICljtAxN9m1RLYLkP/P6L78bTv+5+03Ud9UT9Fs92Fnj07DoeVT6MW4pHsCvmdl9homzJBeZ1qdU/7WTa0Btu2wnMKqP7fRF9o+eGAPLa2aNf4RObw919D/WxSY3VJYBi7xnY9u4jyr1cUkhSbev6SlEpG10Sg2OUkPgxBI0ym077/axTsucft462V+8lfnScpxT66fWGl9y1k2fWLDogfnxPxhr/13s+AV9w528POs55xAnFYJ0JuBNKvm0lBuskf4joRcz8ok3Xyci4mfDkl93naY7ZED36OReMumTwtIacrTCbLXFt5wiH02PcOnsEB8UxHl0+gn15jBktvXKvWKkX4Js8V0zWnFDVqDc16xULL/hw0XQPAyowBAg1CSxrpU1cQsKYQtdrqIC6EFP/gDYnE9JmhLGyo5PpnHVSnauGZPpMuZRBrGyqK3CIrV8zWU+eMde32V9/BxB7nIAA0u/YfbnncCEVQSeLTwPwjwD8P0T0Dr3sWwH8EwCvIKICwDGA5+r3PgPAdxDRCkAF4Ot04icKTRa9EMDHQXWuAAAw82dt+0QyMjIyYnj3C+/GU77nfrzzO+72lj/lu++3z43XTzUBcG2BvekCh+URDuURdsUCE6psDAXAKqcB2Fhq5cRSBu4cHM7xsfk55rvYvBePEVylTpcCaIz6pwvrqkcMAWSex/bpEj+u6iZV7iWp9ravWXimz16y0lGtxz6XGPFjvH7cMceIMNfg2kUYzwxVy8SSuMl1txw/xpThKeIndq+RMQwnlXwLjrF2DNan/PlaIopJjuyxAXwFgBf1HSgj46YCaZ2x/hFlIlVzLhh1oQgglDWKssJsssROucRuscCeVObOrgGhKfeKBhOu4Z02eV6y+re2gYz2+jGETVgvHbu5N15A4BqCSC9rJndBvgroNNBfFz3Qt2aLSqKhhMNpti53jZnD426jfj1G+Iy9pkMCVXOcoW1k1zXsPhWcgfKHmX8J6Xzh34ys/waoLNVQvBbAf4BqNfp1UBmtD40cZkZGRsZGeNe33h1d/rRvuF+FMVIRP/VOjcnOEoezI1wrbuBAHGHPUf0ATdxUg6xqWhFAjWdiLO7pUkL7aiLyvBHV+xdD1doX83SRPgA84qdJNjpl+M72IfHjHt8qgHT5l0SNGvEysFDBEpaamQ5fxuy5yytnbKcv0zq+e52O5Bt8gmZI2/fBY4spzFEnE8ySarzpvR+PZ9/xO1sbw6ni9GOwE02+aawdg/WRPz8E4GDAOhkZGdCt3M08TtyUeOlfHhbK54cnNURZY1quNPGzxF6xwFSsMBUr23LUdPcy6FL9mOfqbyNPtsofdomiLs8Y9rJNzYRXWwWQayDcRQBtU02zbmYrPJ+h624b6xJAqZbo7nWPGiOiaZkOpMumYte04obkOy9kStgBLLneORrzJcejmPk1RPQ8Zn4zgDcT0ZvPelAZGRkZ7/q2u/GJ33g/QEBdAtVMkT/7O3PcMj3CtfI69sQcArX28omrceogbupLeIXzk9tQIdx2nXmqVf7FgHB2u06n1DEYMr+Gvoop1U2K+Bm6bzjelVYFBBWpxmLl8Nhuhy+X+HFj7sopqzvtuMJ8N93yryEEUDj+oeu7xI/rs9RHYGW0cQrJN2CDGKyT/GHmF48cSEbGTYsn3aeVfaIp74I2dYYAQAyWDCoYhS73umX3Bq7NjnDr9GHsFwscFkee6kfAZCTaNcOt1pZqbZWlglEBSVvuNaRNafMj73YAgy0B0wdWwZIhShxPoJqlU6IzvhNG99jWD2jOS4eosTJxFymCx1uW6pgFdNaMm/3F/JzCfYbrt8vIRmbHguxguK+w/OvCEUB8Np4/p4Cl/vtBIvq7UHLmJ57heDIyMjIaCKAWQDUFVrsM2l3h6uwI1ybXcSCOW63dbVkWVLKsgts0I90wIUYIuckqX+Xjz0vDu4Sl/Q+31dlrjHeMe+zYe6HaxyyL+fy0TJEjqp/UGNS1Fbb8S5WlB13EEJJRivgpxQoSbD1/YmVbvidmd1zheufE4HbRUuc9/jPrIoD6xp9aB4gTP63nF7UMLMdgLQzt9pWRkTEEpD1+pCJ6IAEua5BQBJCQNYRkTKdLzCZL7JUL7BrFDy2dLETDxPt//a4HADyvH7PcZKzcci93faD5IY8FFaauOqypBgBBBNcIunY2bXd82C4BdBrYdKxDS+HGkFl9WbFYkNQyfA6yj1HyqFfJtR6pchId3MYoqbqC1VPB5Qw8vouIDgE8H8ADAK4AiNdfZGRkZJwgTIONd79Q/QT9jW++H5DAalc9IIDDqzfwxL0H8fjpg7gqb9g4JzaPSKpR15FyY5P0cI2MOwggtS9ffWu6iHXhpBU80WOuQSLFGmmEnjGNsXTtkELjOopFQTVKqOu/hPSalXSpi0ypl7VWcMeVIld0/KtiXt9uoeuaraOcceP8UP2TGmMfMZNqLR8SUGG1gWcGDcbPvfdj8bl3vHPU+ZwL5BjMQyZ/MjK2CEP81AWDJwyaVijKGsVkBSlqlEWFiaywN1lgr1QdJ64Ux7hSHGNmFT8rAPA6fAldAhaisiRPU6cOAG6HL9WlQrYmC5cEShFACor4UUbQAiUq1CRQMau2GqLS2RahaWihpcgmINoOAbQtQ0PANyeMYchYo6aNJ+yBtE52L0UCJdfvIYDUPtf/LGsWqlPHFtBFAKXbsF7Q7NU5AzP/lH76IIDPPMuxZGRk3Jz4qFe/DLQkTFYScg58/LfcD6qgbtInQLUDVHs16DFzXNu5gVsm13Egj1HSSjfAiCcDquCm3hgU1zw+cdKtUk00TbiAd6uuobN5DbiGwsOJnyHztASj1vvzFEB2LLXnu+N28zLkjyWJXHIkIERMJ9zGPqAeRACNJfDC62KTsD0E0BhFTpeZc+xzubBqn5sAm8RgmfzJyNgQdzxwLwBVGgVdBQUJ0KSCnFSYTpcoiwqFrDErVihFhYPJXPv8zDGVK5uJMBkOV448tKuTMXr2Onx1SIyHKjHUhCBaRtAggdoa7wFADanJHrN+c5zNCaBm0nKyFmvcyLtdHdZt4XlS6pGYp8/YIDDd0n17pVCbkHjrki9h6ZfBaZppr42LF8f3Qnea+CcAbocTSzDzPz6rMWVkZNyEkKxKOyqo31pSealqBqz2GNVehSu7c9wyO8JhcYRdMYck7iR+3GSZUkCb52lD4LHYRBltOlUJapsUn4VqKOzkBbTLrYB+4qfr/dZ5OqSL0AbQMIRIUNrlbh+SP6ljmvg5JFrCRGpXTBPuu44ogQaRYQkCKH7MuM9j171EbAyx79CF9f/JMZiHQeQPET0FwL8B8Fhm/ngi+gQAX8jM37XWiDMyLhHM76n5nWWhSr6k7ea1wkRWmBQr7BRLTESF/XKOmVw25V4eoWG6EKgJyqh+wtpd89x7berU0XSmMMvC4MKofVxZp5GohiSEdCbVpra6IXYMASS48fsxCiBLYpzDErCxBNBJlgz1efoMIU36Da3Pxrgw41LiJwD8IoCfh+pOkZGRkXGq+OOvfYF9/nHfqg2ehVL9rGZAvVuh2FvhcPcI1yY3sC+VytqgL3FgYi9JyhtmGXSVWsuTTvsippJx3Q052p45KQwt46pAoztZNePxrQlSap/k9hvclZuuswBsIlJQZckvqROqxtMnHJchflKNNEKbhVD9cxpwW9s3y9LfL5fg8YiisV6MHcTPf3nfR+Ozbv+DUfvLOBGsHYMNVf78EIAXAPhBAGDm3yai1wHI5E9GRk0228SSgZJBkwqT6Qq7swV2JwscTo4xK1bYlQtM5Qo7Yqn/LlSpl85OuObOpuQrrME18DtK6DbupvzLdPnSteVmwgq7ILjlXt5zJ3NkJ4GgDMw1gq6YIZgsP7SqJWo98dhxBCVg4TGBbvPf5ly3m9UKg54YGTSELNmk5Gtb6p7h269HAnlS58T5xkoIo2bOTneNtJHlMJPN867+uaRmg7vM/MKzHkRGRkYGAB2D6dbuO8DqoAJmFa4eXsdH7D6MR08esWRASxUBFdO4ao8lpFKIiApVLVARoXTusZSKQ6ssTHMCwI9xWvNkkxgDQZEVrbkrPi8b4sdV/KRu6lu+RFuYhFL7iLVwj60bqka64p6QuHJVO/4+K1Qg5f2jSTipn5vPuqSVR/aEx3YJliQRNNJo2d2X0OShn2glCOo2VLZqI6f8S43L+d6xHwe1xhaNvXxD55Bc8re/oEqfADkG8zGU/Nll5l8n8n6gVuscMCPj0oJgCSAh2fr7HEzmmBUrpfSRK0zEClO5QkGVb0ZHDtnTM7G7iLV3b95zb9abThZhvW9flwLAv+FuGUFrk70SlSJ7gnKwWBcwux/n/N1lqcAgtTxaN38BfvE3y3z5KqptKKpO2rdoDM6TSiyjhZ8iomcz85vOeiAZGRkZtb6jYQlUUwZ2ahwcHuFgMsfh5Ai7YoEDeQSgP+aJGeqGyh+PuLHxDgC33AluFzFXNSKcUrLQLyjWwEGtXBiLgEicdFJzdxfpo8ZQB7HcZsSP2kfMfyYxDu39427nEj+ljrVdw+fY+EISpFFy+e8lyR5H9dTln1NBYBJ0mkt16goJIDWu2sbzm/hgmjGmCJ7LQvxcYqwdgw1N+/4FET0J+qeKiP5HAB8ce7CMjMuI93zTN6snxGDBIMkQRQ0paxSywkRUmIiVfUyFJn7gm9EBTR23Z/TcEaCYoMLv/kW2vXvNFM1WuLXuY26uffO8pm2nyWyYbJT9C7bLvXOkoOVlQgGyKXmzDnHQ1IcPP/Z5IkzGoE+6vG5gkVTsDCQ0My4EngcVfBwR0UNE9DARPXTWg8rIyLi5cMcD9+LJL7lfdfWC8vqpJ0qBvTNZ4mAyx56cYyaWUdJhyJxkDJ8VkcD2UQoV7xTCdI5ilFSjtHGQes/EQ6WT3FPL9Tr6fQH93MZTbONCQ/yUet1ClzPZR+TcXBWS6iQ7fP4VQezmXq8Y8RN28zKPTRAbr3fOjpmzOT+31MsQP+av1FYK5uGf1/jSevczkj3xeoiU51QK2yBj1mkvH8N/ed9Hb2U/GRth7RhsqPLnfwbwKgAfQ0R/CuC9AP7hemPNyLgcuPPl96knjsEgTxhyUmEyWdmOXrvFAjO5xI72+DEmc27HIzNZTWilMxVNtgLwVTemQ0XT4UsTQDDePk3JF6DbvicIIHciqEw5F0R3RsCpqwYEBCpdcsa2DAy12v9Sr1+KqikBY7IZMuFkP1IS5W12bRoa+BgvIKM82cQrJ2yxHi5vrR8xZm4bHY43h1x323VLqlIlfcCwkq9mu3iXjQtV+nUJ+S5mPiCiWwDcBWB21uPJyMi4iaF/+n//xXfjSffdBy4Zk+kKe5M59su5jr+WEbPdtJLYnWtMpKKIGL9US1BTilOxU9Ju9yX8Ei+3LMwp3xFOG3EBd95rlOACikwCmnimGtA63o193O3C95Lbh6RHSJx0kApDSIuhRs+hd4/qxFWjYmnjA0MKucRPivRwVTRD4cYs4Xm7MbshmmIY2r02VW62zrhj4+w/vv9dubDIMZiHQeQPM78HwOcQ0R4AwcwPjx9mRsYlhCZ+IBgoGFTUkIVq6V4KpfopdKZGOioYNztiJqpGCWQezbI+uDfBRvUTdqyIb9cuAYvBJT9c+amtRQ7KwASR3rvu/uWUgLlyZ/8Y4w2Ot4FYB4nR+xjQHn0TDDVujCGWqeo0lIyciyFWusgXoN+PyQSvqbGNxUlf94w0iOhroTJPTwTwDgB/C8AvA/jssxxXRkbGzYX3/vPnAwDu+r778eSX3I96l8FljaKodFfVBXa1v6Lvp9iefyqm5Jzi3ogbpYd9rQkhlwhq9qk9EaHeq6hNEAmTzAvIIKCZN63qJ4wF3PjKSfzF4MVyHU0lQiNnb73A12edVu4uWiVhEX8f1xPT21Z/Bk3CziiAmrnJhdkAACAASURBVPjZjNf/TNZRhTeEk9caPkhstc8vHeeYJit9x42Vf50EYhUJanm7OUo2fj5bbBKDdZI/RPTNieUAAGa+b+RYMzIuBe58hf7qC93dq2BgWkFMK+zMFtibGtXPEoWomgdVug65ssRPSRVmtMRMLLEnlDS5pJVnLGhQabGq9fkJyrfc2nJj9NyXHahhCJu0EiX2XAKa+Kl0XTQguLkZdxVAjRmiasdZg3qN6rYBP0MzjFxqTAMb9Q/gd/UYg1ggNqTe3T3OtoifcHnqnGJqJZcAAoT+PPvJFxvIOcTPmI4lZrxDFEubBncnAr60ZoPPA/BMAL/KzJ9JRB8D4MVnPKaMjIybDHe+4j7QEiBB4ILBE4aYVtibLnBlcoyD4hgH8hgzUl2+YuXHVjUNYW+uY2qHkOgQrgG0Xb/yYrOCXAV27TfrMHEb1fZ4NRMKcsmVppzemCs3x1QNN1BL3UEsnRTx590upU2b+AmThGO7eqUQ+l7a5ZbsaVTCblmZgRsXmBjPVc5LahM/5nUYI8RIlXbDk7jKKeYnlPLWbJKoDcE3xHezfcz11D/rlo+N7Y57bpBjsBb6lD8H+u9H6wP8pH79BQDessZAMzIuNO544F4AAEGVLpm27kb1U5QVyqJSxs6ysh4/tk4cTR20laVaYzrdlQC1JX66WP4YCaHkvyK6Tau7RSzrpcu4QrjEicmu1G7GwgZLCupm3QQEKhsliS0J5Mqeu7AtVce6bUxPYrIbavB8Gsont6wt9n0KzSSlFzg2BFBq3wYh8dOH8Pu2Ds51GdjlwDEzHxMRiGjKzL9PRNkIICMj49Rw58vva7qtFioRx2UNWdaYlitH9bOCpBoTXXYPNDfPbjLNKKaXrG6P6oiSJoxdmptpJ2ETlIZJAirb/alRAZlSMbdTWNM23fFXJL+jVtPZFXZdr/Qp6pXTVt2GSZVW6/YY0dFB/AzyzUn4+Nh9eGXhdfw4rhoGtSa+GoW0MXg2fpSboi9u6yJ9YrBEkFbCS6oHEUCbqH5SpXrrEE8GWf1zplg7Buskf5j5xQBARP83gKebci8iehGA12846IyMiwtisO7uhUKRP6JgSFljIiuU2uhZmQA2pshNm87GnM5kKQxBNNFBioEhgExgkoKZCJuslWj8gCI3wUNrjkPIIBPiloJJrQqpWE80ZKve1Z+w9l0j5kljApiTKOvpIyDivjvdRMl5w9hMXN95hWogVwHUtU8vexhR/PQRbJsQcOeGALqcWac/IaKrAP4TgJ8jor8C8IEzHlNGRsbNBqHzT8SoSwaVNcqywl65wI5YYlc2JV+WVAhudlXSjKxq2iyLwfWzC2O11sBcsCEm1EuXDKpJaCWI4wXpEDClXm7nT651sq6JsyRzpKNq2uOoCnz5YscNMaTUa2iCSzoEj10WKH5CtY9XbqXP3fUETI1pHYzdPna9Ygozn3RRn+uQ8i8zJvc+YFPvH8C/pu5nt27S9FziEp2Kg7VjsKGGz7cBWDivFwBuHzPCjIxLAwJYZ5kgGZjWEGWF2Y4q97o6O8J+scBBeey1dS+p0iVdjcrHLDNlXzNaWDUQ0Pj31PavChCMuXPFjb8P0BAx87r511735teok9wsjAfr+1M1N+davqxMnZs28GYCrJiTPzo24DKElaMSUsvJ/h3THn1ouVfX9kPIh5Sx8xhsS+3TVe7mwi1rUxhwfK3aqrWfk2tS6Y+hMah0SZ/YeFIdPQDHAHNg6de5xCUMPJj5S/TTFxHRLwA4BPCzZzikjIyMmwh3vvw+QDSJOBYMntQopyvszhbYLxfYK+aY6rirUV+3b8ibknodWzldU03n1D6EMUAfGWTUQZKAJcNJlpn3G6WPoNCHpYmvQvWPeZ4irwxh0MRl7RL80Ncnup+AZAnjsvD8+1QrbhzgEj9jVCmNqqt70q2CeDM2XpfMGZJIan2vOtY3KqVKx8rb6sIF+OMOiaFtdF+7qKVflw2bxGBDyZ9/B+DXieiNUJfwSwD827EDzci4yDAlX6wNnlmXeomiQlFWmJYrTIoVZnKFmVx6bd3L1mMVkEFOh6++SUvXpqew1JP/em3OOzo2REq/1HG0caB9Lb3tTKAhNFEAxFtcNpPrMAVKH2JBy7rkypgJb5tqpXW6dI1R/KzTycFeQ2syCcRII5f4CY83+BjmOYvoGLPZ8/kAM7/5rMeQkZFx8+DOVzTED0sGpPorphWm0xV2JwtcKY9wII9t2Zcq/XJLmZs4wybS0CTSTMmXmXvdMiOj/okpNtKl0H5JvemYCgAlKkUA2XV90qddgm2aZygPxVD943YpVfuLExuhObU/3vjykIzy1CKRY9Y2Ueg3C/H32ZS6GcNml/gx66cIpJYiyI5nvbt+t1ysGYPvs7kuNimzUuMYrv5x429vHwN9i6LHv6gE0CXG2BhsaLev7yainwHw6XrRVzPz28cOLiPjouHOVzqEj84sQdeVk64rn0yXmE5W2CmXeNTsBnaLBa6WR5jKFXZ0hwmf5GleS9TW4HlGS6WycSZl9ZdsVmrBUsmTY+TJwIxHH2yttCe9Dfxa2M2WaOWPVv2IsPsXGlPEZsKJm1k38mfVHWMJiZAMCpU/QwmS0+oeBqRVQF2fTbTThkPOpGr0uzCmtT0AjJnPTele3eHfZE0qE+qxlGJI/W3O1xBAoaT9IoBwac0GMzIyMs4GuvSeddk9yhqiqDHbW+DW/Udw6851PHb6MA7lDcxo2fL6Maj0HKaaciuiZ8nSqn6WtWzFW/Y1N14/qfKvkABxIeEmiwRKxyjaJVjKgDSy8RfVqFl68VbtzZX9CImDVCev9PYOCZRI9Hjq8HD7CAnUxA11myQKiI+w9GsobAOLyPm7pE+MNOuLP4YSRLX5nIxCvjP56rd8T5Fh0VK9LaqKmvE0sel59/3JMVgbg8gfIroNwF8AeKO7jJnff1IDy8g4K9z+qpeB5sL+WHjEj4BW/DBkWUOWFSblCrNihavTI8zkCoflEXbkwtaZT1tET6P+mei/KeLH9fppdybwO3nZjNVIRj6UFodoET+IBzRGciypbjJa7JvYpUiCmsmZxM2y/gl001bhYzG29MhVAa1L/LjPDQk0qPNVIKFuexi1PQ+G+O8YNIRUPLAIO5W4y9wa/VhXs9CY8sKWe2VkZGRkbBV3vvw+sNQciIBquFGqcq/92RyH02Ncm9zAYXHDJteaMmQ/xgLaN+uu6ke9jnXO4paCo52YiitvWopbnTizpVx6/43Pj3MMx2PRrOeWf7lNNsz+42XVzbw6Rh1itjVJQmMPEJ5bOG6XsErB7erlEj+bqKmHeFuG5V1mDLHW8hVEK3YyCGOsbXexdb2CmmOo78IQgkc617f/WOMSh29+31Pwd25/16BtMs4eQ8u+fhpNxdwOgDsA/AGAp57EoDIyzhRM4AmD5trcx5g7CwBSET8kFfFTFhWmRYUd3dZ9t5hjVy4xFStL+szI1JvXmNISkhgzWkAS25buLvFj4N6E16YmPaH6icF03EohbBlqt9MTethxIX6Mupc0cImftJxUeIGIm8EaM+k3psztE3c7QfRhm8qSoaSPixjhFrafH14G1v0ZuuulPstOn57EMNxz6PYNCDJrQbcRz49AB4FuRxOXXAu/K+fC7Bm4lPXmGRkZGWcBy5MAgGBAKuJnNl3iyuwYt0yv42p5Q5d7VZ7qx4XxT1TPhVf2Fb4O4cYZtQ4QY4qfJBkCNGppqrGsC3tiXSbSfV4+FaRHALkIY76QAHKXx553IXWeTczSxBdAutQ8jBdsl9AOAiim/qlBkNG1ne0CHx/jCWXG0ZR7NbFIjIDZFgabPq8xhj7iZ2jJ14VFjsE8DC37+hvuayJ6OoB/eiIjysg4Y9CS1A9FTSqw0B29uKyV4me6QlFW2JkusVMurcHzrbOHcaU4xi3FdUzFEntiDqG7eU2ogiDVZlSgxoRWEGBMTGYnQvy4Rs9Gmmzf77ipLalCRarjFuBPcF7nJUfp40qMTSan0+zZgVsKVmvvH6GDGkn+hOZKhNV5uNkgU7/eN2V346TUQC4p0ndN+sij2PZdShn1vPIMsN04qFHSjDv3sGQuVtbXO+6e/cdMEFPklbu+/Z8gvx1uCRM4tsd6Ut3hNgJnyXFGRkbG1mB+TyWDhVJhTycr1XBjeoyr5REOiyObeAtVPyFaqmpQax4JPVUEmsYWqRvqWPzkJVKoIWhMssvv9tUuO3LfaxpsSOVDBNmUMwWq3LGEziB1iBMnqv0myr5iHWJ7kkyhz1F4XAPP+6bjvMKyqWZf7K1jziNmDO7F0on9jT2+v/+wxMz3eeraziuFC0rChhI/8ffaSrkLhxyDtTBU+eOBmX+TiJ657cFkZJwLMEC1+qFl09lLMkhqxU9RY1JUmBUrzIqlVvwssC/n2BUL7Io5ZmKJqa4zNyaDQstYJZy2nREzu1COHL7uIn4E1ajqsnkNv6uDuzxG/GwK483iqnbcSbyvflvtg6182f3bjD2YkNcwLd4Em5YhpZQuQJv4Cduymu3D4GkdwivcxssCdmQXxxwvJnt2g1P3OvrZvtp7bv4HzHdBGYy3TS1DNVBGRkZGxuXBk196P4gArgmoGVQyJtMVZuUSj9l9BI+dPYRdscC+PMZMLAF0ExleUg1+Mw3laUfRG19TJuV1NoVOegXrxsgRAAAL64dTOu+HKuV+tYyjeGbdgbMn7gu3dV/HnncRE4NUTlCJoto55zDJpK6DX2rlxsaxud2Oi+NKGFfN0+tf5JadhUkoNNd0KAEUHs9V7PSZPodxbsxH0msZH7nenoLMi6m6STX7fU3EYSnk0q+Lg6GeP9/svBQAng7gQycyooyM8wLt9QNN/EAwRFGjkKrcyxI/coErxTH25dx2ljBt201pl/nhNaSPW+YV+9EOVT9j5Z3GuDAMQ2JmfjGJ7dB63xTixtDt8iPbxhvsWUA38mXlIyQcMinch93/OepAMMRjJwzCuogfICRSusvtksFm77jTBFBMjdSFUGWmRp1SFHFrG+99LeuumLxx9XkInRvkrFNGRkbGxqAKYEGATgCQrDGdLPHovevYL+fYl3NcK6/bWKukFQDY5BvQKCIan8QmtqigVNZ9bcnNdik1kdssY0jZvKsC6vLFiY4jpqJFOt4ISYt2LNJO0qUgg5jRJVCioHSjB488ClTijbdNpKQfDRlj1hURK4UURECSxIifoftRn+f4ROompsxDSagxzWCGjOckjKRPDDkG8zBU+XPgPF9BeQC9YfvDycg4e1Dd+Pyw7uwlygqirDHR0uKdyRKH02NcKY/x2NnDuCKP8NjyQeyKOa7KG5g4bdt9M7mU7LgJQozk2Kh+hnj9SKohWTHzJVVqkiTVarvpSBEnfcJ2nW4WZwh5YCaepiOT89dBl3y5KQ1rytViCLt8hSTVtgigmBmyu/8hnbf6SrvC9VwCJFWXb7qn6VGpP2uQHSmypZGLt1U17naxbVvHiPpJBZ01IvuLZSfV8gpuN7gCzfW3BummHMyqzrhTKZeRcVlARF8G4EUAPhbAs5j5rYn1Pg/AKwBIAK9m5u87tUFmZGwIqqGScoIByZBlhd3JElfKOQ6KY9toQ2pKB+ieq1yPn3A+T8VcoYlwzQS55jTjJcoSZdcVqLeBQ/Neu4wphk28awwxY0vqnFhRoh1veuBad7gyJWvjEpsxUk4Y8iwYXzie1nYRZcxY4qdNpMW3qwPC0dtHS6HVVYYVVzb3fZ6u+j52DUPVT3wfjgr7IhE/GS0MJX9+j5lf7y7QgcbrE+tnZFxI3PnKe1VnL6P6EbrcSzCkrFHox1SuMJMr7MgldsRCK37m2BNz21bUzTQBaeluSPzYrNSQblcRxj/cfyjrjRE/m8KdAJUprynN6VbobEOpEVMS9a03BmPKn7rJoLanj7c8CDqi8msOS6AoeQ37zrerJMs9ZuycNu1ikSJlurqNKIKRbWcTH00G1RhCnysCKGedMk4evwPgSwH8YGoFIpIA/jWAzwXwJwB+g4h+kpl/73SGmJGxHu763vs9bqSWACYqIbc/mWO3mGO/WGAqltEb/jGxjksENZ1X280EkkpVxwunax524yYzZ7nmyO31+5NbveSLxrql62GHr0bh1FaVh/DncCSShL7iJ1QNp5TyhhSx40Pbs6c5Rrwcqo/4SZU+hXHKGKyjEhqyvyYeb9suhJ5JY/43+kifX3zfk/Hpt7971JhPBTkG8zCU/Plf0SZ6YssyMi407HyofX5U2VcNEkBRqLbuu+UC++UC1ybXcbU8wqPLh3FV3sCjikewRwvMaJmcdFVL82YCD4kf9dxR/WijZ7+1Y0A4aKVDSRUqCJSoUDs3x7YmHW1/n1gdcYgws9GU3ERu1CmoV7fZDr/laG93MNI38vp6qVVru29zfV3VjAlm3H1vWr5mjuEGYl31920D5bafT4rscbfvD5zCkrJqg2DOIc8Cn4CK253TYuVc6yBpRJ64BqU+R5VhVd/1gsz3G1iybBtCR8yxz4IIymaDGScNZn4nABB1fr+fBeDdzPweve6/B/BFADL5k3Eucdf33a+eEFR7dwLqCYOnNab7C+xMl9gvF9iXC9VN1bnRNX4vVgGUKI9xE22h5496f9ic0WVSnNzGuVl3CSA7NqccrS+eiRE/Yamb+36tu1d58WUs9tAEgXtuodonnLdjChO7b+ORpAkgc26mRC+GLs8Z6cSbLvHjGjjH4tY+4id17boSSkOJIN+Dp4MgjIxhiK9hrHTP/f7YGDmSoL6MyDGYj07yh4g+H8CzATyBiF7pvHUFqvwrI+NSwip/CkU8yLJCIWuUosZEVpiIClOxwq5YYE/MlckzLVHSSpcjpScAl/jxy1UwSvVjIDTpstQdH5bWK6c9ocf8fQxM1sQY8q2LWAATTipDS7NaZs+RiaohghiuAqQ1pi1jiAmju64hfroUPn0ybZcACs0HhxpRp4yV3ddNlk2fY6Jb3Dpwg7ghCqKYAsoErQAcYtOs16h+QhLy3CiBMjLOBk8A8P86r/8EwCef0VgyMjrx5JfeDwiABYMlAMmoJcA7FYq9JaaTFR69ex2Pml7HVK4wFSsvwQI0c4xr+hvGZJJqLLnxR3RvrIfMFaExsgQnVT9dybM+1Ugs1jAl/qFpc6y5RrjdOgi7wboxb0gQCaqSJUoLFJYAGjqSWMzhEkKGPAqJH/evOwazbrj/IY1JBqmfuV2K1VJ7Ocfo8loKxzC0sUXbOFrHjkECdh3iJ9V17dyqfzIs+pQ/HwDwVgBfCOBtzvKHAdx9UoPKyDht3P7999gOXwAUTSzUgwQr/xzBkKLGRFSYySV25BIzsVQGz7REiQql/gGPKVvcydn9oUyRBymj53CCqKCCFklqUpHMqMGoqdaTg1/Lvk52qjmHc2imG+C0TX/7SKBQ8RMz3Q4xpJws7OTW1UI9hi7yJsyyxbqGrIuk6fOIfXrXhzUphkYRZbrEqeeNjN4ETKdOAOWsU8YWQEQ/D+Bxkbe+jZl/YsguIsuS304iei6A5wLAbbfdNmiMGRnbwJPuuU+xAkIpfuqyBk8YVNYoZivs7x3jYDbHlXKOPTnHvjwOyoWcLk/uTepAqiFcr68jlvVY7EAYl/R1fBqaJEuNDegmCdbpXCoCcitF/LjHj8EovM38vW75U6tU3Pts4vuMxlwJ4qfveCmEcY4bl8YUR83+05YMMQJoCAwhaWNPhwCK4VL6+eQYzEMn+cPMvwXgt4jotcyclT4ZlxK3/8A9zQvj9yN1e3fd4at0Wrvvl3NcKY5xS3EdtxSP4Kq8jj1aYE8svB9TlwCqmTw/H7fMy5McOyVfMYTZDACYAFgwIPQEWtJK1Y2DIGxNdVMv7ZrhhdmMGgQJ03LTP+46xoDbQGMk3SZBYl2xQh+cLuPlcLvOMXSgS20UGjkLLys1XiJu1D81kz9JUzpYbe3HU0vFzsffd8rkb+x1NPvoaxkaQyookwQIZv2/wwAkICoIXTIpyZh069I4xwsoI+MigZk/Z8Nd/AmAj3RePxEqyZc63qsAvAoAnvGMZ+R/mIzThQDqUjXdwKyGnK1QlBV2dxa4OjvCwWSOw8mRUvwEShurULE3vD4JYkrqRw0nUBS55WSb+iem4qtYx83aUbJ2jte27O5WiQyN79yOrUIbPrvET5+6yI07JdXqhtyUgG0Bocoruk4H8RJbr3Ji5y6jZIOhiirXJ6lvn+F7Y1RbYbmXPf7AOGzoeWdcLPSVff0YM385gLcTtf9LmPkTTmxkGRmnBYY1+1HlXqwfUOSPYAhRK9WPrJTJs1TGgrtioRU/K68MqesGuIv4iSGclKNtzolRQyl9VPmXo/5h2Vp/XWyiqhlSs95//MYzyDNNRtwIuWsfqeXreOf0HauP+EmRcd3H7P6ejcnqxVq/etnEAeqk1PJ1vYhSiJUrmk5xqhyOHCLML/sy3lHrdEhbG4ycdco4L/gNAHcR0R0A/hTAVwB4ztkOKSPDx5Puva/x+CmUv4+crTDbUR4/B5M5rs2O8KjpdezJOaZi5XUrkgEpsw1T3RjxY+bzcM4zyTe4/ofw4yfjXxj6KdpW82iTU+7rdcu2YkgTTxHPP636UQr3NPEDxAkCY1PQdIYFQCJ6LH9fvhfhpog3vGi+N3aZExu5REg6GWVa0itl05Cxhh6cQ9bv+vz7yCMAzRjhq5RinkdhfDpElXSuSr9yDNZCX9nX8/Tfv3fSA8nIODfQfj8kGERK/aP8fpTXz0So2nLV2UuXfFH7hj6m+gk7egHd2ZsuoqXxPAHAJuAwLd5rHXxIuG0ww8llbBYhhiGS3XXar5vJc4iCxV2/a7IdorTpIk3GKnXMGFPET6ouf3j2qBmrWwbWdQ1C1U/KC2Fb12EdafkYhFnN0BS7rQTzfaQyMi4DiOhLADwA4FYAP01E72Dm/4GIHg/V0v3ZzLwiom8A8J8BSAA/zMy/e4bDzshoQyuwWTC4VKVe09kSV3bm2CkXuDo9xtXJDezJOXbkMjqPllQ5hs/9P/jG90cYMgM1asjWfBojftZVQbjNMULCx7YG3xLJ06X+GavstqqfDuKnfXw/WaeU3E1i0oudWUA4vpMhURN6EbrLhqp+xiAkgFL7TF3DIe3g3RLFIR6ZLRVVcuxtI+sQsfeGknnRY2ZV0LlHX9nXB/XTr2fmF7rvEdFLALywvVVGxsXC+/7Zv8Ad/+pe9UIrfkzJlyxVyddOucReucCV8hjXihu4pbiOQ3kDB+IYM7HCBFVUOVI5ZE/tPU+rfKzpczCRhNkI7zkBEgLAytu37frlmj9ryW6fgkeRSWm4ZVWp7JXZj7tPkzkaY/ocqjViHjoGQ8t5YgGEf8z0Nn1IdfCKqX3ix4mTcrHgIkYAJccVXLOWwWAgdQ6/07Hr0vag2k6w2kUqhkaDDcGp1D+SgAoMAbL/AxWzLQWrTzk4yRVmGScNZn4jgDdGln8AqnGHef0mAG86xaFlZIyHicMmFcrZCvuzOa7t3MB+scDh5MgqfkqqbMmXMSCe0lIn5hYoNYngNtNQsZh+hEbJrMiMUlRADSxNaZJZp4P4qbXaRz1Xc5JAe1514RlNBzFTivipnfdjiZU+/x2jlh1CLLmKHK/cS//tMmH2VSRt5Y6Zt9c3nw5VSf5YvM6zHdsN8bgZ0hWt2b+rEHKbcvhxu1s6aLaLqeM7u+M6ircx6Eo0rkvenGfSJ8dgPob+x31uZNnnb3MgGRlnhdu//x5/AQHkqH+kUIHArFhhRy6xKxe2u9dE1zzHbor7Wop2wctoeERCR52wnUwaSa7tyhD1vdnOD7XfGjU0NOwneLo6nJmWnYLYnkvXuAdN4oFPkHkdLo+97x7HPMLXrqGzNUMcQfyEGNvBa+w6wl5f16+q7e0zhPhJLRuD8Hz98rO0VNtkIEMzzsbIsW3SeWrgE3hkZGRkXFZo70VR1CiKCtNyhZlcYSJXmIgVShHMqWCUVGEmVFxmSKEQtSZ8YskvN2YCnLnRnecD4kfAN3q2xEzSZLm27zfqcGGTZrFyL3/8aWIoJKOkjv22eVPeKEnYxmep+EiNIR5XjT9ubR+p97cBq85G28C7bwxrHU/H9F6XNOf6NceOk0LmEW4bi0mTx+9RDoXH6BuXwS//8Z3J904dOQbz0Of5888AfD2AO4not523DgD8t5McWEbGacLeXxIAwYBURs+FrDAtVCvL/WKOK+UxDuUNXJU3cEUcK88fN/PD/sRvXrs+P8bU2UUrq0CMipsa8XYLSD+LYtQ/YGAmlkAN2/kLVGEZOeeahadC6pOPuggDm6ojexUaL7vbhsaFtdPhzDM1pnY5k5s1CRUqXbLgPnRlhWKkgUDVWiYj25yUIeQYuJL1GGKt1LukzMnjjJSRd6HlOdAlR9Zy8ZoIJSr7/a6gvkulUAog1HIrAWlGRkZGxvZw5/3a70ewUv7Idtm96VxkPGdK3eK9JKUEKmnVEB/6Lq1CM5dFFbRgO5NLc+NPtYopEqbEqXKySitOahaonbKo2LyYipc2KfeKlWK5apSm66VSy5r5vmvOFmg6fFkvpUQ51jYRTchtkXzpQ59Zdmc3tYQSO1T9mM/L7cgVw0l254rGVS3yq5sAWsfeIeNs0Of58zoAPwPgewH8L87yh5n5L09sVBkZpwlDEOiSL73Qev0UssbV6TGmYoUdscBMLHWQsYpOQm1iZLypcxWZjIcodYSe4CXVkKwzWDoAQUepl9d6PiGVHYJUIGOej92vvfFn38+mK8hwJ9zYeutMlClVTJcMeKzSx5Vkm22GBoAuyTgUQwOoWFC4SfC1rU5fwiNdfUPGMLi1HkD6by77ysjIyDinMMrroobU3VYnskIhKpRWAcwoRaU7TjFmtMRMLO3fElX0ZrWyCbq2P6AbN5VihWVdtDzkwnKv1DytOk1W9lixOdOofczzKnKHvgAAIABJREFUPsRUP2GcMdQ0OIZWh6tWTOOaPMcVMKmYyBJvIwyQY/vZBvpiyKEY2k0NCKwayKimavU9TRA/vWX8aL6DMWxCIK7TnGWMncNpI8dgPvo8fx4E8CCArwQAInoMgBmAfSLaZ+b3n/wQMzJODrf/m3sA98dKZ5yE8yilyjbtSEX8TE1wkajPBdREt4nJbahyMTe6JmMQW9e9STcTi2R/8thWqReQDlbGBDMxxMgGG4ABrZbmo8yHNyB+hpY4DVGqtMfF3vO+QGIsxpY5hSbNY4OvTVQ/qevtXSNqB6WACbgbFZC5jl4AzzUEnc8AJSMjI+OmB8EaPQti7JRL7BZLCLAigERty7qmDuGzK1RJvkSNieNHs4RUCtDATNmF1ImykipN1rAyxqiBmgiCww6YPgFk5pvKdrES2jy67Z3YJOW2g7D02R4DaSWRG2d0zfeCVDldaRRX+nXTOKJNWIQw6vUuK4S+bl+xY7nnl8LQpKMbp/URaGk/pXZnMKNc99dtutCFxE/oxdNXsgV0EDVn4METEkC/9sd34JM/6r2nPo6MbvQpfwAARPQFAO4D8HgAfw7gowC8E8BTT25oGRmnAPObaVQ/QsmMRcGQsrZGzwfFHPtyjn15jCvyGHu0sCbP5sfOdvVyJjjP7Dhh5NwFW86FOPGj9uvfyJa0AlCoshfPqJCsuWBnF7HEhBGbvFMsfyzgkBHlUeUETH1kgzLxFRCoOg2IAT9j0sqmONuEBF2fr81QEiXe4tRX9ozJ0A35zpjzNd+H8Nz6Ml0tE+WIgfk6cLcfq/ppDKqb0rlOzyc3gNPft5J0+ZcJ4EGtYPfEkbNOGRkZGf0wJV9FjaKscLBzjFmxxERU2CvmKKlCoT19VBKussTPjBaY0AozWtl5386LaIyeQzSdMmvUUCXDcz13QADLumgaCmCzEm4vSUe1VzLfhWSnLkft0zc/prZPKUQaokeRbVOxxERfW+OP1NpfEG9VaErgmnPxLQe2haGGzC48w+UB27hxW193VpcAcuNR1+cnRvy426b2q8brJsTace26Spx1VD9d258LAijHYB4GkT8AvgvA3wLw88z8SUT0mdBqoIyMi4rbX/Uy5exsCSBVAUYEkKghZa1VPxWmur27auu+0gRLGuEN75gfYEOSuIqeEH1yULOOJB1o6HMMJ4NNJt8xxI95HRIMXQiJFrcufZDBcQfp4y4b2slqG8RP+Dy2nVu2NARjSYwh5+H5A4wkgbbiTQQ/CHL/dm/neGGhafFuMrNhR7BTwSUwB8zIyMg4Sdz58vsAqA5fPKtBZY2ybIyeZ1KprUtRq/IuscRULLEn5pb4MWRQOPc3TSVIl1rFCSD1V6lUSloBXKAGqzJhO38E23WU09csAGp7AprtKpZbK5UxxE84B3ah06/GUfyUmmybaE8lr2FGD2Hikl2DSr4S+1tH9ROiq4OoPU5S1eMjRdS0/TsdBVCwz3AfXcdovWdKzhJxLWBi5saPZ1vePLFjnmoybSxyDNbCUPJnycwfJiJBRIKZf0G3es/IuNggNMWg5rkmgITunFWIpmOWkRTPaGVVPwZG9ROaPqsf/ZgtcBp2oojIRWMIgxlX/aM3xLwurRzZ3UuMpEllj6Trp2MVT8Mn4PBYQwiOZgI0mZOqNdGEJtEhQs8e30spNLXrLuVKEVjbao85xusnREr14xphD5FXx8YF55qd1UTflD+2A1w/C6a+pcZ3wSWClJHnZsRnRkZGRsZ2cOcrFPEDweCCgbKGnNSYTlbYKVTJ145cYCpVG/epJn5mtGzaumufnzKItLrapsfUsHUH+bCsm1umrvm+0o0HALRMn00Jsiktq6Hnri4SqUf1s41uXmEiLCR+VOKz8lQ/oY9NDCHh4yYtK03EpdrVt5YFnkTbgmydS3cMNvZ6b9vDKEX8dJl2u/HRSRg0d6mpT727akYvhpI/f01E+wDeAuC1RPTnALqlDxkZFwHmN0kAIAYVDFFUmExW2JkscTg9xpXyCNfKG7hWXFfyYlp4rQ+bkq828aOkreOUPynEiJ+K253DgHhGJJQYj5WUtgmX9DkNIS/GtCw143LVKLGJpov48Sb3yCS5iX9PVzDQp/QZg9Tk2qsC0+1WU52+UvXubtC5CSnVh7Brm3nuBrcx4ie6r0jplyEqbcc5QwKdArR3aUZGRkZGDDrpVkvl9SPKGsVkhVmxwm6xxG6xwI5c2oYbu2LRUvzMaGnnBjNXheVFgzpXpn6sWQJiNTjZVYMQFnTZMmbrQafK8WPl8GYf0fEmFEgNKdDMezFSKVQZw6hT9PjcUi9D+hhVVR/xM0SVPrTkK5Xs3LSbqPUr6vAVTMU7nlrHVdU4vk+ppiCDxhYQM0NKsMLY1hx3nfL2TUq+Yirx80D85BisjaHkzxcBOAZwN4B/AOAQwHec1KAyMk4V5PzVXT2lqDEpVk7Jl6p1nlCFSUTG63n7dJAaYzHUEtCd3F1z6AoEYZU6NZatcGTAGJyAxfflWV+uHBI/QyeLPgIoXNa5r0QAMWay6iNwhhI/oTnjWSEcb+hT1IdtZ+SGYAgZFCOAMjIyMjLOFnc8cK+qxBUMnjDEbIViUmFvtsC1nRvYLRa4Wt7AteIGDuQxpmKJA3HUdPaipTV3Dj1YKof0SbXcBoKEgVa2VCQgWTXNQK2VPyxRd8Q9MRV16XT8cvXfhgCqITT54sdm4ZzbFUuECQ/z1yWAvH211vH3bxQ/M1JEW6ljX5f0CQkff6y+31If3ATdJh3LUoqaLtPnmOon9tw/Tqi4SX8nhqqVQluE/rimx8OxR+FuSsLWieH71OOx937j/bfjmbe9b/SxMk4Gg8gfZr7uvPyRExpLRsbpw/zuCQZLhpA1ZFlhVq6wVy6wXx7jSnGMA3Fss0wlVVFzNWv4HBjbAeOJoD6VhcpoGbVRUMPu/O5KYtSoMcEKC10GtoTKNnXKWjsmnk06VbgBTYz4iR4v0gLdbG/IHt9EMe3dE2YmYp4+W5FQd1y/FPFjnrseNS7NuK7qZx20zJ8Db4DTMkzeljrHXmPznT9tAujsk18ZGRkZ5xIsGZAMmtQopkp5vTtZYL9Y4DHTh1UMJo9xKG+gpBX2xNyWeaWIHzMvhiRKu5Nokywz76sYB058CCxY3S4tATuPuGXvqQRJBULpvE6RAaYELKqEHkD8xAgJuPNeglhwy6INSs9QWxE/xucyLO/aXs8yZ+xdXjeuFyatnzBzvzPq9UBPx8h6ozw9t3y9ej2MTru5RQLbPu/RyDGYh07yh4geRvySEQBm5isnMqqMjFPA+577Atz+g/fYSV4ZPetWloHRc6knPyV75dYEUHWUdtnW54iXaKWQIoC87hUO8VMxReuuVc5LWOWPBGMJYyzdVgIJL0homyZXa/6IxoifPvSRKEP2ExI/5vnQOvOxGENY9KlQpDYoDq/5kDKvaFmcNjuOmgQiTn55ZoZGTj8imDgvwYeLTbtZjMU5UD5nZGRknCvc8cC9ikeRDExqyIkifq7uHuFgMsfh5AhXimMcFjdwKG/gQB5hQhV2ad4ifVyYUvuhcUasJLxFAHn714oJTaoMISDCWEqRF9oIOJFMi3WW8t4PiJ/wtad2jarD9fveuNjGuqVWupe0SpZKheMLybehCFU/2ySVXILPlL+7xx0+xv6JPGai3SIcg/2oCH34OMaWUnUr4Merf85DKddYXMAhnyg6yR9mPjitgWRknDZu/6GXQbE+SnJMQit/ZI1SVJjIyiF+1CQowd4PnzJ5jpMaJ6HIaI5D0dcVq7q11IRmDJtNlglobuhDuW2MBNp2WU+KFBhDwnSRC10Te2hwaA0ZR5Y6efvcAvHT1T1EjSv+3pBOGptgTAey9D76/QCA7uDC7VrRhzCw6bu2GRkZGRknjzseuFc9kQyUDCqUz8/uZIH9yRxXyjmulkc4LG7gqiZ+rogjFY+h0uU6vj9KzGOx0r4/ffOjITcqphYBVIFQ6s1rJp3+9m/XBXhUUw973MScGBI/8bbq7XgtJIJCtWv4fnhk1emssg/V7IQ7yYlNkmbrKEKM+gdox1Gp+b1FviXGHJZfqW1Hki2JWClVXuYd34lvYqVaYfOSdXEWSbnffP9tePpt7z/VY2bEMdTzJ+Mmx+3ffw8A4H1f/y/OeCTbAwu2WR2SDJI1ZFFjqku+duUC+3KOXTlXMmNaYEbL6L5qpmjGY0z2qW+9poTML/eqmPzggWuvS5gp/VLjESix8qTIlc5eGWNdRXClMyMmWDEG0u4NdeocUqqfmEdPSMLY90aSD6k27bE25u4xZRg09ZzPGPS17rQd4qwHUKPMOovJ2i1D6/rcTgNu3f4QAsjNfpptgH611YkgZ50yMjIyAOjuXkJNsVwwRFlBTirMJkvsTRa4Us5xWB7hijxSxI84xhVxpJpt2BjFn4Nc4qfLMNkQO8a4uPW+U1ZkCKAJgAUDAkJ3vFLq6RJQRtBOAi2MgWLzVBNjADWk7k5JrXL8pkNYvLTLfS+1LEbyqHNvfHZMUs9V35S0gkRtFVbeuDvgXoMxCamY109Myd63zzDB48WymsTqO48YATQEXmzpxKtDSZq+444hftZJ1J6UIvrMS76AHIMFyCnQjFEwJNClATEgGBBNyVchav2oUIom+yF0wBGWfbk/silVQx9ZMJb4Mcd1iR93H6kJ0pr1hVmlSL24GyCEcIORPiVFX7mXILaPTTBkgrGdzGIBUyvwqO2jb91N4H6fwsnXlmL1TfRrEjGxrmrNe93y7rOQ/vZ917KZc0ZGRsb5w+0/6MeOLACUNWhSoZytsDNbYn+6wLXZEfbLYzx2+hAeWz6IW4uHcWvxEK6KI8zECjNdkmRgyB6X+KlBrZhLJm6cTSlQFwQpEmQmlpjp5h+qC1ajDC/FSpMmlSWISrFSsSPVOnZsyJWmi6Veruf6Uqxs3GG2VeP0VT7mYeIH8/BKnIKHq+hpzqHCnphbH6UpLe15lrRqET9jb+Td+NglX1It6tV7kVK+0NuyYyyide3qFvFjrkly3FHvpdp7NONwYrgu8sb53M126yA2bmU90Tz6EDZv2SbxE37vXPzm+2/b2nEy1kcmfzKGI3F/+ZQ3fCee8obvxEf/+MVqAPfHX/MtWvHDIFGDJGNSrjAplLHdjlyiYoEZLVHrv035E9kW78boOcRQ1c86ip86kDE3mRaBJRcwhtAGZtIz7TtN0DIVSwiqVXcHp8TNDVYAf+IPy95i52GCr1FKHfIDI/e4ndcn5t2TUP3EjucGIm7A5QVYwQOAN07zuu/8mjF1K4DcdfqzVPFrHJ53ar2+7587jvBzGUIAraMQsibqkc55VmUWlHP5arWY6fcZpn74BB4ZGRkZFwS0pKbUi5TBM0uGKHSpfVFhptu678sFDqQyed6luSUpJpHCqhjxMwRhu/LWfhO3R0KTKIa4cQkYl7gpxcohZWqP+PHiDvj7MWNLzWd981z7PJvkWmwchuBpefw4pJjpiNUkD7uvnYu+9VIJtj5CbuixU8SPi3WTeSFJFRJAXfGh95megTLmpJJ350LlE0OOwTzksq+MYSDnEUHsh+SpP/H/s/fu0bZsZX3g75uzau199jkXyEONRryHcwUUYzAGGVHTHd9JtNUhiTGdRLHxkdbYPgB5KW+4ci9wfWPkzdUoSADxjRjbOEzs2Gj7aBsi4XLotmG0EoJc7rlnr1U1Z/8x5zfrm7PmrMdaa++zz931G6PGWqtWPWZVrVXzq9/8fb/vOTDGrfDOr3r2ybVtF3A6tLJQykIri4oMLtXHqKnFLfo6NBncou8HMNzZpuleJwkOTIzPZy8ul5ZCh3USZW8w11qdHVHK5SYPmf2mxM9U9CpfJYokuV/+fmz7czufks9RtIyYn6ZBTWrTTEUKp4CVTLkZ82TV++mt+Hj5HMxNAZvi+5O7n5Qk0YvaZ8GCBQvOPsgQrvzgXbAagLagyg2+1ZXzWDyqNrio1/iY1b24pK8HRUotiBHuG+Wg21TihytERfOEkXFaRTW/vi+a4FPHQAhp9QoEk1Xo2KzaRZNxbbbAxqd/uSqfnC4002smjadEahfvz7WT2+OIkbTkfY4wOQlsE89xyp78PlIXpYTMnoifEkEzFs/kFOWl7cYDhNvHa9uQmlMxbB69xGI3Cxblz4Jp4IoMuvvjP/LNz8Mj3/w8EFko5UZvGI/+hWdCkQX56VE/+5zTb/MkWDcKRQht1cqgIoNamZDuBeQf4NuMMiHFHDKEBaXys9v+vEphct0cOkmm7UmIAUQS5Xn7nHas6WhPqvY5yYCj1B4pr04niZwiZyhlbMznR243m7+/wxBDtqoXlYOR1GNAti36vqAASjv/EimkQrDcl3hPkWLfVKbNfIvZ87RgwYIFNwve+21PAuC8FnkCWWhtUGmDVdXgUDe4oNfBZ/GIHPGTKn66CqcqDIAFlWgm/SXq42RKykgFq1IajSZWzbRBuePUMjYop1lJw/uShIvs9zqvxZjg2kapWiKsUlV1SvworwBij58xwiQ9l7lllDi/KXYllXLpX6kayV2j7jjkdZBTCbOKjmTimNz2phA/416G5Wtx2hhK7xrCqad+LTFYD4vy5wGOK99/V/iRvueJT+x9/7AfeSls7eS3VBnnf+OJEGsIMORea6eOocr9wT/1Lc+FYrNkciM3Wll81i8/A0TASgMbApQCjDm7D2qk3MnhMu+19/upVYsq5Ec3rroEYl8afrBNVT4pIZQzfhsjcoreQcLkeQiskuDthM7JV6mA6IRq0R4OZNKymwFeNTRW7r1fytIff4YwmWsiWBotyp3T1Og51760080TMElgReWqUWPHM8Wg0di4IpsiC1gDAx2NNMmqF+X99eXFafpeKQiSZsnS/BlAVEVEKoDkSNyQKigNlvYhQ55iAn3SqrwsbvJAYcGCBQt2wZUfemmnutFwcaa2YdDwQDc4qtZ4UHUdh7TBQ/Q1XFTHGeUHZV/d+yEFhokKYUTzo+2rbJzVQkdkRoin0KlPamr9+l0V0RU1PcIlwDriZWOrsG7tj2nKAEfal7EHY2/wppeOJOOAODVKLsfLyG0A/UE+SQC1yBtfh2VFzKK90im3jGzfHKTXaNuYM2zPrzO1HHsuxojPZ37wbSrZlyqf4n1PaZ8Zff4oYV+Vxm4IlhgswkL+PMAh+5nb7rorIoBCZ8zL+LQuxQoep0YF8X1MWdSHDR7xb5+PqupIE0U+XUoZaOXWtZYAtL4DMLCW8Ok/92w0bZw29J8f96wTOOoZ4KaQdYfP+dEiTxtgZUgmFSVzE01v/ruWxx4vUZrvaEtpMqHDJdEJ2E7BkeaEy+2NYbqENqdISVUjJ0Ma5ogflbxm1/PfcbtC5akt2zlINnmiRQ0EUdtirNxozmCSf9PyHMjfXZoCVgowxgieXEBhQL3fi1SpyTbmsJR3X7BgwYIbCw5jrIKLtyob0u2PVmusVBtUP0dqjUNah3SvfVSXdHGPe597kJc+idkqqkCIk/rbVVDUhhQuTd13ReIn10YxsJOLh8aIkLQKplRvp0bKkmAppXid9gO+bOM+iJ8wH8MK/imY6ssjY/8h0qdTJKWxzXSWIq1kOq1982Ohnlr8ZiN+FvRwohExER0S0e8Q0R8Q0R8T0XP9/L9MRG8nonf71790ku04r7jy/Xf15t12l5iXdqZe/ULKjcgoNkPWBqSNI4UIqLzKx00u3YuJn1q3qHWLSreownzXwQOOXDnrUEhKnZ+BNpdy0KdCKoAkghSWbCdRzhA/QBfI8HpzUFSWiJSzMew7FUwSP3GVjHy6FyMlHnJpU7xcbtqmnWl6VS6IG96GC+7C+tRd31xQVDJMzplRj6WA7auaW9rGKciRejfC+HmRHC9YsODcgwCQ7QggH0PWqsVh1eCC3uBIrfFXqo/i0Kch5QpMpESQwby0+KEHeS6mwelkPLn9xPuQShnuC9kMeg7xM6VfK8UOXAAkXa6LFZI0L55Y9ZNJ8RpL49k2FT0qxJGojFK1UVAkFdqRVhHLET+l85pL7Z8TF0xK6c/EHDLlL/X3ycVIQ9cgHZzbB2Q7tmkTt2XKOT3t1K8lBotx0sqfYwBfYK39KBHVAH6LiH4ZwOMA/Dtr7YuI6GkAngbgqSfclvMHVu4kP9JAACn3nQ3KH0f46LoNf3hjfdoXHDHEpA6TObVyRNBhtXGkjzIhLWfdarRG4bit0LQK1gLG6khsdBYgCancjY9zsUvy4xKCGiKTpiSVEUMS2VT1kwY4nAI0tI0ULFfWEOa9QtqbSoMZIdUILv3IvbdRCtkgrOys44fytJOYm5oj09amIPX4SSttAAipV/19CTPGNBXKY0o1L7lc7vjZ/FGmfrW2S6WKrk9Gzh61R6TzSfPJ0KaECBs8BpHu1R0TvPLHjX5q8oqozEhpLnVyDtIUObf/cSXZogBasGDBgtPHw37EVfmyoXCI9V6RblrpFivV4EitXclxWgcPnRS7GNaW4iRp9FzafppKD8ReLxyHuQPtew3F2zqZ1OPOMygmP1JjZ4D7+o6IOE01R5qunrYTSBTK/n3O2Lmo9imo3ocIiaG08FLaV/qbSrehYbPrhe8mqMGGDK3ltoDti81so8rO7X8MN7Tq6oKAEyV/rLUWwEf9x9pPFsBXAvg8P/91AH4D55D8ufWVLwYAvO8bv/vU9mmpwFj6zhjkRmKUcjel1hCMf7Akn97F3/Hnyqt9VsqTP0Ki21BHfGyMdtvktkzoAC+/7g7AIhBQAPC+Jzxlp3Mg8d5//nRc+anbZ683Svzs0VtkarCzvZw1JgGGqhqAgI3tiB+DcnpWrkJW7vuxzqAdCaTcNvJpRsZSz9uGiR9JckjlT6790XEI0mcOisbRBZUN/34UGSir0IrjnEKgqCjQyxM/qVIp9763Xeo8ica8gFhcKq8DLze3Ulg6kjaH+Olt67S9f5Z4Z8GCBecUlnyGPVk36KhYZW5RKxc7HuoNjvQaB7TBITWoKZ9qLzFWNTKH9GE9FNUQ6mpZRVWmHaep9JIQiL34+gqXkyJ8cgj9PbisfKf0AbpUL26rHPybYlOwq5VBaGeqRKcuJpOfAXf+hvxqygRLXwUkCbv+8vNjg26g1w/Gok9IzY3PcxXNpnn6zG9/7n82eSB1os/iDSd9lhgswol7/hCRBvC7AD4ZwI9aa/8TEX2ctfYDAGCt/QARfexJt+Ms4NZX3QkAeN837I+8GISX2ER9DvnPmT+CtQRducoLh/UGRO6Gay2h9eSLVr4zUY78OdBNIH6Oqo1Xy7ibRmUqNMLsmdU/RCoQP4/4t8/Hn/zjZw4fAzrfIWuBy6+5E1f/p5M5h8ZSNDHWA+W2GVNKWM/ZhgwW2ICwtA4wHAj1zHWFYii3XE6iLE36uFS8AkEVOproZj8gvwX6RFEOMmArqammQJI9MYlgxkkVnsWm2cI8O/UCKpE9XXv7CqBu3x3JBKtgyJeERV9Nowlo0SdR0vSrWjnataY2u09u0xRSTlPriB9uK3XVWGr/nRGqN/ZAUNExt+GYZNuHAv5cil5umfiYpAF1R9qdZjBys0uEFyxYsGAbXP6xl4Bk30QWUM5SoNItDuoGl+pjPKi6jkv6Oh6kr0MhrvDFZd3ZTJlLu0tMNbLNEj/S2FnGOb4PS9cvPcjLWGyqR4wkmrbzY4kVzDJ9P6R7wVXzcsfVpSAx8RP1y/69jK92qTgq2+niGn9eErVyOO+cdkaJYoZUIIAYuWptQ2bVqQonjdmHSJPRVDJBAOW+681LvJnGEJNB0wiXFL3MgRmkT05ZdDOpfZYYLMaJa+Ctta219jMAfCKAxxLR35i6LhF9MxG9g4je8ed//ucn18gbhJPOG7znO54I+f+/57ueGEydw5WXD12Ve/hd1Q20so7U8alclS/HqcmACJG/z8rnazPxU/kRm4qc50+luvVI3o8mHbsNMmGgW//ya+7c+rz0kNwjTabSwiFtRjdTrNC1xSiJNB7Mlu88gR/OEPGTw9BDdM6Md6pB72mhI4A63yOJqfnOksAqmTeX/ISG1unNC+vkUxNzedrSdyfexlgwEhNTOd8iPo7c9+HcUldaVXoh9FVgI8GM2O9UxZg8/lTuvmDBggULTh5Xv+XJ3QfqJuV9I1n5c6AaHNIGh7QGF9iQ93hZRSuHMeJEevfE8ynEWbuklEmUFC0lzPUsSuOpNN3LtSETl3lCZUqp9RLhMxTPlo6hi0NiYiYuqpLEX4XUNXks6XIl4mcs3atbZ3qMmvO2kfHNFF8gjt3OClKCKefds41H0oKzh1Or9mWt/TAR/QaAfwDg/yOij/eqn48H8GeFdV4O4OUA8JjHPOam/qWx6ue0cc939su7O6Of/g3ckTPOOK3SLSqvNlBkoYSCh3xqmBbkTuUfzirqbrguXYUCCaSVgTLKpZf5/ZdSv6789O2whkDKexIpcm9O6FfAvj+yPbsEArmRqfj7ZNSKhj17prRligIoXb5kBD1pfTJoRQpY5IVTwNQUHU4p2weMJdSqjYKAlHQpdcIyxcqIkSmnqlPF9K8hQix/vN28oWtdCiSM1dHIZ0x2dKleqdeR219ZklsiSsZ8kVJVVHFbXHVu4LevkAtyy+eyhF1KnO4Ei0VyvGDBgnOJyy97CQjU+f0AndmzNlhpR/wcqAY1taipxcVksC0u5z7TD7DQt0yJk2SKsvw8FSlZkaZ+SdXPNsj7B5oeYVIydnbL9NOxwzYThfUu6V5dynpO5Zzvm6UZdFDVkGxfXo1TIn62LdXeM6ceiO/2lU6+b3JlLPbpBsoegMHKEoP1cNLVvj6GiB7i318A8EUA3gXg5wA83i/2eABvPcl2nCbYx2cOLr9ifJ2H/fBLceWH3LQL7vkOTwalIxEEkPf6qXWLWrU4qBpcqDY4qte4UK9xWG3CdKAbHFYNDnXjvX7aoPj60iZoAAAgAElEQVThyZE+baf+kQogseuHv/EF4f1tb3ghbnvDC10J0MpAVe6VtAGUyxfnkaPLr7tjp3MRHb5vkLGExihsrOqlfqUo3SRzZd7ZSHDIULC/neHRqNJokjQh5M8lpMuGfVsKU3bfoqNIlSDR9jOqkFL1K6kk4XX3Dd4nB5k8rajJjtisfMURqazh45ftLJFa/J3bT+NNLE1vkpCjZJKokioaFbbpJ+Un/1mRjeYpWNSqCdscUvkMIW13dz6bMOXObzrlPZbE+RXHm56LHHlXamtp3raV1xYsWLBgwTxYVm9724EwgKhMp/pRGxyqTa8v5RiM070AR1AYqK0etLne0hD6yp1xpYxbzkZT6fsUrR1WNY0hmDdPUNACZeInfS+X2RYRAZaJd1I1UG/9kAbWpbFJ9VKpSllasXaO905WqZ4QP6WqWFOUManRc6qyOW0C5gFN/CzI4qSVPx8P4HXe90cB+Blr7S8Q0W8D+Bki+gYA/zeArz7hdpwKphI/t77qTuGA162bM36+/GMvATXkuBrryndd+UFXrSsQOTMRmT6LdCpO5yKywbhZwcJQXF5T+e8jskfczLqbuQrz+ZXIrd/CqWysuNfc9vrbHQnllwMAa2OVkrM72a9x3j3/4zMCAeUqkrm0LzOTrAHyrP8cw+ZdRoFS5HOP/ejEkHw6rTBm6UTSzKJ2DXWUSWc99xylRsOuc5Vy4zgQYjBxx9dFmi13KqD+KFFKrKQKozGYAWPDkkFzDX9eMoFbySi529/E3+cAmZLO6xRINrSp5wHFXkYjflplo+fkdzH1f3YjFEBLTLVgwYLzDvb78YVDauWVP7qJBkg45auNBs/yauqp8UCO8GkDsdSP8+Z6KZZipGylKqECipQ1A8dibF81A3TET2+/CSnS930cjrnmxlny+MbWHareJdvAfkSyIq0Mt3pEkoy9RNyxremy22YcfwDlOK6vEh82X+ZKwqXtSMwhB6eSonN8hPaNR3/S/4N9P8sNYonBIpx0ta8/BPC3MvP/K4AvPMl9nzZufeWLA6Fy+RUvxtVv6oicKOUr/Nb9wuIPXSKAAvYtXSPx6qt3UaLcAfwNVSXkD8XpXoySV4kkgJQyUIpgDHkCiHDbG14Y8sDJjxABXSn6sFXO/PJtuXz3Hbj6dbsXipPl3lnxM0SQ6J4cNh6F2ieJ022TyYhhKXEJuXzpuNxmeVtjJecn7T/58ZbSxJgwaK3GvspzR4Z/1FW9kt+V1nGGxTEB5LYVmwXKjj5nOpz68ABzCAsbUsyynje8v9QEM5PmdVKQgQ+nxqVpYUq2kwxgtTvPfH6TayIrs42NEJ5VCMuyBQsWLDg3uPxjL+k+cEznzZ4P6gaHlavwdUGtcaSOsaIWdTrYkzwglsiYbUn9fgp+HAdNShXK9O259uX2V5onEaqQJQRQqvhhhYwCp3j1B3tSg+chA2NgWixbIn66wiJWfC8Ng/vXjFPUomplYrtKGIEPtn8i6TPt+srqsLGSSaIrLBEPEEb7Ix58HCaSeu1MiKUSSsTP8G9Txmjl9hQry05sG8Ckz+liicH6ODXPnwc6wg/LwqUkveLFsMp2BncQZsfRr9ApW1gBc+ur7wQp9+Hq1z8VV7/lyXjYD780kB20BQHUq45FfhNMsmg3GsMGfGy2xwofYwlVcuMIps7eS6XylYTi0Q+DCoBRLSqrcFA1MOgqhwFAa1RUxp3JH6Wss/jx5BApgjXeFM8ANr7/7w7fBDYFbKxCY7QbEbI0KT+c12dsmx+tYNAiVkPkq1HY6DW3LKM4KpXMn0Im5YKBsWpdY6bQ6fqOXPPfp99RV4WjRdzRxm2KU4jSNK9UFVM6zq5iVUcAgZQvX+4VLJljSqtvcFvk9nPBQ+l4NCw0tVGaGZNjCgRQ60cw+0FHiQDiUu27IGeU3RHFBcLGeyZx5TFYBUV8D4kJqzjla0DabuPgeqg06s1EHi1YsGDBzYir3/JkXH6ZJ4AIsNqCFKC1GzysvernUG2C8mfo3jy1MtMU7Kv0+hTip9yG8UpfUwa/ZHwh4xpppixLup8UphBFuYHHNE5QML34LFUAj2EXtU/c3ulETVxZNF+BdYj4GTqubmAxHx9ugxwxNYTSMU3FjSB+FuSxkD/7hPgPMPETVbdisiX93xqf5iT/VJacmqghUGCPoq9x5Qfugq0s3vttTyo26fJr7oS1jlR63xOeEtbl/6tVFlY7skV5T55+Gldyg/BkDyuAmKnn77rjBYz/WJFTCdWqxUY7YoPNlWWHrlRXRh7w5JC1gFEw5EaNHF9G+1VBCXDalystOnyT1TDY7JBCkqpAcnLbITXOlHSsNOea9zW0fG6fqTlhKSiZq9bpe790ChcmgqSiRhJA+e3Fo1rBfDyoSIT5sTj/KcGX20dKALU2f8ySrJDrjm6/MHqZeiOl5o7K+0OB+jTlWO75vgwK+9vuG1CHa2ONJ4B09vpL0qebt5t66oZiGXVasGDBOcPlH3+Jj1t5IAeAH9yrdes9Izuj59qrOnK+P1NSvobim7Ssd2k5YJ6iWu43B1kcgZfdR5/V6xMpjmuC0XOS8jXm4ZMaF8s4JTWAdst58qoUj2XOu9uuDaXbZZwQeTDmUqJmEFj7IH52wVC1WOkRNKktA7HaNjHcXOJHLiezQErfpbjhxM8Sg0VYyJ99gn1qPMFDwuQudICewIiqSyn/GqmHfH6T9rM3ABnqiBsCoCwsAZd/9KW4+q/yBBArioi8QTIBIA1bIah+qDbQqxZ11aLS7ubEnj8h9SvxLWFyiKsodea3Qv5nFWqvCFLkOg1WFG1ajUobNK0jFFgNxMQPdzLKWBhDaNxWYK27uSgYmFYBFrh894tw9euettUlk8dE/sbVGoW10WiMxsa6rvM+u8ItuO7a6G/CKgkQSqqfqaMtUSdINhALc5E1GkzzqQttivefev8ocElSvsGXOp30gT5XUSonRw7wyhBNrTvXfrYR8wBfItWqKAAC+mlDfdPhpidFzuX4S5VR17aOADIggBCqnsnj4sBMSrEZqZ/QEFIFj9wuo0aLluR16Vf9Cscqji8l14YwtM0UHAT0qo6FvH0FWOPNqCmovPjcSbVUSvj0AjI+Pf74b1hVrwULFixYEEPYC5CPf5VyA4Fc6avrk6eV5J4yKNfFMsN9bKmoRiAnBpTVvfLkCdGTb/u4mrzUJ+dUsEyYuPZ0xE9nlDww+NOLwWLlcrYNIh1+KnKETZwyL/p9JrE4Jkhj1xFCRqaPb4M56w6pi6NtcuySKH5Kv3U5P/872E39sy3xs83yN5z0WZDFEiHvGVzVIBA/yr+SN7nTxpE/yj3/KO3yn918E5Zlksj6FDCrvJpIeVsPEhUUVPmPyGofcAoaLHCpcale2qt+tIHSFpU2YTSGCR4AwSMlKH3YuydSVViwSZ9bJ/kebt2V3/5B1eBANzioG1Te9K/S7N7P6WdsEm1DGXry5yctEX/57hft5/r5VDNjCQZeAWQVDpPSo0MBytx0L67eNAZZ5yBFrorCNihtY+qI2RB6ufsDAZKspiUrIPRUIpwTTnE1LE0GtRxRTKp69fY3ozMrpYvJClKRUichfrZFGvD1qpOh+x/Kql+yEgUQ/1ZO0g8orYQRmwuacI+IKprBBuKHj0PDRNXYUuw6OncaIGv3Pi1YsGDBmQcPfvo4VWmLumphQDjUGxyoBi0IK18Fcl/IqW6HVCOywilPQxW70nSvUvq0saoY63CsmE+TtlHfOET8uLT2JhA/vW1lUr7m9JvZeEcSFDOU3rJql4zNDtUGK2pwSBsc0iZEu+l6ucpY0bRn4mfsN9nzjGLSTUxyO3OIH/7M84bWmfLfyS03l/iZg7NE/CwxWIyF/NkTrn7Td0flLAH01T6B9LGurLruJlIQJJD7Hn5eIGpUl6YV+QkpL69NcPluVwr9fU94SmgLtwPw+dfalVKvdItapn2RIHhY6YNuvish7Uq51+KhDZCdlg0pYewPtFJNIIAu1K5k/KpqUOmOAKp1G8qAanJpYFyFDIIEohO8aRlL2Bgd1C4llG64siT3EOT3brRjWknR3KhJ+n5o3hSkgQ+rbHYZcRgzo8uVU88HP/zbEuXABREky4nL6l7SCLFEmJXKvOYJn36nLDv5feXY54gf+RvjY18VSslLYmhXDKYMJgFP73txHrt2dQEdHyeTPnwt02Mt/b9OMpDZGvaEpgULFiw4w7j6L58cBijd4KWLbbWyuKU+dlYA1OIWdT27vivv3i/pHh6GE6XvXJRUP4zUnLj0YD/XN0+m0PdTo/sxD8fXuTgAkP42MSFVwjYkRzrYNLS93sBUMkiVDuisqEGNLvUvt55s41AscyNKpQ9BtmfcM2i3ds9d/yTiJd7mWSJ+lhisjyXta0+49VV3BjKGeJSDHLkSiB+f6xwIDLhXawkWxr0a6oyOjXWfFYCWnJ9po0SaA5wKRvd/hZfvfhFAwMN+8vvw3n/xdK8q8vtVAB7klCztscbRhTUOqgYX6jWOqg0OdYNKtaKUe9/Th0khVhewRJZNWzntCwQo69PDvCHrSrUwlrA2FZpK4VpTozEqVNlihNGEFjCKoK2FMZ36yVp/Dmx3zNumf73rcc/Cp731OW53hlzal1XYWI21rVxqGhTqiGjhEpQWLQw05fPStw1MXFqRmpR/HgUfhd2VTJn7fjVx2gwHKnwOWu8vs61XjEwBk9UrZEcU/KaSyg7O1JjQkvIpeWkVqHKQ5EiEjviRx+u2rcJ5Luep+2W9v06X/qVEBy+CQ5YwizYOjZLlKl8AiMgQuT2ZqsaJZ0VZdrhv+H1YPu556V8l9EZak99hRNRRG9rnqn21YRu5c1ZCSMnz+5OBdP9c3uS99YIFCxbcZODujhRAlXGFRcgbPqu268uoX458n+hSuDPePyPx1RRPnynglK9uv7E5cHbwLlU7JwNAU/vJIQXyLqQD97X9FLK+/xIPwDE4vmNFj2JF80AskosTSwUyctuYpVJCf19z1pG40fHHaRFin/7QPz2V/SzYDYvyZw+4/JqE+GH1j1D8KD+REmkQ2neE2nRKF5+CpYMqyIK0AbQBVRa2NrCVDSlbXD2BahuUPkz8yJLp0WdyCiNdtbj6+KeirlqsKpd/XSkTiJ9KtZ3Ch1o3qTaofSTxA3Ry2BQqdFKcymU6FZBqvOmf2z+3gUtxK5/y1aV/dcfQU/94smtbyJuzseSrfXUpYHMwdfl0ZKOvZJgfDOXWKW0nl6Z0kjBhtGtITZUfYZMKFlaHpCNjPE+meYX5CfEj07TCvmVgAVOcurz0/PlLTad3QeSbg87QMTZxzEncY3VMWgEkDqL2l/4V9pOM3PV+26zUQpksS4+ztK/sd/L83ODAK2Tz7nFasGDBgpsCQfXjJq1cJVmpWp0L2Vfl4q28j880VXVu4CdV5OTihyGUyqGnque+P2E8ldThkYch+qlmLgLqK6jGCkKUli+RSanyN4rduM8ngxW1YXKqn8a9J47x+vsuYUgFJJEjfoaU3VMQH+vpdcxzYppt2zV3vbNM/CwxWIxF+bMjLr/2DgCUkD6+kxN+OpK8IEJIY2Jig5lrVv24KleAYUVMS7BGwRoEo+NwGw+KHosrP307VMXzXFs++WdeAKV5+MUrkLRBpQ3+ztuejpW2uLQ6xqFucKk+xko1uKA3IQ1DEjxpmXEF0yNNgrIAxpv2WrSCoa+80qDWBhurUJHBWlVofEoRq4DWRgNowrkxllBpp5CCjkf2rXGG2RaEyz/xIlz92u0NoA0I9zc1mtUx/uvmIv5q/VF8xFzAQ9T9AHXKFQ13XDWcAbFTw8TbmaP64ZEpN5LSlXvX6Jd+D+uEtJmk4xrhnljtEytvylW60tz0bcDblvtMMZT2FkgMP9LE5EtLndpDkQ1l3GtyNuFjufnhc6qMKYDNoUN1NqiuepXYz9BIm6yaIQ0pI6NKERTK3P5U4h1gxXGJy8TqmLRcPZeVzymAGEPXituWHjMfXwp5XXn0VWeWlccol88hNeeGBSCMr88ziOihAO4G8NcAGAAvt9b+IBF9BoB/DeAQQAPgW621v+PXeTqAbwDQAvh2a+3bbkjjFyxY8IDA+77xu32xEe/dCGydsl9S5EpM8SNUPqZSQTHq4iu5bQPVTwFPPpf2lcZSXUUs6vdZAGC3S2HL9ZVp+3Sqnt4SJTNo1960vy6QMULhw5/ltnOlz6VSfN+DOMODR/NVPxI3asBJVmvbhjDbFmeZ+FnQx0L+7AsjxI9SJhA98j1XttLkHrCd2TBA1MIYBSIDtMqpfoxF26rQYbHpceeFg0BHMrEUoIyfj6A+OqgbEDniZ6VaHFXrQPzU5DyAlHgABQAlnirTB7+og/Pl0hmyQpaxFDpHTRaGnB8QDNBAoVIGjXEPpta6dRrr9tfy8YJcyhwfJKd/WYwSHyX80Vc8F5/5S9/riAOfmnZBb9CCcFEdR8fijjeurJSqWWQHyJ1MNOIzcaShVLZ0jklxiiml2DlQyaV8TcFQxQr5PpfDHi2fKFc45UrDYI2qkw6L9K5apBHl9ivn8/ntSsuPV4sy4beeH8FLg8SxoFUSQKXveTvu8/C1H9pfSgABw0HsXPSuV9KutI0R+ZWQW3PK7c6Rc586bkwc2AB4krX294joFgC/S0RvB3AngOdaa3+ZiL7Uf/48InoUgH8K4NMAfAKAXyOiR1hr9/P0sGDBgvMJb3uQ80jtvAT7ihtFFtq6qprpTSiNLca86MJ7P2Bj/KDNlNT6kMot1TVJmtbUIhgKcqDIgZXJrn22uF1u4xgBJuHsGArfjRAEOXR9uKi8mvS9pdg2Te1KC1FECOnp04iK7tkiHoyWcWiIfaJYcCSWGth3TvWzLalSase2qfj7UCFN3fdNQfyccgx21gffFvJnHwjEj0jz4pQu5V5T5Q+nNTF3ocj6Eu6ugzQgtOTVsmTRGj9iQCbyBepqv8eED5s6s6eQ/Atr5VQ/lXLmypxyxZUXuPRm7iFW03DJ58EHXEEA8dLwygJlKRBABgRD1DtnsIBM/SLpr2TQqwC2C0LFLy6dPVKZapM57rnKn952KS73zg/LpdEoqc7K5VuP4SRUP9EIkRgNGxyRGFCNcOCk4a7Jyqt7GCG9C3lJ9pAhtlPCdAQQzxs8Pk/EmkSZlcvHT8kOqf4pIZc+ViJ+RgPYgf1NIbxKSFU/6ftu//3fqTwncpl94kanfN0oWGs/AOAD/v29RPROAH8dLgx6kF/swQDe799/JYDXW2uPAbyXiP4LgMcC+O1TbfiCBQseeKAuLpUVVYF4AK0FQWVIidwAyRTCv+TXI9U/wXsnM2hSLl4Qq+F724/iHVbXJn57YjsyZolTveUAkwpqnjkDIxLGkzVhQJKJkQnpX/lUc/dcMrYur5M3m87PC+rkwnJjvn7hs0VEAKVt62UvFLa3L0xNaesTnPt5xtlHylgLujlInxuHMz34tpA/O+Dy6+7wrknC1Jn9eryXT6XbkObFUIh9bPiVwR2jVca92jZUWTKmSwmzlrxZtIOU06bKH0mkVNqgViYYPD9odR0XqzUu6uOY+EnSVoJBa2b4JpSqRD9FKTYjFjdrAhQ5I+hgGA3r0r/gzkGlXJpXqwysBVoiaGVhrYEhOQriy7/7prHR9bbg/W+s9sbC5YoTG3S50PwvdR202ZoA0mng4M2IpeInChYikqAjASapWDK54TnVz7ZICSBGqYJViTjojrsN86L9+O3kRunCsSVpi3J+F6C5lzkkUBqgtFaBzc+H1C7SnLmk/pEmiduovXQU3PbTv2Sa1FDqn2xPeszd8XWeRHEb+gEcE8m5QHYXVVupbWMVUE4SN5p/IqLLAP4WgP8E4DsBvI2IXgLXg32OX+yvA/jfxGp/6uctWLBgwda4+rVPw8P+jfNjtEAYWGt9VVWu6sXIlaOWKVMyFhuuxhrH3R3cIFKn/snErUmsJa0Opipv0iIbsu+T38sBvP7gnhjUIz/8ZxVkgYqx/tIdJ/zAWadCn6I+z5FwDDbQxkB8zJgysCPXcaqk4XWG4tt4UM/GBNBAStd0Y+cbF08whgyvx9bZFTcb8XPaMdhZH3xbyJ8t4XKYgbiUO6B9qXYmfrSKFT5An/Tp/RnJgjyxQ97/R8OAiKCIugphltCa+E8vSSX3OSaaNFnU2hk5H1aNm/QGK6/4OVBNL/c4VSqMpagM3YhS9UeUN0yAoX5Z+e5csdrHE1mW3EiSy5Nz52VHZvz3vvQF+Nu//D3hODh9rbVxJS9FbrfhOHznMgdDna/0gOFAI32AHiI55hJAk9o7I+Wr155e7vY84qfbjvS16Y/QpeckDdSGVDNARwJJFdBWxzszXSpV5UgfsNPClN9JSvzkVD9h2QkETFcpxE4OZLfBDQ/UTibw+KtE9A7x+eXW2penCxHRJQBvAvCd1tqPENELAHyXtfZNRPRPALwKwBchnzB7PmVTCxYs2D84bvXejo1xg2stXPXOLr3chFhBDqoBIt1+RI0tkSs2kA6ndwOQybqJepdfZVwm44ZSW0p9ZOp/U1qfFUAaFmsg+NsNrZODa6OLt9pEATSsyO6XXEd4NnAEUGm9EmSa1pgapqR6yZ331HBaEkChXUkME+9rgi0CVHbdNPWs395pXeoclc9pq5sf9dD/91T3txfcwEjmLA6+LeTPFrh8d0f8EJdu111FL0n8cOWq1OBOkhrcMfEy1pIflYgfhJjsIU1BHUSeVZL+P7nUMkU2VBSrlauo5cq6b3AhSfeSkJV7pqSqcIfID81pGW/2++FltCd90hQwJn5SAkiR2z+TQLDk08Bob//tplVBkmwS5Yvx1yYH1zkSjO2bM08dZSkhZwSc2z8wLx88hSxF2tquOsQYEZGWjs8hNgzMBULl1J+0SheA3s1cEj85efKU8zIWyG0rtc7vqxuBy6E3IrUnAmMqiTsVU4wqc95LUtnGBNCCWfigtfYxQwsQUQ1H/Pwba+2b/ezHA/gO//6NAF7p3/8pgIeK1T8R3ajUggULFmwN9vyxXr2+NhprUwV1dWsVNmn6NPdViFPrud+SsWg5LuoGMeW6XFgD5Mim1vYHIdKU+ni7Iz5+ybp9NWwuxatTAve2F4pLACtCIIDSUupDkHEoq9KnxKbxAJyN30cEUN4oO9eGEtmUxj0mDGJmlNxTq+qinEKWI5m2JYTG25EbECsMSGY8M0s+mqeJm5L4OTmMDsCd1cG3hfzJ4MpP3Y57/tkzXMl0AFe/7mnhfQAbJ2sLUga68sRK1Ya0KiZbSg9FTPao5BXobnjGEmrVOrIHwoPGqC49zHZm0cFAWvXJnpV4ZWPnC3qNC3qDQ7UJZbLdfvMlEaUx69CDo1RNxCWlO0VD9xAvKoL5AYSUdGiNQkvKHZ+yCAt60qi1jgBiX6BdYC2haTXWrcbGKhybChtbZTt6Vv1oO/5gPvagnZpBSwJNSoalVDgnE+5Si6Yb5uaqUbAR4z46vbTdctSlFulRRWWOUPWEeZQGU12QlX4ng5MS0pG8FHIeX6ttzk9fjdT9D+A9hCTRN7UMqWyf3P6+jZDltcupBPk69kZfKf95TnqdhPydDuEsqH5uBK9FbmTgVQDeaa29S3z1fgB/D8BvAPgCAO/2838OwE8R0V1wOecPB/A7p9bgBTuBiL4awHMAfCqAx1pr31FY7iqAe+FMJZsxAnHBgn3CWqBtFY7bCteaGve3Na61BzhSaxdn+VhXy7jYulhrU9jmWGp96kcn41jufwz3E1H10C7myMUPMtZyByf34+bV1IhtxERUEQm5xespuIqfa1tFBFAO2SqwHjlbgpyvT3csHVGSM1QOxs8o97cyDikRTlIF1FkFlFOb5pAhWqjJ0v1F8LP6xMt0BX2q/hkieIZwFgggJuluatLn5GKwwQG4szz4tpA/GVhDeNhPfh9YxpgSP0Htoxzxo7TtTJQ98VNp4Zsz8qvLkT/pDc/dZOHJHoLSjkRhEogswq9bkUWlW1TkDJ0PdSPIH0f81GRwQa9xoJoe8eO2Eecqp5A3cs7XTm/OUXUlkVaTprSohOjQvkPiMvPOI6lTSVmysF7NZAldqXuyHXe6472RU74ao4Mahs0IS+BAwnkA7f7AqXhUyvYfnEvpXvvCHMJgLDVqSln32IRvWP48dNwlgmdMZcPr5gi+tMOfSjoMYY5vwBTsU5FUSndLpdS97wcC2uFy8dun153pCl83Hp8L4GsB/BER/b6f9wwA3wTgB4moAnAdwDcDgLX2j4noZwD8X3Bmhf9qqfR1U+H/BPA4AD8+YdnPt9Z+8ITbs2BBwD3/7Bm47fW3AwBaQ9i0GmujcWwqP9VYWx3irDpZX5GFsjlvnt3iIGn8nA6ypQNsuTgiTQGT8zWnt/uU9iEfHOlnNDS4GtLjLaDhswROsB8sET9APJibVsHden8JGSVJoG1T4UsePznVz9B+trFQ2Jb4kcvdaALopiZ+bhDO+uDbQv5kYI1nFCx6ZAL5kpWc5qW1gdYGB7UnWKoGFXnFj0xdyhgnMwKrn7mxhnUECcTbMD5vmgkhZvGJXLoZkz5cwj2kdimDilocqk3oSNJ0r9yNZTTHmpx5nqKurcr7DIXlCpJOV75eAQRUaNEqgrI2dGpro2FtC+NcYgHlVD9EBGOUUwuRuE47ECPklR+tVfjI5hAfd6jxofYSPrb6SLRc6vvjbsjuXG4yqV85bFOtoiQjngP5wJ2qfsYUXUCXsuc6y/7Du/T2SY8h5/OjYLDyBGROBVJSOaXISamj7WRIiNLxSr+lbUqspmXL5XaAfjqaDv8BE0af+BwNqaJS7FP1Y3wqZg7SEF6m7Enj7d46yfXja1OqspZTYXXXpH+c+1Kp7R03QPljrf0tlGnwv11Y54UAXnhijVpwYrDWvhNASAVfsODMwVsSOHW1wrrVuN7WIfVrY6uQfiCWAQ4AACAASURBVAVIbxlAWxMG2PbBSEvfH03WqXbEX6dE/PD7lABKIYmflSjlLr9nsDJ5LL6ICzXAx2td/5ntcyf4Co1h0AsoGahOTZtLx5Fuf04597Ht5ywSSt5CPI8VLjlT6Nx+pgzw7kr8pO3bJ6Zs82YzdR7E6cdgZ3rwbSF/sqDohZUlQWHC/j6e+Km0k2JqZQLxw14/KnNTy41U5FQ/pdxX+co3Q56YbEpTvA58mldNbajmVSJ+gPKNIad2SG/IwTgvGQVx66viuq7kpiNNajLYAKhUG6p+NcatSwQQLLQCWoPg+UOEvWj7tHLnxljCoW7QWsIt6jqA/MMl56Uz9q1GGDPDnaJq2RWKgyPEJdH7y43kjs+4PnGK1/QApmQqPBclxQ97IeVSviSpJdsu309R6ch0qn6gtCcD7y1+LyGAykm2x4i5XIA8cixj5yr6351R4mdPt6UFC/YFC+BXyY2Q/HjOJJxBRN8MH5x+0id90ik1bwEAXH7ZS3D1W598o5uxV7zna74HD3/jC7zps8LG+/7c365wXXsSCP2BM0754gE2TV0BjrSi6px4KJAoaUl2pP32PKUrb0sSP0PLp2SS9Fuccgwck6Xz57SXyQ/p2SPXkeneub42N1idVa0kSqJYUVwmZrZBasrc8ysq7Kf3TBORQrk4ZkI6WWa5XTD1vGy7zwcS8XMjYrCzPvi2kD8CXIqyc613v5ZA/ChvpOzLuncmyr58um4D8VNRp/wBpj30hmULSqCuBHWn/lGmI3/kdlY+7euo4vLtJhA/tWo7xcWWIwHZtttO/cNlKFOyIudH05OOkju6Lv0rrv5lyRkHukJnJFK+HAm0D7BJNoCQgz6p3LftFBzbpAX1VWFJTrmYD5Q79Cm+P1JtERQYPhiK/IfQmeWZxAxZqn9y2+f1U6O9KKjgETYhsy5hLvEzBWP+VftMqcohHfHLBbKy5OxpYHAkkWXxGf+CnNfP1DZnFWQTyLIl9WvBeQER/RqAv5b56nustW+duJnPtda+n4g+FsDbiehd1trfzC3oiaGXA8BjHvOYhcI8ZZQIoEe86fnQyt1X3/lVzwYAPPoXnulU0B5/9BXPDe8f+ebn4T8/7lnj+3vtHQBY/e7wvic8ZbvGF8Cq7ONNhUoZfHSzwgfVRRzoBveZA1y3Ne6zNW6htVBUe3Ng7y2TKqulN07OT2bM1JhT7HPzp5VDl/FM1y/qoNrtCI8cONVrLH0r7etCuwuek0OxlPT9QWLCHOIR24+5pgyy5FKn4tT+jvjp3veVOVKFMzX9y4jnihyGyBCZalZSNI2WtM8ojPZB+py0+ke+fyARPwvyWMgfCf5/Uob08ZW8SNlQyUspg4PKET4HukGt2x7xk6p/hr0vpFJmeB3uJLqqVBQe1hRZ3wYTUr24ktcQ8dOvwtO/2chKQfw5tIl8qhYILSzgR3CmGBLzDZ3Tv0Kn5fv4SlWorAkBD6DcZdIGxihY667PPh6Nf+9LX4C/+2tPic5R66t+pdW+FMHLbjviJxeY7JKXzudrSDbMn4dSmIBMeUo+Fosu+GH5s1VQ1IKrbbgAyit/0MIwCZQGJBnSJy13mhIHLggop3axhHpbDClMuhHEJMVLVnmboPqJjoc64+P+Mn1Co/tP9P8rJUIlTmfLkyRzK3pFROCUoDdJ9wrtnnG9ZhkpJtfhpoFdnpsX7A5r7RftYRvv969/RkRvAfBYAFnyZ8ENhEhjZzCJ43wdDVZ1g8f+yjNgLVBpglU2FAH5mz//LPzhlz8Pn/Lm583bJ7yvpe9PLr/mToAsrn79U/dyWH/yj5+JT3nz86DIojEu9QuAM4A2K1w3NTZUwdhNaA8X1mjZYFikbE1FqDJV9NLpBmHmpEnJwZCU5ClVyepvw2JdsAqYEjuOqcNLGCKA4uWcDUaZUInTtcuqmW5gO2fAvA2mklFz9jVkOF1KDRva1r5w0l4/D2jSZ4nBIixDphmEcum+mpfSpkvz8sbOWhusvNKn1u0o8aPIoFJOjTNpUo6oqVXrVTsxkcMTGzivxGtFrsLXgWqgyKJWsQppVzgPki5tjCeZUuYkrybq/CIlVOhccylwplvenz+ZRsfXJ/2cTrvAXYP9nrddMEb85ObnznFJlSEf1pmA4euaXuuVr14RrjPFU7qfIeKnTJCYaJoLbvO2yJd578+TqrtUESNR8m2SUOI/w9PUQG5IHZM7j2k6Wa4E6lSo5FqPkUaa7KwAdSkBv2DBfkBEF4noFn4P4EvgjKIXnDVo66YEn/qW50JrV1m29vHnQd3gsGpwULnXlW6hlMWn/9yzQyz0yCkkkPIKauX3rfxEwOXX3bG3QyPqFOsb43x/7jeu6td1uwp9inzQZdJHifjELdMfiCkRPMXBMTGIkfX4QX4wIyV+uI28rXQ7DPmMUIKMYUZVSxjvV4vnJAxwURjkZNPt1AMyzTKYiui8JMRPSfWT+8xtGMLUmL1UwKXUltQoekqZ+v73w9MUnISiCFhMnc8bFvInh6D2QajmJYmfyhM/nOrFpdQlYVD5h+ZKORNb/uyIjDY71Qnho2BRkfjek0A1E0me4KmZ7NGCFKI2EEb7glQ1BGIgIn3k/PgGXHovES/DclBPKjABIXyVOKhxZI+/brSfzC8m83atJMHIqRRGU5hyKTdbkiH97dhu8oFNSLsSChxJAtXUxkSQIIACwYNuvsznLil+eJ1A+GVk1nL7kngsofTdtsohmZLF13E0BTBDfs3FWKpXyZ9geJvTlIdpsNsr2z7yv9BJQCqnuW1OkQtiS9fjhpd59yC7/2nBAgki+ioi+lMAnw3gF4nobX7+JxDRL/nFPg7AbxHRH8BVEvlFa+2v3JgWL8jh1lffiVtf+WLYygIrE6rNPupnnxNi0LpqsdItDqsNDqsNLlQbHNVrHFYbrKoGq8rFkVp3cZK1hEe86fnF/V75qdvdQGdlQNpVsu1uOHAE0N37IYDe+VXPdin8FmhajXWrcX9b49hUTvkDXTYLFjGCQqyKnaMGHVo2Wxii0MekfWE66DkXaf+WVkSV7U5Jq132K7ctSSAmgOT1yA16pe9TpDEhz+vWndepTfO72U5dJAmgUqWwqet3646vN5UASve1q7H0A1rx47HEYDHOfdrXlZ+6HVYwyZL00ZUJ8lrFih+yWFVNIHzYWJmJApmqJZUrtXIiVS5h7pYZvvHllmPwhTMiRUWuw+tpcgTSnIeg1HtDfq49mcTEjBbHY6xCSwRlDTbGtTD1ygntIJ86ZCn4A/WP1UCBAtm10goNt8sgUJetVTDGnWdOeX/3P3rm5OPN4VK9hiKLA92Eh1QD1ZN7xiNTxqdIdZJkWXVApn/lgou5BFGuKlZvHX86FXUkRjoipUIbrcupt67Makss4RVGhOJabVDFaULRiIRMf+qbFqdVoVKvnylkA6cgDi2XLjPFYDhUP0N3rLnKUjK3PCv9TgKdsUpWg8efpGTmthmM1sf+6yHVL64s5r5Lzo1N7ici8M55/aQKsm0xNRVstALh0D72QKJOgsUNqfa14HzBWvsWAG/JzH8/gC/17+8B8OhTbtqCDC6/4sVA5ZU1AEi7+xFV5FKuyBUXqQ8bfNpbnwPtK81W2oTKsgdVg0PdDfA1xsVI61YHSwCtFAzf5gv3odtef7sjfARRZI1PcbfcDew33YT3ZSxh7dU/18wK121X/etQFCPh1C/Y7oE3VOvaA8lfVFNP6Iukv88+2sH92qS0M1ZA2S6+m1OVFIjtAHI2BQbKWwPEaW0lyFSpnKpYVvfqK2y6Krq7YMyYeSyFquSHM+Y5lMM2pM4QSuXf5+LcqH2WGKyHc0/+BOLHIoxusNpHKn00+Vfv7xMRP56cAPK+PUG5QiZ7wyuRPHMenlSuYhfFndHwqP94J6NI3riNeBUPg7aCgYUhR3YYkcecPgizibA0iI73Z6GtRYNYJqvIwnhirbEUpXntmu4lsVIN1IQOfUoebs9rJ4McmVHe50Q/FREYpKSPvG7cvtaqQBRptN60OzaE1kFm3cRBRnLq06pXvL77LlGZkEg1GyB+5nrY5JAL5qYGS4NkwxZkQs6rJx4Zm7fNSfcMWbUNFpDBZkJQbZvyuA3xkyO2TqqC16kRPwsWLDh3uPL9dwEA7vmuJ/a+e9gPv9TZ5NUIQ8iqdoONDLanUNqi9r6SHIeyqudivcZh1UTxZ2M0GqtwnaoQ27ZGoTUEaxSMUXj4G1+Ad3/19wIAbnvDC6GUha5jpbaFM322lmBaBdMCXHT48t0vwtWve9rO5+gPv/x5+IxffCasdX4/15sW9zUH+Gh7iD9rHoSjeh38Z5gQ4IIgNdoQc62tnqX4SVHqZ0YHDzBPGd4dS0p2+EIaYpB1rsm0G/zpx3pj68rjTgkgAGGAKJhAc9N5nh+8jRU23bbrhLyTxyzndSlgCK+SAOJrzaQLfx67bmOEyDbfl2L9Epk1B3NIr139f84N8bMgi3NP/gAIxI/yUte6blFXLQ6qpqvi5VO6VpHipxUeP4VRA6+84bxWJoAic1RWDUx4YEoZ5zFGufNl2Y0UicmejvSpqY07HbJQ1kBZ06lzjNyOPO7Wd3rAxiJbbcFwipvp/JD4fm9bQqVbtMYRQEqZUO3ib/78s0Bk8Qf/Q1nmPIS3fO6P4vG/8w3huv5Fe4SPqT7ij6G/PJcidcflSpEy8RWMBv3J4IoUQ8h1zrlgZGrQ0lfexGqcGi1a6zprmdpU+2OVpsgtTFAGbWwVRpokeZUqnFLSR6Z6lYifXNUrft+Nck0nzKLzkQn4JAmTq7qRpnxJM+ucGmZo33I7JcVPqYJarm2zRj7D/8yTd6wA8mit6gWWvI+SgovbJhVcfM3njkJK8HWKVE2UkcYXjv+skDxnpBkLFiw4BfAt/ba7HAn0nic+Mf7OdAOPxH6SXmEOdN8pX2CEVedaGay08/RZaefzyApzAI4EMkDlvYAMCOtWg0i7sU2yMIZw2xteCCILrV2hDOWr1gIIhtEGTjFEyoCs8gogbwK9JwLo97/s+fisX34GWqOwNi7165pZ4Zqv+mXscRAcKUJgxUxQ/rhYS1ZXLRXYSAeOZOywUzEJ2t64OI1DlA+acw/1QzGP3E6qBJLt5GVL+5d9fbTvxAS6FaRQ/5i4OltfJbRLmtcU5IifuWbPU5Cqf6YSP6WKYdtiGwLovJI+SwwWYyF/opQHZ/Accqr9CIs0c66UwaHeBNKHq2cxcmkokvipVfwwDMRpI/xZIiJ8MgTJvjFWbhLgh3cbqTuUTy9zcmNfecx2JcLDDTL6F6ruO9uXq7L6h71/KmVgWh80iaCHfX4cCbSfGz2n6hkoHKljnwak3AiUqELRBRCdLDmFLDU6p/rXUFAyqcpBKRc413GH4IBHjzoiKFcVrLW+fVxqlNCr/OXaUE4DKh3fqKfMCSmAdkH4HyCu0DWUsjVG7mX3U+jFcv/b7LK2/9uJAuEkeMwpsXK+TMX2jsjQRyX1A9dpsMLd0tsvWLDglHHl++9yd1JWk6MjgQA4FoONnL3aXFeuclflPXqs9FRRLm4kn4buSB83sb9kgHUEUGUVKmXQGLduW7ECQ/l+2iloFDllkVImxFDKOvKpAWDhksKttVEaGLA/Aghw6qRN61O/2hX0yuC6rQdVFuz346pyxti1wuoQcine7vO4Qjy3HcAdT5QCPvJQ30/L6siWlAQq7TM3b6wvTq0Deu3iGM9m5iFPjqSqn+K+E9VPfzsn29+XrkmJ+Jl6XIxtU92yldkKOK/Ez4I+ziX58/A3vgCmVV0eM3WkAXeGtRxhSdK7QjUuylS2KZS97jyA+iofnczr37Q7j5HBB6EJapG5MtVuO7Hqp6voFXeAxupwnNp26V/IPGwC8IQDkwcqSwABrKDyHkzKoPGk0saQIH46uTSRxUHV4rN/9Wn47S950eRjLp+LaSQBqyNcQNIvRzqW/sXnZVsZswxMst8nOdtxJy6Oka9p+D37zyL40xDBoCSA0JFdJeJHJUGTVP2kbT9rD/HRKNuMgCOn2in9n+eme81ZR7HPj7hmjuyLf3s9Eiij+inuo3ffme9DkKJUzr6/3Nn6vQBY8s0XLDhvGLhVkSFYH6yQcooeNnHmwbKgDKKu0EXNxI9ug50AIO/9TqFTkVOnG01obeNiR2XQtC71SxJLnE5Goe8mtEZBWwtrnY+ishbWD6pZQx0B9BMutrr6tduTQMdNFY7xelvh/taVe2fvn5ZawNrwEC2VJRuontKakRJAuUGCoYFbicFU9B1v7kHdmsSLKdkw6AUUHdt4/1eKM4cHG/vqH02dej/a/gDhs9/S5wXF7wDJBPQJmRLxwsvJ7/m6lI5x6PhOskx7bv9yf+ee+FlisAjnkvyJ4Ikf0hZV1WJVNzharXGh2uBSvU7Su0w2jYvhDI9jOSATRLXybvwFlU9aDUlChVQcZt37/j4RbNJR7ZjyJYmfmpzMeEXOD6emBmkKWxiRCQoRFXxFUgNgDXfMG+iIAAogBfiRLGg40gdaGF23aJWCtoSWFNJnQ0UWn/v2p+I/fPH8KhWvfMxr8c3veDw2RnkDwkqMfDgYdHJkVv3UZAB4E0aLyDMHYCJpmKQZS2eaQkalRE+8/X6aEnv+8PEZuM7ddfocPJnoeGq0MKSwthoaCmve1UAf18mBp5cyLx2fJC1S7OIDMLrv5Pzxb1qJYwP6hExOBbTtiNVOI10F0g5AhsBuo0C6ROqNe1qVCaApakMJ5y/mpP4lsmdXInXBggULZoPi5wyy/pbam+nfEqCVxUq3oXoskz983yU/6MXET2c30MWgmvPJoIL659DHIc4fUaFRGq2hcE90FVQd8cJQPnXeWkBZcilqyoKEojoQQF7ddPknXrQTAWQtYdNql/plapf2ZWqsrY5IB+n906V+xSgV2RjD1P5iSvn1MQymKfvmmkAIxQSQWz+v2gaQVV+XMDdtnq+F8aRbSghl21aYdxIYKs8+hBzJIwki+bsrGS2fltfPHHB7zz3xs6CHc0n+vPurvxe3vf52AN4gmDi32pfRVC0OdRPSuyrVel8SqXqJDZxd6pLx/hnlfacqH4lSpxIecJMUh2w5SpFmVWxD9MBfvuuUywd2BE5a0QjkHvEMyI9MsZGd7vmiRMSZJ7daG+fTug5Go/aqiYocqZQaQHOARKLOe2sJbVPhsNq+3L0zrVaO2LM0IEMGtJdSa+uOn/PRjdVFhUfqkRNtc2bHLNcrBQk5A/CoqoFQe/DDelTpwLfJpXslqUEEaPSNu+e2XWLbAGvKectdj23SwFL1m/TAAfLqnpJ3zxTMIX1y5FosL48JV0f4xYofYDjgjfLshboxh20VQEWF1ISAa9v/0T6xRx/6BQsWnGHc853O34dNn9/zxCfiyg/eBa7qBUOumpftbgrOc8cVE+F0Lq7WBSCQPanXpKwiC/jYiSxggEO9gVGElWrRVBsYS6EaWCPUPzIWNZbQKgU03aMBD+JBA1Y5A2hLNhhC70oAsfHzWpR8/8D6wXiwvtbz/XHtdSnnAFD7wSlWWstS5UGFjCTFaqTPKPUXOQ9CGV8xIZJCpvyXyIiuH4ZQXfN++9uW/bCL1bqULJ0UfxlVm4h+PiXLygMrrNbuG1i740lJmPyujZ2eFlXadq9tSXvmkDJM8oy1aY6aaZtj3Ace+dD3n/5OzzCWGCzGuSR/AjhdyI9qKGWw0i0OqyaMrhzoBhXFlbxS4oe/KxEunAbVlYGf94Bbkntm834TgqicShbDWDWYNpIeM4/+S+NeoCMNvD5HKGVs1LGwksi1G4HcMr7UtiTVNLn0sZA6F1LovGyaLIhT9zL/8G1UP93xOMKnSPoAQGY0ICi8fGDEqpkSSiNU+6oAlgYlafCSGtF1qhojgoqEfPSEj1SQmIRMcOsN33WLJVbPYvqOQK6aWXHZAnlRQun/OHSN56io+Np11UU6Q2V5vRlRAJtR/WyTplZqyxj2kUJ2qrCIHvQWLFjwwIes9HXPdzwRV37opfECxJOLX2Rae64ilILtET9pFVljyd0ZfbhhQFDaYoXOM6UxTmFjhK8Q4JZtjAKMSwczlnyqlwEZglIWxgJkfao+bGRcvStWWlQsM9qlfUFnYy/2V2wtgY2fnY68g+yzspWsPKbEXSVCJFW+jHniuLaPxPuc1paosuX30f5FrJbHSF9JUvE9TvzIdkxR1kjiI40zh0iRtOLX2KD2FBJqCkptKql/TkvVNAcL8ZNgicF6uIki6P3iPf/0GY4wUBa6cvnWF+oGR/UaR9UGR3qNi9UxVqpBTQYHqkFNLWpqe8QPg4kJ7eWoaVpYCqecidN/dCA5uinMhw0TV9mqVRO2E28jU1Iyc5OSNzFWuMTH1LVDo6vwVVOLFbWoqcHKv3ffuTSwmvh8NThQG9T+/Omwrc7EOcwHm2ML/xdBnPF1YLPDlXYKLTbl1spGpd6bVuF3/+ELyz+CCXjNZ72mOz8jfxdJpLhzYdw5gjs/h/6c8DVMMUedIM9RdL4S1Y8j4vLET+kYwjRBIaZhsKImXHf+neyKIiGEuHJDupwBzTqPOQyRELmqXkyEyspXXXv7x5H7n41BXuNuvzaaUnCb5MTrhWXE/5q3436j6Tpl4mcucr/JqYjSzPx9rzTF+7TRtGDBgvOLW1/5Ytz6yhef6j7v+fYnOcWPJ3zYFZq9Jnnwiieubhom6TepWlTUBu/JLt7kdd0yTknkpkO9wUq1ONQbHFUuzuWBzsjb0quQtDeZ5rQ05UkpropLCh2BBUSx11z8/pc9H6uqQeXTzy7oNYx11URbqECy5BQXXHhk5WMr9l0skScpSvHC1L4iR05x7zmE3PHw9YviMDHVUbpft37veEU/mIsDor49qPjL/adsM6t+ZKwerkNyTNKnaaovzhDKz10y9u63Y8jvZ1uUjnUutkn5UhRPEgvxs2AKzrnyp+t4nfEdl3FvUKl+efapSFM6NHWkxlQlTm57zPCnaVPy+9T0bu6+5HbD+kJSHBFWZOI0D1KhAlQLHbxhtHX52V01qY4k60YAxOiDZ/hZLcHXoVP/8OSWr5RBa73RsiKYPQtGQmA18sDKx+KUQnF6Xuen0/kfTVX1DC1XLI0+oXOdtAyV05PSHHmnBCOfOuRH5Sb+bziVkPd50uDr09ouSBtT5oSUN0HYFmXRJ3wMpfM6h1Tp/l/+/iHUSdJceZdRzJPCzab+WSTHCxbcWNz6qjvxvm94Svg89T/5sB92ip33/i9P2rkNVlln90MAlPOaJGW7ATsmcAKRIwfBbFRoZLDgCAEVOCUsLuRgQFBGw1iDCuQVQC4dzFgCFNAYF0tpowBl/KA5y4kUoAADAzLDNgdzwCbVity9fWM11tb7OybqERO8Zwjs7QNy6f0tCMqWlTtyPiuChryB0vkyBu+20/e+cfvKK3JSYkKWRpfK93idTF/rU8XStP1ou0OxiC14CxXPhYuza+pIH6BEypR3K9uX7nMsTa2cOrc7uTQGqf5J558Wcvvidi3ETxlLDBbj3JI/D3/jC6CUG62oqxYHVYML1QZHlRsd4dGU4PEjfjmpp0n+QWw4xzeHoZu0JHhkylSA/36MUMj57ZQ6LkCqWUx4QFes8Alqhy5HeUXAGoCGQu2DD0MU2h+b9xnAVwyA1aEymPQtCh2eswSCsQZQwsOnAtA4SfNGO+Jrgz4BtgsOdIPrpnbKiEh10uWeGwtsrMIaGtdN5b/vRuTcMfhzaD05AgqmtR3xMD2VCBjOQ88GHYO/sU46zmBCrvXXpdwGn7oDVyAenAq2R+QCpm2Q9fpJ/tNzUrRSNQyXn619MDpWpWpO5bCppE+asiWXi8g5QQABCD4DrV/GrT98v5OGozkjcYnSb4i3M0cRVSKlSmmK8bo33gdowYIFp4NbX3Vn9HlKWHb5ZS8BteSWNRQ8fGQ61+A+X+32+b4ndIQTCDDaugyllQnx58qXYq+UCSQPq3/4/spkj/LqTC4iAvh+1xIAJvJtiDFU4gFjLKHSrVOggtBaQmM0FA++GQvD5ZsqYN1UjrQiAyJCS4BSQNNqVwJeVCXbBb/xhS/BP/qP34qVanGtrXFdO+PnD5sLOKQGh2SYfgIX2QB5X8lAoPi4gOKBHQmOZWR5dHcOdysPHwiYgW1IwiSe3xEfUytYdQOnNlvJSFojlNKlXEEPMTCJcr+qxe9whW5wPG1jSk5s4yuaW24o3ptqunwjvHdOAw//xIX0WTAPN8/Q6R7xiDc9P7xXXs6qlQ3l3GW6VQ7hIS+TbtGZvdpAGm2b4pBirF1ztpOilFddWh7g4y91VCwt9Slq6FK85HEoMpH6R6op+mlrXfDD3/MIWRVkyt2537XKGeOCWuPB1bVip8yeQGtoXDMrXLNuum5dudLUM6jzS+IKUbYXhKRIg5JUkryrWmbquRqSSMs0tH3jrOVVj5pGTrwek6q2jZzP1Agy/S3MVRmm+4xTrSQBV/AkGLx39lPX0v2nKa8PCNgTmBYsWDAN1pssJx8npX8ZT27Y7UaPL7/2Dly+2/kOvvfbngRUFrYyoNpgddigrlyK1lG18WlXrVfBuJT2A9Xggt4E1c+BaqLqsWogxsylDskqYRW5YiYhpYxMqCrG3kNadWk+ylcGC3GW98vkwilXfvr2+SdI4E2f8zI/CEDYWI3rpoZKHvwVOpJBHhMAsD2Ahg22BDyF1GwRd8k4al/pwEMekeEYkhQ/Rindq0QY5WKDrOVDsr9eqpRID5OpX2zp4GwdbFD8lFLT5hA/Y5DpUHOJn7QdufSomxXyvDz8E9+/ED9TscRgEc4l+UNkkwku7UuofKSxcG60vffQAnnzLPtw7AOSlDmtBySZrjZq4Jt5GGWfICaCYs+a8va6DqoLdHhUiztrDlIqknnqdueRKIlAWg08iF83Fe6zK3zEXMBHzAXcay7guq1c3npGBMqDqAAAIABJREFUgdBTa0wkTYYqYg2pfrbFWCAzRABOmVfa1lDgM2X/p4mT+q8v6BDuF3s616fl/RMsPvY8LViwoEOJyLn1VXeGP82tr77TKXKUdRPPf9WdPXXQ1W99snvD3Z8I+K/80EtDOlgJQfGj3MqXf+JF0fdKWxysnO/OAXvveE/DC3rjJrXBgWq6STvfwErEUiWkRHpH7Mf+MW5bnnRSvg3eA0iTCX6K2sdXlXavSplQLIWUK1m/D3D8fWyqMIC2sbpIAAGxsqWscul861Kfmzl9wdR4I1cEpIQhcia3bGmejJdzPoHpdy6utfH5SH4fPNXUYoXUYyrvPTMlbjsJyHaUPHH2sY8Uxpa9e7bZ/5R2L6TPdCwxWB/nLu3r0976nEjcaS0Fc7vg9+NZ7hSDJYzFL0GhjTqgUPnJY2rnkebAxsz2/AfeOQ/JOdWPrPDFyh63bL6U9QpA67dTUxsIEOOjhLWtfIUoFVLAjH+NKhBQlwLGlb8qatEqwiGA622NQ9248qVw5Udbs787/vM//S149Z/8XTf6QSZ7U95YhQ+bI3yovYQPNZfQgnBIGxyqDR6sr7n3tPGmhAlZw8eMYdPnXIAyxZR5DKUgI/LD8TLptC19Y13n9yR9ZHLga5nbJwcgWx0LhtN55O90KAUpRVdRw0bztiXw5PLBfwjd+Zr6/86Vf5XeASm66ylz7ccrkW1DuMhzkXpgpZXkSuj5p/m2jpWwX7BgwfnB5Ve8OHvXv/XVdwpDYgijZY8QCLqZl197B2DJZRQ1Lr+JrA1GzZaAKz9wF6yOKmQX8b4nPAWXf+JFbjBKW9z2hhdCPxh4z9d8DwDgs3/1aTisNjjUbMjsVD5pWhcQP9jz55To6BfssH5+p66OEEqiO7++lWrQGA2oBkYTGquwbt3gKKCcXxEsjCJUMDBGwSoL6yvpvOeffO/4SZmAxmgcU4VjUwvvHxT9hVoQrvtBtrRPkedQfhfFGP68jMUE2ww0GZTjoN72k5h/iiJbemPy59z38rs4vjIAJbFNGqN6SMVPLg4eHMiN9zhwPP0Ur1La11lThKeQhtfAFD+j8W0uvj4L9oFzR/5EIEBrIf8cYNuHMMTEj82bgr652BRvkLLfxRBK5aVzlYay6/uHfy7zzmWcW2naZ0VHRO4hsC0YVacEkJM6s7mdhSEnWTaGUCmDxjjlj1Yu4HnsrzwDv/MPpkuR//6//04Abt23f973AwB+5F1fgFv0sOqnhZMp32cOcG97CAPCMdXY2LUjJJQKvZ+m2GOJCaCUXLhZ4fxkyt/L3xif0xYKCm1plb1gjo/PGCESV9bY7ZoFQmMHtdZZUD9JDAWgpeVL35cIoJsG1i5lRhcsOCFcfsWLsxL8W199Z6dGIRsUOKDOn8Za6q9rvSmzBsgbB1NY36eMKQDa4vKPvwRX/+WT4/bcfYcv327x3n/x9JAWRX6/VWXwKW9+Ht71uGfh0PtMHlVrXNTroO6pQqp83DhjKR5oLPS1aZGSnJ8fL8cEUOV7Ya0t0FZYqRaNcibQrTX+NLrBNeOcd6B8Sfh9joK/8jGvxTe+4+tD2td1uyr6OBrrYq/7zAr32kNcN3VEdLiqtM57L6eYlilDsmx6DifRx455bQLjhIFbfjyGkMRP9LuygEbbG2ROf3vyXHHK3RTkziZ7N+2C0zB43gUp8cPv+4qw6dtciJ8tscRgPZw78uePv/I5+JQ3Py8QEYbzuYkJIJY6xilf6YN//8Y44ssxJPks5PPG6+eZeHnDNvAdFJvZRQ/Zwz/8Kak1ITe6QBCxyV73MNz4cMJAQwFo0UJ5FZC/AJbLc6tg3ufm948BUN5bxuJANd75zwU0hlyeOhsVrtsKtKUSwFW/iNflIKJncEeAsTYc1zWzwjWzwkeaQwDAJX2Mv9AX8Jeq+3CLuo5b9P2+7Ps6+BuF9CZqB42VxyDNtEtVJnKVKsKxiBGknHQ69xva1cDXwFWr0BRX3BgyIR9Dqv6ZShSk1a8AT+xYNknuq5ykyXMJUxQp2xA/+SoisQ/PXJJkjuHyXMJqVwJIti/dL6uBWk8QS9NnYJ7Ka8GCBTcpvI8PfDpSRPgEfxqAVHf/sN4AKDwbWD9PE1BZwBBMS04cYimoh6xPd7p8t0vnuvp1T8PDfvL7oCrry6A7pY/yUbZSFlobaG1w8WCNz//1J+EhB9dxVK1xS3Udl6p1l86VSUVy8VB8L8uROWml2SE4MomNlBXaEO/2B0I30C5WE/ustCeD9qy6fOVjXov/+Xe/Fhur8aHmIv6KvtfHuv3juWZq/Hl7Cz7cXsSH2os4NjXYX5LV19JyQHnfmkO1QY02isFKRMsuxE8w5bYEkIIuDHKNxTsl5Uv3DNBX9eS+S42a+TdSj7QnTesqYV89LVewGtpnR1TtaacZzC0uMnae5mxPnoOF+FmwT5zLiPhdj3tW1hNGGqCdFPGTEjJTlB4l4kd+76o6jJM9Q6ohmRPe7S8uT7/iDhScHxw/bMbGcbZLEaOu05XYtlOVAY4k6yq/PRrJm56CL/xfXVWPb/uUXw9kTW57fCO/11yAsQr3NQdojEZjNO5vV2itwrGpPTF0EI1mtb4CmsRJqjh6FcES8mKyPHmkjaX0pd7nETXVVOSMjt028re4uWRA7x6Q/O6z+xghMvaNfRptn6ayZo5yauzclbZ1o5VRS775ggUng6vf9N3e1MERMvAEDzwBQ8pCaQNVGShtoKsWSlvoykBXBlXdQtctKj/p2kDXLfSqhapbUN2CVi1wYICDFlgZV6mrtoA2IG2hKoPbXn87VOXe66oN2w/7qVqs6gYXD9Y4rDe4VK+D4udStcYFtQ5ERRgYEv3aVFVwT/UjU/QLMS+vV3vLg0o5E2pFxptQm8j42b0Xvpnu9OPTf+7ZePQvPHOHq9lv2y36OoB8PODSvWrcZw7wgc1D8MHNLfjg5hL+bP0g/Nn6QfhQcwkfbo+i6S/aI3y4vYh72wtZP6F9YRc1So5AGFIJTfVHHFovZ96c+uaE74DiNPkYZ7Sz1Hagf672qQIqnfsS2VScX9juFDzyoe9fiJ89YInBYpw75Q8APOpnnwP+O1a6/1AwTJDMu+JDxE9++SHZZplFjkYAeBsTH3BLN6KUTOJqW8Pb6hRAyqd1ubb49Xjwhtz4vLEaXK0il/qV274Bj1Y5ybarWkGoyKAhFUigjd/e5779qfgPX3zH6La/7De/HUNdUq9SEQht6CxjsoOVJxuruqoVZFCbFq0/Jy15vym/PeWlTPsKRErqn10RCCQhkR70Kuqdt3KbjIvgT+RhPUf4DHnOpEqU1KOGyc1tMLesOe8vP39Y6p07hrHy83PhVEAnm7bHSFVAwPi1AuLf66mTQTd5oLBgwVmGFX4+jvixAGxQ+yhtoJT73lWp6ipWAZ2CxnrVj7UEC8BqgjH+s8mkiLGiiFzlK8B/BqKCIoqc6uewanChXuOwanCpPsYt1XVv7LwOip+pSNU2pcqzjNK9P1X6cipYRVx1rHV+isorfIzzbXRemQqNSKMjsljpFn/nbU8HkcVvf0lscj0Xh2oDwPUvTuHtIjTtFREcux7bGtfaFe5va9zXHkB5dThf30O1wYa6+FLD4l5ziI+p7sVFdQyF4+D7k0v9yimm99mX5CpVdWbW/Ti/pM7eFWOqlRutFhiq6DWWXjW2vZzP0BBSZVKpPXzO5qa6LYbOe8YSg0U4l+QPd8bWEppWATV60lVZon2M8EnN1Bg54qdE+mQrNo3MA+BNda1PmQJMdHPMpYWUiZ50H6z6WVETqnyxUW8/BUaONDmJrQGhhXJEELHxXYs1AFh3s1VQWFHjOnYo1/6M/02XAqaCAqdGCyhgbarg/bOCNylER0goWHzZb347FFn8/H/3w9nj785D/vw87rb/A//+6iMy59MRQIfU4qI6xpFa44Jeo/Xy6JpM+F1trMa95hAaFtdtjRW5tLiL6hiHtNlLx5qmS/EDcI4EmkNkTglwUrVILo1nqGKTTCPiYGtu+pc0Zo5Sv0aNHF1AnKZ+ud87/O+YohFUVrSlKJE6PYIiQ2JMRdeOzHVF3/Q6F9DyNSgd91T1j7FqspqpM2zezpNMIpcKVkr/Cvs/Y95ICxYs2ANS4odsUORwOXJJ+rhqVbH6NUcAGSvIHxQ8gjz5wYSP8vvi97Vy1bIq3eKC8Pi5pTrGg6rrOFANDtUmG9sNIS6E4YprKE6h52VKilUegApG0OlBucG1Srk4bqXd8o1vk7UESxQqgFk//w+//Hn4zF/6XhjjSKBd8LLP/Em85J1/vziApQCs/QAXx4TGquAv6WIH06mpyODY1LhuXILTodrgT9d/GR9f/zfUVTM6kDOUMr8LppIMKaHRJ+3i7bjfxjgJMqU8+1kifYBpKWhTTZZLSGPPXf16Su3L7XchfhacNM4l+aOoezhSynrPGeo9MM1V+ZQ8MErEz9yqX1MesKJlLFcRmu+fItOAWPUzp0w3ABirgxLItaerfCA9OTa+M3YjTjrMlw+H8oE2VP3ynVvn1aRCKp1TE3WjUQaZoG0AuZGVUhCiCdDW4pDWOKQNjvQaBgobo1Arg0v6OAruNlajNQRDhAOqoWFcgCjSDjHh4Xhfgciu6UI51Y8kU4D8f2OfqiTZ0ae/nbkkQ877BxDHlBA/JVLnNBGUZ2G0qVz1LKdg2pUASjHVD2hKxa9tMEQA3Qjc7BLhBQvOKm599Z1BYMwl3J3ax6ltSLk0JSZ9XEEIG3we0xLl7P1jQGiN6j4bFRFEEjygyGqfyhcSWVUtVrpBpYyv6NXgqHIDRJeqNY70OhAT/Yf7uP/J3c9r5QgWN+DRYgONXLXZHmxHAqUK0BCHWFfu21VXNTBuBA9gn0UQtFKOXPOb+7S3PgeVJlR6d9VP2p5+ejywss6K4KI6xpE+xrGpQrx7oBtcqq67aqteQXQfHaAF4Vp7AGMIl/R1/EV7hIfoa2FQYl7b5vf1rfc23DY9Sf5OdrE1KG2bUeo1tbgMQ4U99oFUXcPzQlsmnMO5nj0SUwig0j63wZVP/MBW6y0YxxKDxTiX5A+AyO8njPBY2moUXiJ96MkRP6UOI0qzGvFKkfOD+idFkv4lt1E6zrgNMu/cESysiOqUGcnxynaE8u7daL9T/Og+0QOF1qdwldK/lCdFjNXgql8bb1iokxGRtNKFkdXGCvjF//6HXOqXX+5tf+8Hou+HOvqaLA6pCeqf1ipUpFFTiyPtlT1ksbEax94DyJDyRtKsktre5Fgit51SCtguxE+JVMnJy+P/xMkFLHNRIgeGCKB0Obl8ip2reGWUUtuWl4+q54HTEztj61waWM5Y+SSxDeEUGXRn1s9d45NIh1ywYMHp4vJr7/DmyujUPtqlebG5Mqt8pHdhUP9Q5/3YVwC5mND6zynxY9B9x9BkUGmDWjvPnCNfxn2lm6ia1wFtcKAa1KrpPVwCebUCE/psBu38d+KYrrYultgYHd0H+16L8Pvpq4Xc9xbwxBLvQ5FBQxpro8P5Mpaw8hXImrZTBf3uP3xh/2JtgSd/6tvwhv/yWWIQiYkTdwBHygI4xsdUH8F1W+NIrXHNrEJ/8An1h3GLut+RO1Z55bXzNrrWHrhS8qTx5Vf+EL9+9ZHi+GMFcg5ziJ/WckGT7WKVVP2TkhBpDDQnNczYvoKl51FT2MyuRFApFSomuAr7HlNMiW2PqYCGCJ05cXluuSm/koX0WXDaOLfkj1YWrXHVvox1IzyNUWis8h1H91DHkJ1p6aaqyPYe+LijjpeLO21ptjxm8NzfZ/9h0FXZ8tvPdgzdA1NufeXVDc580KCmThbLRILsGLliAhtBA4Dylb9aEJQvmQqf/tVaH2BYtzX28tlAQ1Yuk3nVnM7Dqh6u+nVsKihr/ehUC2V0COpkcDY1R7qYmoe8xwunfj1E3Y+2cqlu18wKa1vhkDa4qI7d+SMbSsF/sLkF18wqbMONTK2hqRnsiPaVXz5lxIjJujk+RN116gggoJOXpybq48bR5XbuWkmh3/akrYIAcqRlRzCweXlEBtlx4iJLTiQE06DnWHLeUsXP2D7l+Q6+XEB3raQ3F/ok8T7LrMf/b9s777n/2pRy8Gn6F3CDyR6L/vDlggULdgf5CV2al65c/FJXbUf+CIUPxwZM/kiFMOAeaK0YLGLFjYwfpE0AxxhcZKJWLQ6qBitP/hxVxzhQDS7oDY7U2hkpw/aInymQsaRUDAHOQ3BjtbsPFp6qeUAvfLY2qxZyB6QcAWQAo5qwfjgXyimPrCanslR252rKX/wb3wVjCf/u8+8K877mk/93vO29j8re+zUINbnY63r1ERypY1wzBwCAxz/8P+J17/4cPLT+b1G68cZWWZuFHHaJt5g0kANvxlKRSAGmpRFJAmhsmW0gz/JQW3v7ZELxFLq6KcSPfJUkkDwv+zT6XtQ+ZxhLDNbDuSR//ugrnotH/8IzYawGYEOOd2MVGjPu/D/HaC19KMs92JUe9ra5maRVm8LDK6Q3hu0RQNltBWInx2azkTMAAmpnyYcViTxvofThEvSA+f/Ze9dgW7arPOwbs1evvc8594gbE7mk+9K9QjKBhEgggRJRKCljyoAfiV0hMo4xdh5E5WBj4zg2kl3lxJQpKrETpfIqxaRKFOAQCuI4GIUoBJewQbKQbEWJBNb73qt77dgioMu52mf16jnyY84x55iz5+zHWmvvc452f1W79l5r9WN299o9R3/jG99A58fXZfvqYdCwI36CoklP0hQJJ5Eddzz8CktA58r7/HiZsDHTE/nfetN/OblMCQ0BLVncoh0ebu6gJRcsvdDfAAA83LwYlu3YKZ966zpN/NP9bfyWzW+ipXGSZVGmKZTIjZMCc7EkmMgJIPdegagpkI6HIleylMZzKCa9F05QWiTf95T4Tf//Tk1g6Oxm3Qy0fo+odXRbiqI3T+VYl5JPpza2XrFixf2BJ9/5g6GbF4naZ+OUN42xaDc9Wl/mpZMdoRMoUtXP3BIaO1ACpeTPtumd2sf0uLm5i4eaXVD7CPFT9GpLCOxM2ZGpwhuwIn8kASDNF/xxGHdvl3EK8ZPEpBRJCVC6LNgGAiioMPz2tiAYy7C+1XtvXGKu84m3Y/GNP/+9CQEkY7YM2Ox23hJwi/b4UnMHt2iHnYmx1mvPngnjaWEBA3TNnTBn9ezU1z/28TfgZZtphcipIEr0rU4ST+yyVAJ16L4lKduo8zrw/rmiaXOpEfJc4qe2j2OIsdr6tXK5seNaSZ8V9xLXkvwBEMzo9n0Da50/y65vsGsa7OwGLfXYZIZ1UQkwLqcMyhnJ0PisyZjB1xJfn9o+Bcnky2p7Kps/dQMUr5/Wt3bXKofkYYoMtvDHR1ExBMArejh67RAA/6DZo/EEyQbA3mVjvKLCgNB7gmSgPPAkkgRvrbGwvYH1EugNUQjk5DpZL0sGgN/zC3980vS5BjGotp7w6pX8GADOyQK+a8fncMspftrP+fPnzncL9516oT+H9Z3Abpodfm3/EM7b7qC686kxlxUyUWmmlxWY4G9jlVdT/M6U/JgSf58CAbQEoiSL+6iTO5oUkY5pUGRj7ZzOLYHSHjhhfIglkGEbZAbqn7JSrFxKpQN5GUd+jHMVPwPDZ63+ydSMsTtgqgDS4xrrrHUqzCVq5uw/VTtVStqusgh8TTqtWHESPPnDvnNnVuZlGovtpneKH1V+BaT3yRLhk/yt552Re0QggVRjCSF/tsaRP2dmj43psaE+KpZHEoAlFahWaIsy3JE/+yTeatH7pJoL66XUKH8cbrJ9GTj1TyB79LH791rqwxO0NX1QF225h218Iq5vwvl43bvetrj061ve8z3ASHxtmdAToQUPYq+WGLfNDufslNOf62/hQ08/7s9PJHS26HHbXHjluFMBGbJ4ifnCoPxOJ9CO9YwRr0v33rAz5lLj4BpJNTVWXTI2piC6KuJHkCt0gGmS5RgkHpEj52zKTDrH3KhoJX7uAdYYLMG1JX80pK5bSr967/0jEs28FryGvLuXnugPKV85BGPByljJScnrZ9b+ksCDA9HhYD055DJH1gcjYvhck4e6yXLZhOvGzNgjBmEaebbuVCgFIT0sfmvzm2FcYYxgnJs9znmHc9PhRds782cQXrDnAMbVPYd2mzjUS2h0UszUNEsMhpdiTPGSkyIlhU+NLBgeQ6pUqhERIVCHHd3vXJRN4odqn2NJwRoRVWuRPuZjNLXtY03Ev9iwmg2uWDEPr/yxv4xP/sG34skfdobBn/7Dfw4AwmuQ765lYplXYyy2bY9t06MxFmfNPpZ1FVQ9JYInXzaUmAeypEK0K7WMges62hBja/bO10cSaAUfmTlzc24J0FLvvQL3AzKp5R4d97jgFtLdKj9uXSrWePUQrGvfbjglXkIXMWPRwuKuSlLu7Caco42xuKANdrRB742xv+5/eyv+3jf/5dFjy7ExthijfdNTH8X7PvMUOjZoiWGYAYqxV0tu7uqIYRm4tfkN9N5HMU9q3UKHxjC2FBVNnfeRFEiyK5yHEyiCct+fmPCdv41c/TNW+t6EpNxxSperRK4Cykm4pdClaCWFUZNdi2MwpTgSrMTPvcEag6W4tuQPEZIuD1bKvqT0q0J9a/VP7fPUbDhma3LkqhYzQhSNtVOO5Rfzvt1T5V5huypDJOiTwIATksuQ6w4RwIAQQK78yyl+8rFLWZgFoeGUKJhqh917w2cxidYBnFb/uG04BdDves+fOKi8y0mE7WCy7mUSB9DDXz+1TJplsDgnMXzsQttRy2ZgOngqDNtklie8GDTUTXPHAgmtADpVO+/hPuL3o94CNn6nwCZRJQm0B06NABKUvntjqpFjlDE1Y+fUoyBV/ZyCgJLtnPp6LR/D6dQ/K1asePDATHjqR34gNKpwSp84p0onLzKxzGvTOOJnu9mjNT02xmJjYgvwvAGERons0aXjIS5T/kACnfAInRbJ+jhBGmUsS/zVltPET1Rm74tzUQ/nXdlS7AbmjqEQj7JTToMNen8+EgLIx3CWgY0vAbOWgsci4GKrbdPHErgDkmzvetPb8S3v+R4Y4kGzDUF+LvtCDAOihCBJStk8wnkBhdKvvAw6x1T8MweSID2mNG5O+Ve0dsivZUWxQv47dvCoLhfHED8aS0vM5mLsvBkAT66Ez4r7DNeW/DHe8M8awr43sNYpf3a9K/va2wa2kcd5P2mSn0S58tBJ8WFM6rFlkim78UdiY4z4GUOJ+NEPRrlqqfbQZENWwh8Lyu3d84fTFq5bVUsW26D+YUhX0B6Ejhm9MG3sH7zJE0kEbAHs2JWJGV9KY0A+GJGJe0gCiSH1Xd6gAWPjpcl7r9rakIUlSsgfm/d1XYjJdvc+SG2Yk8yTnBcLxk2zw8PNi4FkGCP2To0SETRmXg6G6hoXPnG/SmP2ZMsh0Ca/kiUr/T+USJGwnPhCqSCtXBo1boKcE5Cp9N4G1U/4PhD8uTJJi3u3/Zmk7OB/rV4ylhM/8ncsZasrsY7BsYSLXr9GNNXO1xQpNJfUHtvHpeFYJ9QVK64R2BqVQHFzKvn27GQQyrw2jfP2Od/ssWl6nPm26oZcA4gkERTImTQ5p9/ThE8TCCApZ6+X7QNaySFl/zGGOtYHR5KIsQTfNeEQj8Vw7/PnbIt9EutohbfJ5lWrzkOcM7L7KFu/7caTBM7YWoyft2KK7Z+492zATPj6d/9Z/N1v+kH8nl/44wAwWXIvBFAJTj1ObgbME3A8/VA/IEHItUUZXNdKEkQnwGQ8UwjfCaX80p8J6TJ3e9cRS56JarO/e3YbX6aEOVH51PZW4uc+wRqDJbi25I+AmUDkfusODvrBKTHJK9RQyzJAmv0ZkxQmD6cHPPiPGaKWMKftYxzv9HjCwy/FTmASIIkyxhAAZvSeROgq29IP4U7541uPhmxUVvfrVUJWqX3gCSPDOmM3Lfk+BtLlC5gOPoQAMsRo2OKcOtw0d13ZFxucmw7v/tRXJNmKy1RiJH466ruRq3+EAOpBAx+fEqEJyPlN1T9zFDsCC5q8RmPdOnSXsnogF8eYr1tcXnntCHFwqtKmOaSP3t8x31+TBP3HB5up4WhGiF0ylqh/VuPnFSseDHzq3/q+RO1DpMgfw2ga17q98cSPKH4acmqfjf+tSZ9c0QPocq+hskcTPlNlXzqIzpNjpzA/jgm16CXplCqc3H/dvLcJxEiv/XtAgEpEJmX+PtHmItvYTj5RxBL70hkb1D9722Aj3cDIAg2Cx2IoIwPjX/25/xA32vlxzLve9PaDzpPEH5aHRMpY6dAwQcohbkiSQIPS5infzPK+5HqWlp9LAC01f17WsGP+do/BsW3igWVEziHdyI6NvlfiZ8X9imtL/rz3d/4AXveutyXvlXxhcpO+BsOsun6g0koETQBNlS/JOofgkABDl0qlY4ikTnVdyTyhD14/bZATZ8dBhIZd8CYme85orwnGslbJio9BA/bGzzFQEvWPO+bTMb8ykWgCCBjP3ujPttTjnDpcUAeQtHofTtJ5u/vBNkc+W4ISOZiaBPOAABJYtYwmW/LyrzndqkotvnWrVGCC+CkEOVN+QAMoFY82Pm4KYygpbJK25SPfuSnSp2bSPBenIjlLGFMEXto+CwTOwLNoRP1z5WofhbXefMWKaTz1Iz+AT/2h7wv/MEHt0zCMJ382Te9LvWwgfkTxkxA/ivTZqLgg+qmlRA+QEiNRyV1Wn44RA3r9Q5HHjhI7iSpblD+6YUEPG5I1req8atRYB4b/ft42Mo9JqXRGAEn5VyAvPPED4xMJ1nn2bNFjBwDWz10VH5+l6HiD3ndRdeMhfwyuq2vHFNRBQ/LH+N/ZPD6iknfnU28nJq90zFOK+fJmFU3yLBCTpMd4zcwlgCS2W+o7er/jUGLmFKTTFFbS5/7DGoOluLbkD+DUPsZYwJowinAMAAAgAElEQVTQAQKIk8DG1wG3Zh+CgqSOumLWlxv05Z/NKU0odX1w28y3V1YhlM2dZRIYz5jHkhJNarm/ReXTkiN+zs0eW/TYwlbqhjk8TDujZ11+5rxZDNlEXQL4yVq6VWTlX9KhwhCH7lmWDHpm343CBQh708cJHXRUAPLuT30FzgPhkyleGOhAxYwTMCQTGzDOqQNMJHe2tE+Iw1qb1xxTpI+WHeeoeR/I4YkCyJk+mvi9yMiuBjpIjNdszP9natzWZyOl9EsIoLzMq2TsLcGsqH9C1i/fZ/X/0CYEkHTm0ObS8r0TX6FkHSDtmjJB3JT8fGqv5yiirsq3R7LOobzhCkoXawQQcHxJ2qWBsXaaWLFiJp76kR/wnj4AGQvTuBL9TWNhjBA+0dh5W/T4SQkgabFeU/QknRuzEnrB0AevLy6XYw4JVIsJB529VLmXLj8GADCwJWAHV0oP+LmK+6LKsw+dvuDna0eiJF55yT3dhPKv3hCML/mCBZqmw13E7qpo3DjE/Fl3XD0UroRe5vN0Wx0TLrjBC/YcO5/UDP5G2dxkQdVr7D5vQrLqgrchIdVDPC7jnF5SQMezNfxOiDXCFPGjSZ2lncCA+SVkiVJ/+W7K26TLI1U0yjUYy3BqImglfe5TrDHYANea/AEQDOoAqDIhG1QqRkluGzAa1SFAbjx1E7WUsKm1Tq6tN1YONmciHSOAZNz5JBFr3wtkgco8tehDiYc7Z5H4yR32xQS5gSsBc344imDyAUUDA8McsjM6s1ZTdFhuoFuSSst3Q06ebC2F0iVRHx0ShAxbZ5PEPe6HgR3MIMgZ89NpsUfLTTAbvOzsS94mfHJ56E4LwwwZgEFJmKxXI4CA442Jl6KanaupqkpkDhC+7/nyOQGky9wOIX5OXZp1aox9f/Rnl+U7NLZvV6ro7q/he5eNt/TeihUr7g2e+tEfcH/4OVqUPtLFy3i1j+vkxYnSZ2t6bH2SZ2PStu5a6bPxvoQAwnI54TPZOKPg9VhatjTnD+YLj6kE4uD9RGVe7sraIMZTDfrBHBTLr11cZEE+NiIY0Ihy0j9us0v+WTKwvYu5JA7bmB4bNrC9NxtWapqNsQc32wCGcYO82vnY69ftDdyxZ3jRnrnPyZXXb2kfFOqOCOonySgLgwveYMeboKgqlTRPlbPrZFXJ/7NmQCyqninip6T+OcqQurCqVlhdBS7DlFl35JUOvac8npX0WfGg4dqTP8YwrHW/G5892preteg0Pc6N68qkTfvyyb32fo6cjJlbh5s8UNWUPlkQoEtvwnsTPLkpTW5C8ED8faLix3WuUibPSCeP8DczOl//3XD+0IxQXmP9PqzP8BjYoP6wysQ3BEZs0HrpcUNAx4ArLXfKHx3E7H0G6hjU2pVL1unz9iw88G99V44B/HwjAdotc3cQ1Cw1FVyCPOApEk56l5kKaLisyx5aJqW2AUQB1EDIkD5c1xoJFaXZQ+PnsE1WJVfqf0ETU7n6Zyw7p02lo7LHf8+Yk2s4MJcO46aEAGookg66re8Yan4+h5RuzdnfoQRcfEAaV/2EBzBE5Z2sX+u0NnsMY+St3F/CvQdhvHGZxbs8CgSAVrPBFSvqEOJHfH02zs+n3fSue1dj0TYuSXK+2eO82WNDFlv/u0SWaMNm6b6lVT56/tDNOgT5vSvXGdTvszHWSMylKzeenADSx6IVSo2an9JlykrulvYubspCiB4cmm3InAzfZdXKvAmUlbGeAHLEkff/sd5rkSwMGd8FzHXPFVgm7K3Bxlh8y3u+5yBfH1Fv94WmHR0bXHCLF+wNvNCfo4dTU19Qh1vmLlpfZn9eKK1Oz41BbNRhqjFfqTNY3auPldpsqJ4eI4CW4pB4cazLV3Pi+FOj5zLZdGrkx9CEWOR4AmglfR4MrDHYENea/Pngt34/XvPTfwHkFT+Nrxl3rUL70LErmhnLg0W5flreP0V9c77tnPSZLPdZ+GCVGwc2+njVeBovfXWlX9HnRxM/pUyBEEQdpAaa0GWeQ4YsDDv6RPaXT741tVLI5LCFIVK1/oS9mnQPlR/XiLMejN5niS64RYcGLfqYDarIi93k78vgdCYwM0e+F50gUjPySKbkQWqtLXy+nej54455LuYYP5eQ+xeV2rfrMcoyevlQvpYtly6Ttn/NW8tromsMYx28pv6H55JLp4QmfjROYUh9LKQsTKuAclxVZ70VK1bMh+vk5Yifs3aPbbvHuW/d3jZ98PQ5b/aB9NHlXMCwfCqUf5FFa2wgfYqxFdniPTiQIAWCO79XWwxJH42YuMhJh6ECKG/KIOtrg/3BtlUyTe8vmaPVMkYSLWRmkeLGk0Mu2RP9fyxZNHAdVvfE7lpZTwLZGBcfExsLMWMDcZV+1vEGF7bFC/Y82DPsjHvEOTdOARSOoxDf9p6069morpkqJh5R9oTXRRVXbO9eK7MSAmiJMXOO+WbR0XRaE0w5EVMiTU6t/hEC6NBSMR+pHYxjjmklflY8yLjW5A8ASBKBfJbIBRiO+JGffKIoGb8CKPp9AIeRQbkEuUT6lB6y8i5lSzPrLgAqT3LRaNAODJ5z4qd8TBzIo46boH6RYETf/B3xI35AUf0j20myU0qOLAFJSz321MCSCeVfmvj5fX/3P4Ahxk++8b9ZdH6AONnIWepB2HGDF/kMO26wpR7WFYEFwswQ+wAsVY/oblpynsvGxIcHBYegWGZXCE4TbyJ/XfKOYHlZ2BKI988hBEc+nuG2hwFeXNfCzPHmKhynJoCA47xortLDZw4GHmYF1U9xvYkSsDGCbik0AVTDlfsDrXzTihVlBNUP0GysK/Fq97i13eHGpvMKn96bObvfZ80emxCbqYRETvwrxYUmfgYK2ALxMyCJC551Oelk1JyTL3ssprzhQrLBlwulZfPep9ITJxJzWUlAsVMK9cprzy1fLouWRJv1SuzQadVfI1hn/rxnp/bJr8mh6p/et7MvndGeyauDDDpuQnJRzpVT/uxhvG+lTqwF4geEDnE9Kcl3rzmoupP9KuJuqKyO6+qfsdnnMmK9EhlZsmpw+z9+30vInGO8dvR51HYTc55HDsVK+jygWGOwBNee/AEQpMBnXk58o+nwUHMXZ6ZDS33IGOQy4AH5EggJ96vURSD3pSghVxrpzkLx76g8SKCltrlhH6cPPSUFjduHBEgxw9/4SS83eG498VO6yQqr3vhgw3jPnYadZ5CQIbqjUUMcApIeKSFksgBEE0CGetdaVKR9Bui4D+cdZg9gM8g+vfmX3gIA+PF/+b8bjF+j4w1Au8H7PQMXvMGLvMWv9zdxYVs0ZHFGHR5uXvQ15z1aX4oWT1OWedTlVUn5lCxtDg4KlpjxjpWBFb0MRM1DUeqed/cyfvziA5RDlwQB5QfzPiH5kNTtl5YflH9hqKLJO4gNyK1C2Z6c/6QNbnac4gsWlxk/9/lDx0BdNVMJNNczau53KO+iFfczLPdaovo5RemXRsnTYrKzV8G/4zKxSo5XrIh41f/0/bC9V5sQecVPj/Nth7PNHg+d3cVLtnedysfssTF9KOPaGDHNTRNkliVRoL3qou9PifgZKDcKxE/wEMveS+63lTnmUOhOX7rLV1CjF8r/pQlBS6nBc3If93HEDlBdweJyLXplAF0mrqQ0X8q/QuMNyW2ZPUIpOFzJ/T6ZLw+7F17YFudNhx0a9NDl2MA57Z1Fg+1gyKK3rVuHNzBs0bDFBbe4hbv+vHGiELZMuOAWO27CuWupxy3alcv3Ec9Z4sOEYRyhlTYt1YkfHS2cigDKlePyOrdqmEuSLFHKDMoNF1z2pb4/RbuJE2MlfR5srDFYimtP/gSDY3Jtwbdm7/1+9mHSBdIJqzZ55dntqa5a5fEMgxH9cKh9SQAkDzEWaVelYc16HcMJK/X0SI5fGTwn66i/azfuWP/stm8L7ebT5UUdlLbd1IogoPxgL3Lk0PVjQn1wKCwTdl5yfMGtC6rIuAyR8dfNB4+asChJz7UK6KoxpewRzPG4Kpk714iYqeuSl385T53x1qUyzqRkbWaAXpPs59vKS65yxVPunVA6xvxeMqmuusdKoKL0/YCUyiH3xrnIiXFNDoVyyiM7z6xYseJw6EYbweencT4/Z+0eD7U73NzscGuzC4QPkJIi5W6V0R9QlquhlhCplYpajmWkxzRnOKTs1JXip0R7SQUel3HQfnsAVOdVCqbQln1SzifdJMqsldLJ/oQSafw825ImgICtKoEzdqjIWoqON8ncJ8a9ALCFxS3a4cLcxTl16EwTxm3ZYMcbdLxBx00oG0uOxyfgOjSh++o5dd4rqE/m4VB65raebCdXAOnyqktv6FHYfon0ceM7vFzqKgygl/6HlPyDNKE1Lw1Xxkr6rPhixP1TT3APQcQgqVM2acmXJl/moibPLZk11yaExmfVRe0jxE9DUZnTqNdAuXylhGEHsCyoqNwidRlTPFZ3k50yjGsoToTBOwgcjs+ofZvKOGSdwbgoO1eIdf5pm9f4k6//7e/9rsoRzIerO3dy4wtuw0/H7qh6NkngsOThd6pr1FLMMn5Ges5L5660fPJafXdL74fxZNmzsXNzLPlxqAy/VCqQv06/y1kZAXjwk6w7cg1OMf6lqN0HdJccjXvh9TP2f2Ew/N6d+v9oFviSflaseEDxiTe/DZ/89rcGk2cxeD7f7HFj0+G82eO86WIyjqIHY4n4EcR5P5pAm8r9aily4kfvI8fhc4xNth9iGXCMv9TxJA1E/Lot+vCz9TFsS30geLSno27m0ZBNzl9+nPnxhlgL3k+JnDLpzF+zrXHeTFvj/ZqMnRVDTCFPOjUgtMS4aXa4Ze7iptmF74pe58K2+H/3L8Gv2xvFbV54ckn7LTqLAw4/UcETPXyScq6gMEt9dURlI1frlEqVMWPofHyyfIxNyqqfOcTO0pKqqzB3LiH3VqqhNL6V+PkiwRqDDXDtlT8kJV/NHjc3OzzU7HC7uQgTyFy1gEBUDHo9Xc4S1QhO0aKzVGEbxAmZEVtEWmiiJnTEgsvgODVJH+u6BcqIUFAyRsyzS7q0I/zoSQ0p8dOQlMRwItsUqagBfKmYnI8ouZ3TiSzx/AEActO0zUrApANYayxgAUsENF55YX3XCLVvoGwMK3jnx96Ihxs5lhL5FJUwLrNk0FETrtvWB15bKhFaeclKo/4eKhcOkQNbSKlUOUtVPia/Lg+lwzUkpVY5fClbKAHT72P4/1UjHnr1feu9V4HsW69b6v41paDRaqLS/nsVFA68jrJjlU5fSclbBXr9Wlve2vhrHciO8dAxsN6DK1Uxuv3mhNWQHJ9fplYn+aplrYVlqtsvnPOa/9OKFSuuHqL4aYyQP5H4ib6CdbJHIPelvtDQQd+zjiUe5iiK8hhw7nbzUjOdjBPCxpTurQRI5BDiNUiDBqc61uXIYKCHRY/G78f49u3KU0diqkxxHcbrPxNiyjXaACwZ9Myh/EvOBwDs2SRl9+K7uPHHNFV6r2EZvj29Q+tLv27SDuemQ2v7EC+6mMH4JBypbejSuKguHsTPkP2wMwllPQeWvRFzoiX31UH2+lDD4zC+iZBQt42vjUdwVS3dLxOHev3IdVhJnxVf7Lj25I+B6/Ilnb7OGpdlkglXcHhb4rhe9PuJElhNauj6blk3UcSogEDeA4RUssHTpwlmfCMPTmpiFzWOOx/DbJZW+6T18uPHXqrblYnR+t99VWXkZMViLJh37tGt32W7qQcQu85h0vmLfZBhgL1tFrO2JRUBIJmTmDUDYlDWceM7R5APVKL58xQs4rWR9vG5ufBlQQcShnyghcOIJw3tBVQiNZaU5dW6XOmAOScWxsZ/aNesEtGVl4bV9l0ibKb2lRNAJRj1v5zfA6auX36fS83to8Kwtu+SGmo+cT7//NdM6e9PcPLAsGLFCuDVP/H9MMYRQNt2jxtth5sb93PW7EOpl3gyTsHFLvG1Tp5IqbmUXR/qgVcs+/KxFLwyxsUmDrlh8sArqLA/HecFxRPS2DC5r3NU/bhkoVvu3M8XPUUzY+PJnUDYMwDao4HBjt3+wM78GbwZ+PT13uBZPJB0OZnbB2NDXh1qXRy297HRzrrEmJBAgO8A5rfx5l96y7T3IhoVZ7n4ywBoQXjY9OjYqX8uTBuMn91+TDBy/vTupXjZjRf89WB/vBbn1IVzu+MN7vAWLTt/y44kTubQJcb5GpWTQVpdo4mWmmeOED/6W3lUaWG+LUo/i/soEHtLfH0WLKvHcQzRJZiKKsa8ldLznB7DSvx8MWKNwXJcS/LnTT/3Z9Bbg65vQASv+ulwu73AQ81FMHqek30uIffaKamAdDtOhIkhSmdF8RO7fpXbKwNIt8PKaLqS/U8MV1VmTcye3Zjld7lEzWS/RfUjf/ccJz4LP8mEiZbhjJ69IbM3Q7Yw6Gb+fwZJNwArk69WAMErfuS3icofY9gHIJF0GyNknIGiSQieeOwUAoctOeKw8/9WEnzcsWe4Ze76fQ1bjGr0IFfbDqci6vz+kV3TUxsCzllubH+a2CxC3tbKNVbfokAMTRNAQoaJCfRl1dLr7UoWVYytS2q9MD79uSdl/VLpOpegQCmVOQ0IoBGVlb536K6FeUmp9kI7lnQZI4hK48+Nuke3nZ/jeyQ9X7FiRcRv+8m/BIBcuX1j0RhXnr1temy9YXCuhqkhkN353MM1X6DSNsokfrpuea4JiadCS/hhIm3+XCUkVUt7px7OttUzpaomOOJni9gFzYDQMKMnp35pwCpJ6O6t8iAuzTYAMTKOpJbNkhgyljYdMQz66Kmj/H9kTt97VdA+v6d7VdO3v/e78Nf/pXdUzkckaEroPYnT0j7sb3DO/H5f88Qz+NDTj4d9bzn6FXVogr/QBW/QgHHufZNy756GRIGs1WVRXSPLNAk5dPqW6cCQ7JgqcZIxlfxwLqNLVr7/UxBAenvh7wPG/vijK+Gz4nrh2pE/3/S3/xTksA1F1c+26UNt+Zb2J8kiDwygs4ecpARMxqOy9nG5lPjJDUyT1saBABo3UpbtAqLsKXXuiQ94Sx9USwTQYBkwek8IlfaRq6ZK0CSWzsC54/O18uQ6jBm4APNuv4GYQ4ZzAcZ3/r1/B+/8uh8q7uecdtXALdTZe2PAQPbBlbPp1qB5i9HSsQBeNSQP4syXSnIswRLSqVzuGI99rirkXnjJ5EgUSjRuXqk/l+/lqcqNxhREpyKT8m5t+n23v9MRP8fg/lX6DLH6S69Y4fCVf+MvAmhAxE6F4kmOjVdfCxFQQtFrLCv5DaA0dgiei9m2p+aXktonVyHr9/IZLf88f7/0mYxbxpbHgH3me5P7HW4Rx+yIH0cC7agJ8Z5T6liI+TN8KRUAbLGPJE6BAAKiCqiFL6cNXcZ8YjMjgNxBx/fGGkbUICp1UXj1nuACPKHhO8kaTxz23CQkomXCd/9z/+dwmz4OhQE623nipwUs0Bh3vC1ZgDkQDTGxGdVAsr0a8ROXOY4AqkVN1VIunl7mUBx6LGMEUO2ZobYdPRZZfwx6+488+tzMPa14kLHGYCkOM4V4gKHlpgAC8SPGgmemC0TEZXaE0QFJNInT/jrDduvA/Ae8qbEHwkck0b7EbEyVUsuaNUEGW59VxB9IGz+H1qvquJfsV45DGxQmv9W5C4aFfr/yW6M1Pf7dX/4j5X2E8ZYzf3L+cmPEMXPnVFnipdm+FM+1uTfegJCKJMn9QAZplEoS9d9pkB4DcSmH08bIU9BqkLT7xoFjn0EkJOWR8v848x4xViaV/1w2DipvUyWpYlat/YZyU8kSTkHiLSG4DulCdmlgPv3PihUKRPSfEtGvENH/RUT/MxE9XFnum4noV4no40T05656nMPxMIii+iMokQdK2wXED2KMky8Xt8eT96Q5Js8Sc+if0DAk+zs1Ah6PtXQsqKGJHwOLrVcGtSTKH0eOaKPirVIFRc9GLsaa0t1VlOc6pkoMn9VxxGYHXq1k3Lob6tEap2J3f/ehq+7G9NiYPrk2G7L4o+//o4Pz8df+4Td478TpsjlAz1f1ZV/zxDP4qsefDeX159S7lvHUoSEbGnfc4S12aHDBjY/N9PlPz0WuCkqu6WCsw5ilpN4p/eh96B+97URtlC0zZ9+nhoxJjy0f95zx5OfgUDzy6HMr8XOdsMZgCa6d8qe3Br31GQzjJqubmw63N3dxu7kIN35d/mSPuMYl9Q+QlYAB6cSZTLpD4kdvI5QBefXPFKR0RUPKlYQk0d0kNCHlXjNK5nIGkQCyYQKOC4oJNHyWoPVePiBniCxSZDEglPKvyXIiIJEaGwAd4IyffevR3honPWbrlEYAOl/2tfeki7QTF58BwTs/9kbcNNZ1zSgEEwYuyDqnfTAazNUZO+/9Y8kE0isnhTpP9DjJcZN0ndjxBlvaq32WPXPmohQQjRkGiu9PbV+p99L4A3dyHf2f+oxH1Uk6xsREWHkhgYdkhja7HPP9Ka0XSNgQ7MdxRDXPjO9kpv7RreaPxcDr6kCMldjlHQuHrYRPM/HJuczPTaKQLHynlpxLXYZ7XxFCK1acFu8G8H3MvCeiHwTwfQD+rF6AiBoA/zWAbwLwLID3E9HfZOaPXNUgP/Kv/0UArvSLCvfQhlRyqJL0GnarnE4c1bpLlj5PHuIV8VNDySdRtpnPQbnix/pYxJBNGhrUkJvuO3Jpjy36QPxo9Yk2Ku4l8cUWDbnS8lDi6+OxxkcY1iehxD8yL/mKm0/L7Ru4+7c03hAFkPX2BMYwOjYw7OZIq+ZK68vo3/KB78BDmx0A4PGzz+G2YU90xZI2UdVoYZGck/zaSJJzDIaALUfPJACxe6vd4NzsnVKK3fkMqqziNZJzkSpRqir4ggpmqmyr+P5AFbwsNlyiuBnDqcrGpv8XhvucQwy9bCV9VlxzXCr5Q0SPA/hhAC+Du6e8g5nfTkR/EcC/B+Cf+EXfysw/c5ljEVivEpCSr1vtbthOVN3+5hAqh6AkPdbqmyniJ103EkAygedKETFQTsagyjfk9ZKHoyU3eCkDC+Z3gdxxGSZ5WG9gUa/qLgd54UHcG0NLqY0BARzL38Tk2pKXOsOGOn39oP4ffejb8CWbL+Cm2eG3bOCzavvqA69BVIVEw2GRRjsSp+NhGZ48wHdB4WMWmeNOEUBzMmSnwiEkVCgFI+u/D6ZYDnbZapgS0VN9zcr/B2VFl14+J4CWYMprbO41PIYszAnqMZPqqc5kY/uY6vaXLJ8RU3PXXWIoflLwaLO3FStOAmb+39XL9wL4NwqLfR2AjzPzJwGAiP5HAP8agCsjfwBX+mWorrvJk1Dx/fIaQ5K/XLKak9jF/c4ge2ooKo04247cgrzKNyeAkvFUYjJR/LTU45w6nNPetx8HWnBKDrC/9xE8keOSYtYatOhDyZcJpV971zUNJiQLDcTIukSa9SH5J/6LckzGuHvuhauPwoYJe9u4DmRe1dxZ14VLYvMX9me4vXEeif/M5g4A4Ja5i1vmrrNl0PE5OBBAjfLkEZPvGE/XvRZ/vT/Hb21eDITSOVzXMGPYGUxL8oAJHYxLWHI0gZ5TYpS/lpGUSqbGyKTwemIeK22j9m3OybMl684dj4b2Ae3D/2Mkv0rE1qnK1lbS55pijcEGuGzlzx7An2bmDxLRbQAfIKJ3+8/+c2b+zy55/wNI+Q6R838xxLi9uYtbm7s4M90ouXIZYwEQSZ+FpV5jD1XuoagpLp92E0vbyefLnxJBCcQAiHEG9kRP78ucek8E7dFRA+sJk1ogF15D2l7LA56zBAZ861Fv0tsaoLNOneR8dPw18MPq2ODMb7Nn4zpewPn9AAjBVW3yuW0u8Gv0kDN9VmTPHXsGA4s79gwPn302Wadjg4432Kk2pAasOk/E9/Txl7pm1aDbv+oMWAxyq6sWETOAqfdNaQxDf5o8EDb++xCDyzkqGd2WPR+bHiOAyXHmpQOSddbL5t08SkqnKRJiDvEyRf7p9WvnoIT8HjbHbyn39jmFt9BcAqY2vpz4kd+1h7/88fJ+8I9aseIK8G8D+PHC+48CeEa9fhbAG65kRBmIGGACM4EZ2FuTqmJmqDXmQOIc+Ttsf4GSZ9Z+SsRPZbnpuaIckwHwiSgbiB8p92qJh8QP4oO1ATw5ZLHjBi3tY8k0ScdL9l20XBzV6RjMbzcnqRJSiNws47qB+fGLClu2RM4nKCi0Te8IIJ+U3Zo9DLmSsTPT4eHmRaeqRh9isNLZc0QCJbG0VfO0fA/e+bE3AgC+89W/iJ/91FeipQY7eCIMbp4+N3vAAlvExJ8hdslFZuzIYMvWe/1EAiicFR4nKU6lsKlte+z90n5zAqi07inGmyugcgKohinCZ4x8WgmfFSuGuFTyh5mfB/C8//sFIvooXPBxz2DhO0yQMxjcNq7uOJRaYdhWdC7xo8ux5mIJ8bOEjKkFFyXpc+yWUc629b49aLqd2UMpjyPLeCTlZSOxU2n8VqlF3ISfkl6hxCox6bWw3AQ1h37fEONm47JMt80XPBmzx5SnyYvsqKPSA37H8V8tJyI6ILQhlfPQog/fu9gKfegJM0VMxvK91LNoKfGjW76n76fEyhhSH6BYmiXXS3cy01iqaiqhVL5V8osoyf31eLVxdYnYWqJgOQS1kq/L6BxWQqn0VH9W+y5qMqdEAM16IFr4QFZ64Ftybz4pHvD68BX3B4jo/4BTUud4GzP/L36Zt8El3n60tInCe9UvJxF9F4DvAoAnnnhi8XhraAyjtwAzBa87G/4uJwxq94d8/gkP6dl8qdutV8eF1ItH32NLypx8jEVvIYrKkfR9Z0i8BKJkaakPZMg57bGF+ObJeHSSgAMB5MqlHanhCB/3W5Jh1sdQor6WeEzHVCXPozi+SPz0ILTyuY1t3Q051bVR6mtDNjyMtGTx0GaHc9PhnDrcNHdxTjucm3icY9hiCa8AACAASURBVJAOabrkThOAgh/7+Btw20hnVkLvlTwtMc6xR2OGMcEODXZo/Dnp0XpSrEee3OGQ5Kx5YeYEyNwOWKXypiUz46FEztL15s60JfVT/v2dWr+2z5X4WRGwxmAJrszzh4ieBPDVAN4H4OsBfDcR/WEAvwynDvr/CutcSuAhyp8NWTy0uYsz4/xajsky5UHG1ENGYpgazGMPM3c+BrqDT67KcJmg+JDXznj4sgseyhsCLLOfAMUwT5sOmoEfDDCSzRdFjC8B69BE80iZjEvrAcFfwFA0aJSfrTdrnEJOLul1SmVfgPMDEk8gAMEY0nUIcwGU4RjA6HMRH6bT6yIP4LVSwUMVPzWUiJUcOfEjv4VQceVUZQLhkJKpuJ8hqVDzi6iVf+UYI4DmjKm2zrBU8zDF4RISWhMx+jzVlDN6+/J3zYz8kGtW289w+4d9ds+wxh0rTgBm/h1jnxPRdwL43QC+kbkY7T4L4HH1+jEA1SckZn4HgHcAwOtf//qTfotdFyX3vyoE0M422NsmUQCF5dW9fE7CIZjy+1ir1LVrdHyzlxsSPyUyOy0DjiXqpSSCTgomn4la26tTtM+PCesPfV+EXJDyLgNGw85Dx4ZuXhRJH9iQkArHlpev1c6HJ10cWeDID0smxGENVOdPAhy1RL58jHGj2eGG2eGm2eF2c4Fb5i5u0s63sHfHWTMuduSN9aX6fZJwKM0nL9ozdNQAzQvJNrYhIcsh8dXDEZMXksgL9gXWk2pqLF4R1GBcVbOUAKr52lymkijfD2bsa07Ukpe/1TBGBOXrybleSZ8VA6wxWIIrSYMS0UMAfhLAn2TmzwP4bwF8GYDXwimD/kppPWZ+BzO/nplf/9KXvvRk4zFgbJse5xsnL32ocSVfeYv3QQaqlvUpvK9NkqWrhP6RyV0URyLlXd7VS/YxvXxCdhTIpxKcZ42v5y4EXNrUeS4acqaGDQgtSVcKmxAuTdLtIj2Xbhvlz6TLQ60zFwC/D4uN6XFm9rjRdLjR7HCruYuHGmf8fdtc4HbzBbzEXOCm2eGcerRUru/Oz3y+X9dS1dQzl3DGi863yfpsl/u5bXa4ZVzWS+TdgSjLzkHsuGET4kdUP1ufKdSm3VNqphy5ciiHdK4bWz/tcBdL0WT8Le3DMciP7qYRavpFLYZ0n6Xtj//Ec5CXe5WOPX9Pr39q4kFfy3yfU1iqlNHnJN/OqT2iSp125py7mi9ZPvaat0fpvrFixRcDiOib4Qyefy8zv1hZ7P0AXk1ETxHRFsAfAPA3r2qMgg//3v8YTWPFhxjWErq+wd4a7OzGNWQ4IjzNS1Z1R668I6fGcoKofC+qfTY3wVi6N4o6XDwIZT4XnxvdVjw/c0nnJ8TuX2IWHdqjZzForUxWz7Gln1KnMB2r6nlWSr22Zo9bGxeDfcnmRXxJ8yJumru4RTH+0cdZ61glpVrSvMXFk3YQU0h83/EGr3nCVUKK4bZr4mFx5kvpzsgpghqwa8zBG1zYDe5wiwt2ZWM7SKdWCirpEpEzFTOXyvbya1jD3P+YaSNlCj+19fOfOci3ufQ/vNQxTOORR59biZ8VK2bg0pU/RNTCET8/ysw/BQDM/I/V5/89gJ++7HGkY/JlX2Txks1FUFvI5HdK1MxrD/H4uZdwgVhag35K5jB5uPfnw03EkXwaM2scUyA05GrX5fy62nInN4bv7tVSHxRgZ6YLkmMJsmoqGRmJbs8u+5VAUgd84tOiy83kuHpVjpQ84IcMUzS3zom4pByodH6KQepxD/QlP5wl62rVDxDr83PPn9zfKCe24jZrkvz0/JfeB8aJn0OxpCxudDsjKqCx0tA5KsT6PnOFXZkwyVVoc0q/9D6mPIAOJdTuJ3KHVsnxisvHfwXgDMC7yT1gvZeZ30JEjwD4a8z8rb4T2HcD+FkADYD/gZn/n3sx2Nb04Abo9g16a7DrG7y4b2GIcd5scWb2MMaiITWHivqEKvcYpcJpqUdr9mEuLpUTlwigWcS6uidNtZt3+zLJ8mNzQr49XY7vWrDHRJAQEq0nRGrGvaIugZ9v26S8f4+eTAhmOjTYUROaZYRSfHXO80YAOXIPxh6EDhu01OMub1ws5mOvG9JoxZfb3/YJt4ebO3i4edEn3/Y4JxuOswQ5vnPqcZsu0BvjvRRNEm/ra6H/fvVjz+EjzzyKhtz5DNuEU5xYdQ/fcQOgceVzADp21gCg9PszJHIo+d2zvtZ1/5ux0qba+9JkpQZR3pTWOwRlo+rKtVJjqx3P3Nl7bde+Yg7WGCzFZXf7IgA/BOCjzPxX1fsv935AAPD7APzflzkODTF83hin/GhNVBvMwVgnolLnm3wZWS4nfq4Kl2F4Wqtpnl4PAAhdokiyvpZ971VHNnTkApY90DmCJ3rpWFASwBjqsYFTPm2ox7npcNPscEtqzL2ZYpSPp5PynJHoa/vHvvzn8cGn0/LFpnL9E3UOc5BlSxlT7lUk6wBDgkPIpPj7tARHiVypEVRpYOvJuGydfHva4Dqsq4L5UjY1IZeQdnPLURqT/rtEbk0RcKXtH0sClYiVQz3Bpvd1/PdjbumXJoB0cH7ofXGYNT+cpFyx4kEBM7+q8v5zAL5Vvf4ZAFfSXXUMjWGQ9RUyAHpr0NkGO//TcYMzpHHZgAQqfKYbWeTEj3ShAubfn+L2U0XPGOkzOFb1+Zi3WVCQkrQ1Vx1ERbEY1Kyigk2JnxKxoMuLEGIHpwCS5NKWvM+g/7ujDSxsaLyRH0utDB9AKMHXx9WaPbq+8U09GBty22pNj5tmB0PWK64vcE473DYXTvXjPY30ceqzLR2/BC25krhz7rClHrtBnJQSQA0sfvzjX4s3v+r96Lx5tcHQOFtQSm7oxJH4BgmBlF+XMWiyKX+vRq4kBFK2jzkE0GXhUBJpCVbiZ8WKw3DZyp+vB/AdAD5MRP/Av/dWAN9ORK+Fm4I+DeDfv+RxBDTGGz2bHjcaV+F8ZrogDdUlUK7zAYUHrNBZqZjBHhI8xf0Tq+Dh8hQ/0u3L+Mn9FEanImltRx4MDQhzfH9y5l+6UGypR4fGd4fYAdgOzv8YXPcu6w35yCt6fCW7dUdhDCeBS2v2vlXqHrebC9w0d/Fw82IIPM7JFrtopOcl61RSIXW+5omn8aGnH/fLOGNBwCmPSl43BnDZJN9hIvEuqmQ/DTh0znDbsSclfsaC5jkB9aBsiZz5Y8OMXgUMzjdA2sH3idGxPja93RqRMyfGr5W0ncK/BhjP+M79/yzdIw4hfVKj5vL3YdxzJyVUauqf0nL5/ofb1oR6HNuUQijviKf3L3/fMwJozTqtWDGA3K+Z3U9vDfbWYO+9f+B5h9yw12YPlvn/vsmIn8SUeCYBVFYFReJnSv2SY9IHMiOXks8GiqKyukQ/cOckUNx7JIAMwXet8mP0f1ywi1+k1XmfjatUhq+PU8dh0iq+Yca56dBxE8rMJPa6ae765Jtr6X6Ldr50a+9L1IbxV8kIWNQzW/RBua2TCXLtaw0G7nALaREPZnee4Mq3JP4d7tN9F8aUWDUixKJM9OTqJj3SEsFzKpS2NUUgTW1HJ4dt8r2dp0wqYSV9VizGGoMluOxuX38H5ceue5p1CrXJYLyk+ULMChUfrDiW4+iHmqV+GtnD6lWUejXEVaNhIDV0noJ0bpjCEsNnIKppLDM69XDfkDvXLfZo4P1yCtm+0U5XfhJvmHFmuiRQ0UFhbJnah+DDqY/6ye4S0l7UZmbPegyAU/0IXvPEM/jIM4/68btgYUt7XPA2dD3R/zViJiiBah6wDoy6RRnkP8t9aYDxibUG3fHrWAKotI4ub3PIJP4s44iB95g3T1IKV1An5csvxaElXXpcx5KyS+9Dc69LYuo88/yMlX8NvrMZgV4q/yoZu89pE3/fgXE1bpwrVjxAeO/v/AG87l1vc/dRSMt3Qm9N8n8usVprogooT7QA6X1Kv6dJFXng1wTQFPISr1nKFxnnyD2vhFAqjqEdgMzlib/dnPFnD9miuHYEEKMjCgRQDwvA+eV05JtRwCRjHyN+ivv3qusz08GwRcux1L6lfVRbmw7ntMPN0NmrD16LutxLCJPET4ei+qch4Jx67Lz6p+s3WdmdH69av6U9fuZT/wLOqUXL7hyALDqOc1fnvRvTcxATa633B9qKp2XVLycmSMVMQY4lJ7jGSB/ZlmBp7K0x7UM0JGrydeTzGvGTYw6hlMepK+mz4iCsMdgAV9bt637AN/7894ZAwjLhzOy9OmQ/OoE1gf0fqoBqyybvKcJHXh9q7LwU+UNY7p+j4bpPOAVKbVw5MTHc3zzlDxAnlNDpAOwlwYRzuDbgBhuAXLesnpy6RiZgfT0AxHGxgfGGg1vaO1UNE3oTM0DRXHofDBRb6gPx8xJzN2RyhKCq1ZrnLdBr2UGNHuQ7SsRAaOc7lO24wR3e4DbtIRGKIQDsztGOTPDJcfvLlSrRm0n7B4nqJ//mHqqGKHkoHLud8L8GisEle9KL4vI148xcvbOE2EkfHtzv4bUd6dZVJcP0d9QsJoxKrcrnkjPVMflgfjpwz65xts6YsmegmMwIuGK2OBtjvu+SEqi23ilLG1esWHF6MBOMsYBVuhQfoxlJAPmSbJ2wKZE/QErw6PdKn48RQFq5mxM+ullGKU5KYkNOYy/xz9Gt0/UxSKevhti3TI+G/3KfK8VgmmwwgSQZKQcCYFjiGqfsMZ74aWDQk0Fn3BjvWGeKjMTioNw9S86R3KsN9fG4k/G69aWV+5b2CekjsZcornXstfOJQpmbJTYSAqgB4aZh9LbDi7TDBbUuouUY/wFIzmEPZ+IMAI1lWCJcUCyvA1ybd+tjTrmqmqQ69/tviSZJGYmT9VmR+KZG+JSIlLxNeo1QKXoMLVQMzSGINJbYQeh182MwWLt3rVhxalwr8geIqp+bG1dj7GqNpcY3ZlhKktAaCTRG4NxL4mcpGrgOCGPdvwD/QDxBAAGxzaf8PQXjy5uCSsUTI1G2y9gBvi24Sa6H268LFuPDn3tg3Hojvj4EUzwgfYQkatHj3Oy9YeQ08VM/Fg6BnAHjnR97IwDgO1/9i5Vl5VgMOmrQgNH5IC+eDxfwlFUyde+bcG5nXAPLkfgoH9eQENH7WuahkO5XEwmDki3W6w27Xel1po5zygNm7PinMPbgcQhKBs7p9qevaZK1xbgx+NS2qwH/iLKn5IU2pQSac8+bakN/v4DAq9ngihUjIOLwE/wYyWLjTZslUQP4ec4ndErt1Y1PftRIdllujvInn8eFjMmV3Ml9XyuUpZzKkyEl5aL2I5JYVF6H/WRKk1OgkVZrXgVkOXoAbalHy873Z+vjMAtTTBgU7+8JIZcuJ9YH56YLXbnEXzH4+xCKxE/vCROnwnGK6xbioSn7cWoa17HLNe+4sK2PpZS1Q0FJ3rPBzm/JcPRYivsn6OSClNS3FeInR+0zOc5amVi+3rDFOQfSRB9VzQT6sv14SsdZewaolbH1zCvps+IkWGOwIa4V+ZO2oxyfRGsEEIBBKdjYNsZex+1N+2AciqI5XUWu65Q/dVKrZ5OQPhZxYs8zEG4/0xNMQwTLbpLvOEq8DVsABqAehl3QFRQ/sIDP0uQk0MB7ieLxtOQspMVIMZA/6N17sCGTI+Vec4gfQwjfKT3OWQ+wnvCSTkodb0IAYsDe7JmgSZxQu0oYBMDJuS2QIXk3EIvhg/gUAbQU+ntVQ15SFtelSHYh/bxKFlW2L8j3M2f9Kcwup4J1ZWycmlkDy+8D+Zj190AbXB/aje3QdUo+QGGMmPYDKo0hP1eXMf4VK1ZcLT74rd+P1/z0XwARozGceDKeNc6Dr1VJGo2gBM2VP3KPKHji5eXZYwRQifiRMYh/TFgWykeI3Jwn8YgkpGRcUpbd81C1FJQ/SD0D8/mzNucf0nxDysB6rw7eskVHvfdf3IdAoRdl9linssI8L/FZS/tAvhilynbkj+tgJv4+taSb9t7pQnLBvTbBo8epf1q4DlwtetfNLFfxVs6hBWHHDbYErzQfdrkU9XEDT5j587j0/AtRFcdUJ33G4tCeGZ0vhbMAXvnY83jus4/AR9Hp2EfK0QTHlJDNxRgB9dJHPnvp+1+x4jrjWpE/G2Mh3b5cO8feP/gNb+55N4D8s1x1kqOk+AHihKPbVYd1DshaS0Ax1gZaf1Zq35xsD85bpyGGdH4AAS1EheMm2p6HBnwlAijup14OJsFHCzeBbdEDxgVqYqYsx7hD75Qx7Ai4FvFaNdk5KJ17IVmE8HEBifsuuN8WuluDzsaMXZ0GQib1icIo7wb3U5/4atwyd/HSxmDr92XhMm0NW9zhBsAZzm3nTgztcZ6Xd4WM3TCAGRICKrM4Mn69/GVCjy8nmUr7diWa5ePKl6l9PthmVtJVKveagyXlW6MeSRPqntr2gJGHgLzLWSg3MAcRI0s8yRJSrXAs+gFNjyfvUif7lWXGCKBDPIquFGvWacWKIj70u/8SXvu3HAHUmt4RP2aPG2aHM9MFP77afTEvBQ0lrQVVTuwoKV0zLcAmuffkHbYkaTTVoVUnflzcZIrxoew734YcY/D7GUlO6tKvparkdMwultPeiyDXfKGlPVpu3H6Mi3V7mNDFyioyq7htFQNr0kfir3PqfOnXPnj7iFmyPi4df1m4eTufe0tq9IaAlixumbsheJtU6utS5EJSqDa3HJO2bY+4fhJvWyAQPz0In3z25Whp/ranSKsSMXQZZNFK+qy4NKwxWIJrRf4IgrqEXGYgx1grTiCV+moVUMnUOVnvxObO+UOQTM4ytjHoWvLyttPyL0doXEE2AIyeGA1HhUTo9MTAVkqACH4adz5FbrzlrJMm2oLfD3of2Fls0SemfSVfHNmyTLa6K4M2U5bgplYT38MMro0QDgbRW8DCecNYkHuH0kDEUDQJlPOWb0+/f3pN2elR8xCaQ8hMLTNm+LwES9eVID9fz/huK5etysn3U2sXX1YIHlmyVhhnrgoqKYHy/dfGF/ZzH5Z6rVixYhkaYmybHufNHjeanTcA7hQpMn3fk9IqraLM26znBBBQvlc5z0EhLFLipxQL9QNSCT6GqdxfKXbllASkO1bVEfZEseIcxDbwLgkm3VddDGbRk0liTkuibhonf3LSJ5A/ximBcuJHk1n5lg280hoclDxy7bQSXdD6GL8n4xU98ZGnlpiQ2K1G/JQSLmNXqUasGNCAsKqWhY3ECXYitjl1iVdpjIcozjRW0mfFiqvFtSJ/3vWmt+N3vedPQMwEw2R+4MNDyOBMkCLH+n6UkEzC2RQZMjJMxaAjVRvVTYmL+x0IVQ9HrgZqyE3uDTNcF6wePRGk5XcDxk4RQDrTJgFIqnJKSR9tMlhS+2hDZC05zokf+TufkJ1xODv5sdp/YrjNLoD6XH8Ltza/EcdKPuBQhsd5a9G4ldj1KzmfB5A+eTeFU0Fn5sa+X2MlZmPePMeQOaIiyf2LauOYu/0pwjXuP33oyDuSHduOvJTxdqVzkXDJkX9X5z50LO14lnsO5QRQPp7iNgqlcnr79yXWrNOKFUV8zc/8eTSG0TY9bm463NzcxUs2F3golHwtize0t05uKh/NfkWhk5ZqA16BI0kiP6e71/vxBJ7a5thcICpM93d8LyiMCtvu/UwtSaFeG+QieisegkAOeP+f3ifBttwDZoeWoxmy3o1TgDtSpaaU1xYDQvxI7HUe4q+62mc4Vj9OsoNS8EF5EwjnxLC0R2OcLEa+G6Xx6rHmybwS8RPn2ahaj+udRnEjKMWbcowAwvkD80niubQj2eXJwVfSZ8WVYY3BElwr8gcQbxaf2TB9IEpGVTBKoqvVPLYgLZ4q9zoGpXIHZ8JHYQx5DXtugizvaZVSrlAKagUmpb6xwWCvJ/LyUh7ISvPSrzE5qA2TLYXAowV7Yz6n9jFwhn6yX5l820BwOfVPTzRaDuKCDFfidU77qtKnyYIQ+OMUSa07f3E5ed364KalPTpqknOsjQV7GFxwi5dtPh+ChsaXup1T52rToYkAA935SvYHOHl2eu6HhE9emtdXLseh3jBzMdeEuaS4mrtujqVeQFNIfZFo8F59vXifCOVLsMUW9vp1afupwqucrdZ/60w3EP8fcuPOkjnzmLmz3n9eYqZRLEvjeGxjBJCMYY5Z9X1L+gBrm9EVK0Yg3b1a0+O86XCj6bwZcJ+Uey3xRCyZKxfVQIqwARBUOJr4aTN1eF6yX4w7YEOTidK48m6LWmEkJV+lmFQSQu3sMzEfEodJ+VdLEgMCDbokSSFj6GGK9+18HokeOTYprc/VPmNXWOwBQocyrXyuJpAIZ8QAXOt3aw123MA5+cg+dQKyfqMe8wiVWE7MlHWzk8tGo46jEWX8Aowpk07p/SPbWwmfFVeONQYb4FqRP9/489+Lh1oxe3ZKkDPTzZITl6ANA5NsR0b8LEGpm0KN9EmWqUybo+USBeJnDoSIaS/pgUs6W0lr897LY8UAWV7Lsj3sZCAiJV7SnUE6Smilj9teOhFq4ic+iLMnxPw65NRKUWE0LPfTtf+Wh/X+hhgtnCopRw9Xg28pI3YKqpGcxMrR0JAAuiz1zykwFgxOjXmMEFhKdpWIn/Tz+Q8mmgASckYjIWsqKq/5+6qojAo+Q0u7bU1hzI/IlV1wkQCqKZNq97JSudjYspdJcq5YsWIZDJzZ89lmj/Omw82mw02zC54wJdPkudsFUCSB+jxuozgnC+EkxE9eviTbyLcXx5nO9zVo4mfqfivNNgyzSwiR+BSVFSFuu4c9vEsCL6iimX28FyHxVjsxbp30qMVd2ldxdFvK61BIoDHINrfkztMtOB9FYzcuYTiSWJlzTABCEhFwcZUok4QAcuOYV8pV88vUn+frJNsm8eucdRizcEoC60sfefZk21qxYsVxuFbkz7bpXRtRT9o05BQljVn+oBODhonPUVf91EiesQBHP9RoxQ9QNuDTD0K6dh2IRnxz0MO4wINiKVLvvXcGx6XUP0sCkBgMuCDHknrfT/oxCOnDa3fsFErEhuOxo8GHjFmPI5R6MdDBtVjfwZvTEoCEbCEnXYZkKqOqKkB1HimN8ZwsGnTYGm2sLdfVq57g9mvUGMdIn1y9hGyZmgpoCmPt3uMyw3IgTQYUy9aWjsP/vkriaoniR5Y14fsQlTLOpJrQIF7vBBSvfSkorRErtc5qOeFSwhLT5NL+p7onyvj0eAbbKCiPauqffJx63VLJ5b3E2mZ0xYqIN/3cn4Flwr5v0Bhgu9nj5sapfh5qLnBmIvEDTPt+jaHWYl1jK23kRSEsPjxKwXuI/44j33MnmnRsh0AMn6dGVCvfGW277dU/LdiVsFXalzfqnpbPcclyYd4bkj5uXPPQ6/0VPq+dCwNHAFlYwBNAoZmIKh8ea55iVEynj1H+XpqcqZVwTRFAyZhCIoei2ocMOtZzKIVlbTJXjhNStXEsHSOwkj4r7g+sMViKa0X+AF5eS4wbzQ6GYuvOQ1FqCT9G/Bxq4DdQ+lSInxJitkpP1rqjhXoon8hY9eyyTtJdoWeGOYGhnHSdCFmnRL6qSpyyf+CQdaG0RExDsjPi6yOKpVIr0VLZkRA/YsDcoHcKGiXtdQHNfP+oX9m9HH/wVe/Dx559xI9nWO4mKqdY/jZOltSIn/sReUA4a52Cagk4nASaUoEIwSXL1LxtxlQ/Y4SILpfKPYxK95U527wfUSpFA5CYUV9lG/frov4hoscB/DCAl8H9e7yDmd9ORD8O4Mv9Yg8D+HVmfi0RPQngowB+1X/2XmZ+y9WOesUXO77pb/8pWG7RW/f/vmn6UPL1UHMXZ6bDlvbQpdNzlDRLkM/TQsLM8fgZLQ0aUx0GhdA0GVWDawDhfBd79aA+ptA4RL0hcVhou57FXe6enSc1kLxOxzBMtA3jF5WsYlFtDbcj7+fr66Rd6TPni2PRYIcdpd5JomJypFCmgoUQgWmZs8SUujW9Hv+pjZbTBKUifrL3bKVd/JLvQYnk0U1OatDrrKTPihX3L64V+fOuN70db/6ltwTSp5khtwWG5VtTr4G62qeGpWofYE5Hr6H8OG9VOmgVXuheFsdx2GS2VH6cEECAJ4H8+pSWOQEInjhaHZRujxOSoVbilZ/NxLuIleLJy5RbpOZ6UlaWPuDaUOaV+0IN9+2OWYKtne+m0cN4E2x3/FPZwqXEz6mUM1VFydKs2MjwawQQcBgJNEUETJEES4kfHTjGbmaRBNKfiS+QJp1OQfxMHXMe5I4puA7b/7ghag1jD1ZX2RXnINybrNMewJ9m5g8S0W0AHyCidzPzm2UBIvorAH5DrfMJZn7tVQ90xfXB3hqwv6dsmh43Nh0eanf4kvYL+JLNF3DbXCQK2suElFzJ/WNL/aCj15x7S4m8blQZWN7xa4oAEr/FMd+foAj2Sh3RF02pN6aPxal/tuTiMMOcKLwtUExE1eIq+by4nwI08bMbMTDWauc5MU/jS8VaYpxxH5TlMhd2/nx2bNAptZbzf7JJAtFtr65iOpT4OURZk+PQUq38HB6SQFwJnxX3La44Brvfk2/XivwBgI3pg9mzqH4Sc16PcunE0MtFI2+PPli/Mo3lQUNN5RNeZ5+PqX5Kxs458aPHFYKVyph1twkhdKyvRQ6ZB/DBk5gJvynsWVQ2AEInLU0QSCASNVw1SbP/PVNu3IDQhW1r0m2owmkI2PqyL2nzKue7RAAJOv+daVXw5jpHwAeMhAvfUcN9poPSdP+lFqnhHGbX49CSrxwlEqFWlpNDmy1PeRVpjBFAelsllP4DpzqH5WTJ8u5i0UxU72/QSpbUfhgDcugqUOpqcuj+x0pKS15Ec9Q/SzuD3R/ge0L+MPPzAJ73f79ARB8F8CiAjwAAERGAfxPAb7/ywa24tujZhBbnG7I4b5zXz0ObHc680XPtf3rOPaJkxFwifvoahAAAIABJREFUWzTxU2vlfui9Za7vj8UwmSOWBO7zCgHErsmFZQQSYzCGQgy21AMotH9P3qss51G7OnMIkZz46RQxM9wn+xJ0DscpcVAo2x+JBeU4YkwZ/fX03NySHTQGSbdT9yw6RnVVQ6766Qdq+HT9GomT76PWUWwuHn7kmYPXXbHicnFPYrD7Ovl27cgfafMuv/Oyr6ERby0IKdQ2n+Ah7RTEj/bXKKmUlhJUS81fRelzqPdP3I6D87ZJ1UDFSWri/C+pMc9NkLXx7sDgT9YJ5WWFB1RFAAEIHURi9w4hBIZZO2f2aEP5l4yjJH3Oj+9+NnPOscSocIoAquGQ83GKEqGc8Km1dR962hymkilhblv2Uyh7Dl53oanrwfu5JqVfAp9V+moA71NvfwOAf8zMH1PvPUVEfx/A5wH8eWb+hSsb5IprAWfw7BovtE2P82aPW5sdbphd0t1L0DMN5tMSSib2bn3xPMzJ9sshfo7xJxL0MLFLqFcAadNnR1SYEDuUOq8eA1H/SOw1hbGjXUL6AG5+vmBGx4QdDDrl9wbEOdORMWlJvxBBOj6w2TqlMWuvyYZS8kesAkrxSU78lMqwLgNT53SuEgo4XCEGrITPihU13O/Jt2tH/lgQWrLouIFlg54NWtNXSZ+pB5mxACGV+ZazN7Xlx8q7xpQ+GmNqn3xcJfPpEukjZMUFN2iJ0RVIHvl9jALIjUlUEOm266THaSdbA+Dcd4rQNfYCF1TEbMkt6vEidbhl7uKOLZBv5K6dXJN3f+orcMts0Zi7kJanAjFcvOO/BxfcomeDl5i7uIAJxtU9fEDDAGg8czN1LWqExGWilE2bva7Ithd+vY4lxNIuayk5s5T4yNU/wQjbf+2m/H+G2yuQt0h9drTH0KBbXMGsfFkns4VEccGIunTf0Q9ySx7KlnQJuzQwLivr9M8S0S+r1+9g5nfkCxHRQwB+EsCfZObPq4++HcBfV6+fB/AEM3+OiF4H4G8Q0T+frbNixVGwoGB6v5X27ia2dz/EBHksQVX77DKIn8E+JsjssWOV+KFUAqbLvsJ7Bf/FY8uIls7Nc8udcrWKQGIqAwTip+PGb1sSZk455tTRwE3ToWPj/B7hyJpOiB9223F/U9KdC3AlYACCyXUggVRybXZZ2Qk9fmrNOsZwirbsc9U/K+mz4oHCvY/BnsR9lny7duTP1uxhyOK26iixtE373ABhSQBxauJHK5aWEj+l93TLTgChxWcDOpnpc7p/Sv6e6vRwmTDwJUpCQtGQtGhAeJHdw2zu7VP0XiInQ9cPvVpJ1HOUOndoHElJPS54g5vUuXXknHiCqtZTZIzsqJVBLTFC1qitp9UkuQfTg44pwkM6zR3aGUT2MenxNbPMKm8lLygRP0vGcoziR8ZyndQ4J8A/ZebXjy1ARC0c8fOjzPxT6v0NgN8P4HXyHjPfBXDX//0BIvoEgN8G4JexYsUJYeBVP5s9NqbHrc1d3DQ7bGkPabOeLh9J3FJZl15uCnkp/KlIH1Et6lhuvBGHlBtFz6H8HpoTQC7JA4CBHRq03OMCDMC1+LaFh/dScu6gFvAnivFy4ic/4z279zTxAwCveSISDu/7zFPh7696/Fl86OnH3bog7PzcJj6NF7zx240JzTAns8U59ehAOPdXriFpD+9QuoI1Y+nLwKCMKyf4fHxcUteXEqL5MktKvVbSZ8WKBHNisPsy+XbtyJ+GOHnI0WVfUyqZq0CN+JlL+gDjxM9YcDPVucz4h7MW8J2vgJ7qnSYWGz1nJM+cz0p1z0uDlNp2e+0vpFrP12AIaDgNJuP22Mm41TZEtu0MBl1duUzyIlVOvgMw6GGdDJpSMu7UmPMgfsqH9SUlX1eBqVb2c499eQvYkVbsIwTQHOJl0Glr5namzMpPiUkz6gPKwu6Ltu/3oPbSy4p/CMBHmfmvZh//DgC/wszPquVfCuDXmLknolcCeDWAT17ZgFdcC0jZ19b02Jo9Hm6/4FU/e1eOX/lnyVV8ci+Y1bQjST4Mm17MJX3G9qXvS9KoobR+0kkqKz0DhlYDpfJ96frV+5ggXX6cADoEpyB+SnHWyx59bvDep599OV752POj23rDKz6VvNbE0Ieefhw7NIH86XijTJ0bP8dYX57vrtPWK7tvUZ8k0Q6dMcZU6PPK6OIyFhyMlO88/wr/uVcz5RULKuY+VVy+Ej4rvihwb2Kw+zb5du3IH2fyx6G2vGdCa4ZZlyUBwbGQgCZv3x4+n/GwMzCjLhBYU8SP/j0Xue+N22dKyJyig4He7tLP5kJnc/pQauYmS206XUMLxjn1OKe9C8ry60aqjh8uWLzg1o3fBySB/GGX+bJMYTs9CEZ3ovA+QFu2AA1NqI9FqSQJgK+tT5fR5UP5w3veGrVk9HzUOBf6/8z9hteOI1fN1Eyi8/Xy90s+BFOYImhL+0n3NXYPGI6jtt6SUrSlxNFSUlE/kI2XWBzvxXEo6N50+/p6AN8B4MNE9A/8e29l5p8B8AeQZp0A4E0A/hMi2sNVlL6FmX/tyka74lqAiLExFhtPALXU48x0TolRVCFH5WxO5NbImKInoyJXDunmNQa571iY2W3pS55DepxAmfiJn5FPwrnyr9z3J1f5LPVgHEvGLcFc0kfw5ATxM4XXPPEM3v/0k9hxU73fWxhfVg3/XRB1Ve9KxnwJ/RxfxVMjJ22EfMmJn7nrz1mm9F1YSZ8VX0y46hjsfk++XT/yR0lsAdfaExgSP4dg7kOIRk78DD6/ZOInL3ur7kOVrEiniV70xyjLjd16y42erxK6u4SgNOG719N12M67Z4+Wm8HDsYF1BFCyf4MOG+x8hzAZiXgrlR6Ca2TCGGqlX/r9vENYjrQ9eaqOGSN9atu6hzqMo5AbJ8+5BocqtA5RV5X2VdvOvSq9KxFHeTlaVQE1kvGfUgbdFyqgKwIz/x2gfBKZ+Y8U3vtJuCzVihWXBuPV14YYrelxZvaQRglAhbhR7/VMSTwj/8vVGCdT1KRqZh33leO3uWqfpHR/5P4i2yt5DtXGPtgvDAxz8PyxnsjoMSzB1zHY0kTcMQRQbuIseGSE+DkVvvaJT+MXPv2q8Pq3P/mrxeVkGVH/vPKx5/Grzzzi4t3wnRsvAZuLpZ20JKEppI/bfx5TmoH6p7YdQel6aqJwJX1WrDgJ7uvk27UjfwAJPixKZnt5NqhkhDxcZ9ygdAkptLSzz7GKn2RbgcihwXs1iEFf64MKnVE4JHA4pWneGErjSoMiyTRGFLuPJcfrDQLBCamWtpx16oP4ECrSZAPFpYWSL/n+9GySB/XDyYRh8Fcmuqb9gETBo1VAYlhc6mKVq37CZ/dJyZeMearkawmO6ZxVMkM+BlPfGT3WOSTMUoxlsWXfczuSLe1AONjfVauA7o3yZ8WK+wrf+PPfG8yeN2Sx8QpsUWJr75tqiesIEZR/XlIs5suU9zFP6SPQSTwZt2WTHIO+59SIn6WJx7mJuJLXz9zE3DFl9PlZvAriR/ANT3580TIfevpxfPiZx7AFXIv54KkYibOaEugqMKX4KaF07Wot4l/yyNOHDWzFigcBVxyD3e/Jt2tH/hg/4YrUExgGBEuMkKdQaj+qJcJAvdxrDDXSx+1jnpxZj80kQcH0P4nUmrtSJO9VUzEcdOM73GjwGEyRT0JedSwy6qGhs3R7kNfxKuUZIVd6ddN06C1580ca/PsPTB29+qdnC6u7d6iyoIZ6tOQypFv0aMkGMmWuikarfOaUSuXbDOvm11BlHzUBpJGbPOtz+yBiCalTM3qeUuOkLd+XewyVyByNsWPQJW5jJWQlQmcpYZSPYy4BdCyuqqx3xYoVDhtj1d9uHmuprybjNIrEsVLSDpoqVBQ/ZWXRcNsSp9UMpktNOjTxU4JRYygZTutlSshjVguDC964DrYy77Ii00HJw76QQKcow89RUlELxkifn/rEV4fz9m1f9oGTj2suXvPEM/jwM4+5xBvH74llbwUAxpZooJQuweaJ0Jnzoawj12wu4VNKtDZEg/Vt8pxAuPXyz8za/ooVK764cO3InxwhMDhxi88aFpuVkp0s/VpC/BybMdcQ02dLooYp7Y8AvnrSBxgnfuQs9ODQWUvKrBr2bT6FrPA14FAEkEbS9YuAhtmRM2RhudaDy103kzzoR/PG5CFevecCZfZ/1wkq9145w3MoaoogediXUrD84b/k8/OgkD6X3X1qzGfnlMgJlRLxUyKdSkRM3uq+tI0aAbSsbfwywku3is/vs2Mdgi4djNPKyVaseIBhiLFt3Dy2MX2x5GnufSKoa2GKip+x7q21GCm/R5TuGaVy/THipza2GvGTq8X169KxhAYccHNrsevXiTx8cpRInzGy58c//rUAdAIznq+f+MTr7ikB9FWPPzt475PPvjwQaztpCY9pEigngC4LUvqVq3wMTFHxtRI+K64d1hhsgGtH/lgmGGJ0vEmyMEPp8OWQQHk70Dmqn1zlE7ZVIH2AclBTNUZcQHaFrJM8SIFwwQ1cyBHLNgxzyDqMdSM4FeYGNPmRiuKnY8Id3iTGtC1ZWEuRaPE/MvGXIOqf28YCtgMM8II9g2FOSuncsv4hOevaFcq81IOsfN6Sy5Sek0Xrs1Bxvyl0IJAHfaFkraL+GSNmeq4FOyKR9iur/QnxIwqlse03l5iZPAST3acmyJtD2rsn6qlQWkfq/flmyxr1Dl9DRZLAkXrzysFqx1i6xxwy/uF260qquhHs8m5hK1asOA1+9l/5L/At7/meUPrVkJQD+1LpETWiVhnqmMhyuZy0RPwc28F1TO0jY6mhREhNET/565q5vySuLJwK2yj1T1qaTqq0vNwefAl6nyiT7eX70/ixj7/B/+XPUbbbWpx7ryE+QBaEM5JEQ2oRIE1CcgLmsgigvBuY7v6l1T56/zde/qmTj2PFihUPJq4d+XNm9mjI4qa5Ww0ELov4AU6XeT4l8TMmt66ta5nCQ3zvy516cDWQuAy5cYn0yUdrUO8s8elnXx6myR4mPNhaNGjJYocGDVufRevRka8Dp5hVK/nl9ABacoqhFr338ql7RcVSKDt4L2zXB8lCRIm/kNvO1clowjXPAzek5z739smJHx0gloLGJcaUSzp9XQWmvXVOl4S4163X7xXulVH1YeDV82fFCgUDp/rZ+JKvo7bl19fEy6mJnynSJ99/2Gee/Kr4+wySjzPv60L6mKwMX6t/SqSE2wcdTABptU8+T5dUPz/28TeE89YEAiXtAmnZDL4Ln3vuMQAIrc7vNZ587Hl8+tmXA4ixjBzvP/rsI2mSjdIYJ09sLTWABlAkktL3ht/Bs5d/cvF+Vqz44sIag+W4duRPzDi5SWZL/ajHz2VibkvQHCfpTHZgWZgOUnr/yG8kAGEe+NsYGNeSXCtBTpBt0hgb8VhLUcGXP/4cfvEzrwQQHyq/6vFn8b7PPOU9BSx2MNiyHRBAJQPAxqs2tuhhiVxQmJWd5Od5TrlhIIC8+ugqSZ8cuXonKoLKfjVJOdpAMXL/kQtzUDLgniJKhBQ7JQF02UhNvocdueqKn5GOXQeql2S7c8Z6X2ENPFasABCJH/G90Z2+liJZb8RbL4+T5nT5yg3hSyVewLKOrEtbzBe3VZh33DhcPCIxioHEu8PyLynFP4YAyomfxx+tt2ifE+u++VXvH7w3Fht8/rknrsyk+Msfj3FkrRX9yx59Dv/os48MYs5/8tyjPkZOz2+JBBpTCkU/oPL3rWcbruOq8lmxIsMagyW4duRP7CrBWXBwWuJH16LnGAQVlYegsYDoEFPn0naTQGLiHOQPXZbJkSPe5wUEdOy8aEr15sfIjcc6SNQw1VmiNIm/4RXppGmZ0GGDjhmW9u58kYXNCCAgkkAGwDkRetPDMKPlHh03oYNXrctQ402cgWGJjgTJcm5bokGQUDqf+jzr81Yr/dKkzljglXc6C21Rw7Y02VdW/Nwr5CqlKUyRDaXX2qy7Oo4RAijvnJZ3/qrJ/y8L+rhyAmhqvVMSQA+W4mfFihU5tk0PywZbs8eZ2btGBqrTVw2T8RDn5VJL1SxD4ucYwgeom02PeTJqL8C5427g2r5fcIMW1quN2ZXde+VxYgBMdlB2BQxjiFKM0TOjy5arET+x1CtP+KTH39Ie/+sn/0V8afOb+FJzgZuGcU4Grfet+fxzT8R1icLvO8+/YraHzfs+89QgrvraJz49a9250MTPM5/1CiEQDBitIm1EyfS55x4rkkBarZWTPiUT583LPn79HuZWrFhxMK7V/eKPffAP4aHGS2/J+g4T9tKInxy1kq+lD0HH1q0LlgQYOeTBVAigjl1pVE9Scx5NfkveP4v2VSB+8ozTc5995Kg2om98xVAaK0SQqIKAmF0DidIprf3WaD1RJAiTNg8JwCWYu2YpgzQgbQ7E1DaKPkT3AfFzVZhLUiwhgE6xvyWYq2Y6bh/De9+xnb7Gztc98/tZs04rVgAANmRx3nRexWqDGruEOV4+Eg/NjYty4mWsbXtYRjxVFqh8BEuInyXIlxcltisxd6RPM1KKL16AOkGkDYJrChSLmDBqaFzxAyAp98p9j+R8Oj8n58V5wQ0M92i9F5QeVwl3nn8FAKBjix6Mu2xxh4ELNnjRtmEuaE8UNy9BzwC8+qpUupaTQI2/Fi05u+Yp4gcANi+bbmm/YsW1xxqDJbhW5A8QS2cOgQ5E5qp15hI7+XL1sqz5kuEp1c/Usul6w3MWHrAY6In86wm/kwnvn1J3Avda9lle7xjiZwqaGPrQ04+742SGzQ5XlDRNmLCRZN8aXxbnukbUCaCa6iftAEaDGvIx6KubE0Ci/hlT/UypZcZMpB+Uzl45lpg9C9E5VsqV+yDp9+eUgOXqn9I4lmKsZEv/rZVMufrnWMy/R66T94oVDzoMMVrT+1bvvS+FiuVQJZ+cHGOEivXpJg2Za6fiprFGHEuJnznePmHZka5ktWX1axeTACCDHvBxiVcLg2EzNbZWAJVawOdtysXPsWfX8UpG8OQI8aN9fjRK19Oy8yy64A12aHATPTqIzyGNklGCloxrrkGMli0sLC6892I8lnTfH3z6CXzNE5dTOvb4o84faIocAxwJJP5GOUplXuZl//Do8a1YseL64lqRP7FjUgw6Dt9WWtZ1CuPVYilHIVtxis5kY+VeUw9Zg1aoar0LZrQot50MKphs82MTu3STqBEcpYlVWomGfRdayf7+L/v7xe1N4TVPPIOPPPOoK+Higt8JI7Rgb8j9nIHRokdPhJYtOgkwYdHxYf+CUyVzJRItP4faVLlG/OgrXSKAdPv3sF6xjXjl+hYkz1eBuaVfc8ybS69PZ+hcJqCmxzVdjrXks9I45hJA98KHJ+9YFt6/F92+GA+OwdOKFZcMMXpuvdmzLvlKStInCJFaIqxEsMxJlpUUP0uwlPiZG7ctie/kfryjJpTjd+QIIFFjp0qfelyWQ2IxF4/Vvd7CuGG9Z2J8rWOxHs7gOSfVLBMs+7iS5qmVNZl1xg06cmTVlnt3LlD/Hl0mav5AJYgK6AvPPwWgYu68kj4rVizHGoMNcK3IHwk0BA3x/Am4FoAsnFCWlPucmvgpk0vLx1/LssWAICd+JHNTLv8ay+iURjcpMy4oqOaoqubiKx//LADgw888Vi7LYetIAN91o/EKIecXBDgDaZeR6gdZztPfoHp2pXhaqi3Iu2rViB/9Xuns6fentjn37C/p+HUIqscyW4mzYF9Hch/HECinVAodO5Yp1MikY9VN99YEeuhHsmLFdYUBw7IJSTgglgTVCJQ85ojbOs3/1ZTHzxhKYwbGVdrDhNtyH8ZQlssmqH8Csc1AJ6VC3IeEnGsF3mTlXUMfoFpyaceMzp+jVz8e47APP/MYOja44A063mDHDR5uCDvewMJgx82wTA+9S6B51VdLe9ykHc5p75eT44z+hlNNLjZoYIjxEABgH3wX83lFK1k/9PTjeM0Tz4xu96pw9/lXDuLhtaxrxYpjscZgOa4Z+eNqyw1ZdNzcmzH46ReYV6N+qvrwdJui9phnGps/OOYElpvc3fm9w40L6sD+SEVuHQmg3GwwV3/I665AWkwRP3lL0R4m2ZchV2LyE594Hb7tyz4wuq0pXGSqHQkwLshlnFqyri07VJtzZn/dO1yg8cfrCCSjup/I+wDCZ2E/AErf3niO5z3oCvlRKvGau37pdWmbS7arcS8JoKO2u3B9TTjpdS0vJy/0d6UJ/1vT5/AY8+bLwqlKvZLStXuh/lmxYgUAd3+60ezCfCcE0Fxz5EOaXJQwdg8oET+5SmWK9KmN9RTEz2C8BbPqBhY7NE5t7BU3LUwSI+SNN7QPkNsWh99jozkniy0szqlHxx16EDpucMEt/v/2zjxesrOs89/fqa7umzSBKAmkO0lngSQYIAmSoLJoQEQEJygYEB1EUeMwgLhgBFFEGD+DAXVElgEhapRdtsgAIQySsCUEQhbIIpmkSXduQ9hCINC5t+s888d5T9WpU2et9S7Ptz/16bpnfeqt5Tzn9z7LinWI6LJqnb6Ql762ruh/Bpa0ynatcnDUY0nDBZ/H6WzaDZHWKO5HK/VQP3V6rXDgq/cHkm5dKd6e3XGcWbKpxJ/sRXlJqwuxobTOS7i0NpnVGkf4mVbIa1W4b1L8OTxvcXEtEgrSIs+rmcNU5ZdDtrNE7lgZZyi2qDDnfFxiU/+mst/GnZi0/FEPY0lx8kdaV8fSFMS4L07lhZ/kOMH5LRAJe2ZEBQ5RXviJSN6TOBQeTI6r/qdsEbfA+SiheZDOIubrEa0lJhWckmOMfn42G03S0aZd5L8WLzboOEAimkSZqOuIQSpQmfAzy+9rVZ2fPE3qD/W3naLwk/8tz4rwZT5ltgtYL/giPWzkOpOPzE4FoDLS/b+8dycnHJXUWtwugu9nrNgBYmDVDrDfDrBCh2/11J9w7ShmSathUixmq3os6QBdxRysmCWJrjokXU3LCx0nrz1f2ymd2BRdi1gKNT57wCrQMcvUpxxw3Z4jgUFUd5Y9t+0Y8hvapHI1oWcxHUUu+DjOLHEfbIhNJf4sgiahw9GQA1AR5jumA9RG+GmSy121TSeN1Cm498rOMqWt3/MiUa8/0zR43sSmpM5PNHa+/jicsWs3n/7K8fQsad+eLYANgGCr9VhFfceoQyJEdEmKJ24NtYBgEOFTlqaTd9raRPlMk7pPdNtW6vOkqCB1430rPoPzioipEjYmSRlcpFDUtt17Ff3uMFMsSO04zvSJchGtixB+UsbxG9pE+7Q6bsMajNnI4DKSCJyIVcVspXxSrioCKPUzIoytUv8mKps+frAGscjblE7cxWyzA8QcGGmpfuWtu/r+zlZiDo6MLono0yXKtDmvvjaUlxKI6PbTxpIuYFuBFULhalSY2n3jnp2cdPQyN+/d0T9zP3WfxHfYvXfHVAUgF30cx5k3m0r8yYab9oJQEBE1ci6SVpTjX9TTqJBs2leevm1pBMmETs9I14yGN3h1bZLT/PKi2aj91mEpdJAom2Uic8EuKkwchxmqVYNVE5Hg+IqLbRLxMyz8lHUOmQXZ97NnUf+z0rMescQKRsdiDokOEIU6QN1Q+yfbzhsGAk83FcFssCxNH+sxHJbdRACKyHXwGCOMumo2sOh80xr5WaZ+ZW2sSmtaVEpUm05geXuaMmvhp2pcpin85MkLQAur/ePFBh2nT1JrcXB97sgGKV8tupnOgqadWYf+bmhzlT/X1DeD0d/TMhEozvissSXCxzal6fjFZQ+yYkpWAEo6eaq/10rwBe5YPpooE6ED0A3/d1BIsR19bYdGq/1U+C5iSVv66V3ZUgGD11IRiVQaTZ8IQJGJWIlP2ZUNygn0j52QjuPNe3eUnstxnHWI+2AjbCrxBwYCRi+TojRP8sJP0ezWLGa62jgXRbSpkdFDjVy3svDinlkIUw6FBY+qb+PeRPhJHcyiWj/fXD6q322hDdk28CkX3/IjA7tQP91rv0V01Ov/HTHoDJbYO3jeT4vKfEb7HcRyH9w6AShN/er1Z+zGLBxcEw6+KCaJ5qk87jpNmypKHRynY1hbmkTozZs1EwG0Br83jrMIIozVOKLbPZAU+w1pX/nCzrOM+En9maYNOMoEH5igi1eDtDCo/l2tmpCLSGqb9RQFn2zQrj2pf1kSQUo6Npmurf3xMrZp4DtnfYm8CJMKLwi+vpykVR2+8zbuXN7FD0dbyBZxLhJ8hm0q/w2vE4aGauiFlPxeaAk/qC8ZZ0Qgx3E2HO6DDbHpxB+gX7SvR0S3xU/9pNE/UB35M01mGfGSdpcoPm+zL1g+XDcfdlzHRbecDMA3e4eU2BEii3JFGreqx/tvPo0nHX9V43ONSxzq+aCk8HWabz4ouM2gC1hqd+qoFAxFZ8J72CrRp6lzlR6jiQiUj/6JGaSMtY0MmnXh59HztT/XoiJLyur8lD2fJ22iftaESOM4zkyJFHNQJ635YqEL60D4mabok/WDyqJ6hiaOcttXiT4wLPyM23m1qgHHwJaiuojDEcdl+8emfp2bnlnppGfeB8tHASV2V/kJgwYf6f5pG/lt1uGeO2/lrn3HhAii4rSuIh+wLrK5ynccrYGYxC6l18z09aWFsHsZgSxbegDWdr1Ax3GcNmwq8SeSEYeK/6u2ha3WI9boBb7qQpotHlxHuu0knWVGbBtDOCqL+pm0403RjNQKHZasR08WZprKQ4xhNJqkTgBKW4ouaYn9toVDoh+w37p0iIbem2xhxrwAdGj0fa6+9WgOiQ5wSJQs7xJxx/LRHLpz8pafP3Pc9UN/f2J30s0BQS8Wh0QH6GAhLLr4GB2NdkGbhElqAxWFX2eFpHGjgfJRTpMwrYLOay1yJUsqLhXV9pmV3W3ErKooo9HjTl8AL6t5tCaif3zWyXGA5PvYVS+IPjGdMQWUOup8tLpdIPfzAAAgAElEQVRJuLKaPjB+tE/+uONGZJf5btkUsDjIN1li6iJlRgWgZL9mry8vAKV0JO7ad8zIcYuOXVfnp4gmk4edTGpa6pGmwl8U0uG6JFFAkYxViyEz6ZRGGE+74LPjOHPAfbAhNpX4kxJbFESgilafFQIQTCcKqI551KtpStyfqan+Am0dI2g2KwBF2YstBlK/q8TNe3ewNaQwLWmVbIe0HjGE1uv5lrHp+xxbsl3a8jN1lLpziMTqWURXcelNet6CmGHRp8rCaRZ9LhOaFtFu3RmfaYhBpbW/Jvy8zbLOTx0Lq/vjOA4AXfWC6DOI9snWY2xCXURPYUoVcbOaPhWF85t08Ko8dgvhp25yLs7/jtXUZGxKkZBSVli52K70PY1K96s6VpmAVEeR3WUp8f00M4UOZ2SFoIhV64EYEYBc+HEcZyOw6cSfpCCvWLEtbLNVVqzT2vHoHysnAKUX85GLcgmFjkTL2+Csg1Aa9ouGHI2m9pUdC+g7GgQnLi0uuEKHpYYC0EhuudEvLLiV5Hk3Y/chURTCcWMO0X6+bxHbbYW74q3sty7fjZdqz9kj4q54G9u1wqr1WA3576kAdOfyLmA0vemeO29t9JqKeNSxN/Wjf5IZpaTTxMGRDbVdz5IVRIrWN6nbkxdy6gScugij1LHqmQ2dfxq1gKYlAJXV/+nZ5GlzZWQjmGYtLjRx6IfqPmTrHUxBv5vla8tG6PTD8mcQsTN/Ach81slxAkm9mUG6V5XYUsRIKlZmkmecCbOOjJ6plegzjr9YJ/w0jcQu899SP6+X8c2Sq9PAH5tEdm8bBdR0v7zvMFxHqN3vdFUEUNpSvcy+VAjCEn80NoGiJBIIccSR9bUnHcdZi7gPlmdxU7AL4BWn/BuxKYn8MRHXOAuTpkWVkTQGn09hw5QY9R95eiFlqskje7zB/ioUssaJFknEELGt4CLdJaKriK7EVomDFbNdB1iKDrBVPboaODlVTuVWHRiK/EkLIRbaI41dIDnLo469iTN27c7c3A5EiqJ3v2hZaksT52gaqWIpw3nvAwFoLRZ/njeFwtwMoqSmccxIw2LQWiTScPvnpu3r27a5T9Iu/fPrbBwkvVLSDZKukfReSYeWbLdb0rWSrpL0uXnb2VWPGCURQMEXmoYPVCf8VEX9ZDt2FT2SbeL+Y1Zk/bT0sUpn6JH1x1Zsy9Df6TYxGvFf+x1FJ/QNosy/qm2aLKsSfsa3T0OPIsqEqKRD2Ba20OEgdekgllRetsBxHGc9svkif4j67bhnJ+7YWNE1Ra3Zq46Tt78uVW1k/zG0v2xdnRhBOGcqpGXTvsoEiLLZmTT6JzmPcXDmonvn8q6hi3mkOAQUG9tZhQjusq1DefwRMSgCiwfdKYiHZt2S6KL69+qufcewfcdXardrQ1pQcJpCTRWTFE3OFkFMiaiv91MXwTRvZlm0cZ7pa0XCxUi3l7LCnhovCmhR6VLTqNmz0Lo/BsSe2OjMnIuBF5nZAUl/BbwI+OOSbR9tZt+Yn2nDHBytLOrUjZjHhFyWvJ+X9c3K/NS+r1P0W65ki2wNoKRbaP1vYJvGG0VpXeOkbM2DoqifMrrawqodmEoNSMdxFoz7YCNsOvEnNrFqnf5jv22lqx8Ag5zwcVp1FoXxNs0xz5M9VttUspQm5807FXUFEIeie/rmxEEA6oXzqlF0QVYAKkr/ys/YpE5Lum0H0SViScb3rceS3c2h0QrXrdwHgCWt9MWzXuai36UXooQG9Xd6ZnRV3zI9TQmbJAUsJTZAIjIDGemA5rthzavWTxWp8LOKDYknWzVIWatK/Sp7DfnUunmkfk2TqvemKLWoTUHksmNOsj5LEwFoVulRTTrw5KkSb9pEBy1OAPIoI2e2mNlHMn9eBvzSomypom2U3rRJ/Z6yzqtV/l+TBhzZ9utllEVg54+RbJuf5MvtWyRqWHL+VesQRUmUY0eJzzCN6Jos1RFAg+jqdNusWDRtW/K0EXxSoiP+E4Bt0zbGcZzF4T7YEJtO/AH6qV9pjng2/auJYNM2r7yjuHD2Jusc9FuTN7yBGzdqqWi/eMjpKEkj0nD3iEFeeXKEke0nuGls4hD024gadFMRAeu3cL/olpPZmhGkEpuSApNL0QGWdICu0o5bzW2NMb6+fCSH77yt7csC4NRdyUzSjXt2huMR2sEntuTboc+ToiikXl98TMSTujpETVPBysZ8LRZ/zr7WOtua2L9Wig6PGwGUMg0hpY1AXiTeLPpG0nHWKM8C3lGyzoCPSDLgDWb2xvmZNUwvJFalYkXTfVrXRmzwG1OUup6lUYfXhu3Xy+wqEn1Sn6yssHXeZ0tT2LLb932d/iRTWTrU9H5Py87Rpnh0FeMIO2Wkgo/jOM5mYNOJP0lnKOP78Va2RavcFW9jKVod2iZ/Q9Lkop8vqpynyWxSm7afZYJSftapagYpWZ+t3ZPZ1qKhduk9S8elM1xLJwStrFiHJa3SCUWaBznX1bNC+baidU5BthNEKgBts07Szh3jq7ft5Igjl/nZ467j2j1HDRWQTet8dJVE+nQQXWVSyVKRqESYyKal7d67g7tNrBDx4KP3jmx7+VeO48eOuaX0dZx0dFI88Oa9O0gKBdengOULLY9D29SvgbOYzByu9j8vxorZUPQPNBOA6l5DmYDSxvay6J9JKbKtrM18VuSZdn2ZNLquTLzJRt9VRRzVHSf/GrLHKIukaStuNbqpSr/zE4o9CxOLfNbJmQKSPgocUbDqxWb2/rDNi4EDwFtKDvMIM1uWdB/gYkk3mNmlJec7BzgHYNeuXRPbn7I/7nJwdDc9U/AdchE1NdEz2fTzNrSdNGtz/LpjV0UJQbnYE4dt8j5ppLhUCMsKamfs2s2e23b0fZ0yn2yWws+kLeRTXPBxHGcs3AcbYtOJP5DMWEfYoOW7ia6Ga+yM0zViGnV++ssLxJsstY5GieiTnyXKCz5Zsn8PC0GjnTHSKJtIiUgwbm5521mhiIgevRA1MyyObFePnvI579DNRPukXb6ahkN3JCJLCk5/38SqRXz6K8fz8GNu5vKvHDe0bZ0ABJkbchvYV5bu1bQLxqxqCCUCYEYMEKV1BIpEoGmEeE9St2halKexTSY4rZWIoCx19swrlWrcFFrH2UiY2WOr1kt6JvDzwE+bFXu7ZrYc/r9d0nuBhwGF4k+ICnojwOmnnz61H94kJWlL3zcpa75RFz0zrgiUkqZ+Nem8Ok4Kfpn9qX+WF3wgREPlBJ90fep3Pe3+VzS2ARKfZ5yUr6yf0VQcmkZB6SImEX62HHHT2Ps6juNsNDal+JMl2yEKxi/WPA5lNYOG0sFChM+4dpU5F/312TDlsotuoVM2LADtty0cHK30Z/AmyS2vE4Cy0T/ZOkFdIlYz+y3lxJJOJsonH/5cH42Sm3ULz9Mx+/RXjqfDILKg6Q3xCUct8+W9OxttO2vyolF2tq6jpJhwkzShdCybvv9FQlFV+lTbFvbzJmt7KuhkizEXCSrpuiYC0Dw7ds1CkMpGQVWNRX59tqXz6D7l6xaPTZZf5zgNkPR4kgLPP2Vm3y/ZZjsQmdl3w/PHAS+bo5kAoelGUn8xScFPrump75ONbG7byALaCTV16V75iOwiX6xqMq4s1b4uwqcoBf9X7n95pa1V1KV8DddhLIgSzdXvKTtG1br8vlW+XvZY4wg/Lvg4jpPgPlieTSf+pBf6ONyQpeHH5dsPPjDjRvZU3axkz1Hm4JSleCU2VTkdA+eiKHQ4v93wOROb8s7Ge/7fQwr2T+onbVeSPtfN5JaPS1MBKN0uFYC20eGufcfQM+MeGv5454tGV1HlkHSVpA52FbPVev3PRZJaFvZr4ayccNRyvwZQp6D2T9b2adAkeiabCpc6bT1Cceo0SmlKokBVoegmLn+ZGFQXidP0dqKu8HZTmooo0xZcpnmsItuKBM8ioaso9a1NEetB+ll1Cu2aE4AMzNZaJStnA/Iakjq1Fyu5XlxmZv9N0k7gTWb2BOC+wHvD+i3AW83sw/M0MrbQwtw6/Vbl3Skev036fJ6++DRGKn4TspNxZX5Zz9TfLitMPeOEy8Y+7xFHLoeOqdW/jU2idsq6tTahSgCatEuYiz2O4xTiPtgIm078Oe/UdwHw0i8+idiifuRPL/M8ndkpmvGB9iJQVQ2hOuEnta0teeGnajapyNEom2F68v2+0H/+/ptPG1nfxegoIs0tn6SwYJsIIBgWSIrEkjbORVVOehRC1DsYkWzwHma2neQmNK39UyY6zKvLFwxH5XQkYpt+pE1dp7C2P9nTTg2bVEpoK+bUbRvb5MWa88ebFdOsdTSOKLa2I4IcZ3qY2f1Lli8DTwjPbwZOnaddeWIiVuMOXfX6XVe7iugyHIVdNenVlNSXy3ZyHbf5RnbfqkjsvD+VT7vP+mRZf6xoIm8SwSfPrDtrNaUogijvmzX1cVzwcRzHac+mE3/yxCSdv/LXmmnP+PSdj6Lc8pqQ5rZOUOpgACNORl079zaknbX+/eZT+C/HXwPA8m075ypOQLlIVCT2TLPLRRL9YqWRCG3qEKQFoAH23LajVgAqo2k0TpVAkh+jbKHr5O90u/kwjgA0LzpT+qhn08KasBYjWKdV/6fqOE0EoKbfu3HrhIzFWnzDHGcBvOrUd3Du1WezP+6yLVoNAtAWtqoXJlUGgm2btusp2Ym7IoGmbfONojT87PZDafQFz4sm4tLonrLC1s884dOlNo5LdjIuTaPqTXE2vK3fVxZBVHScnsV9m13wcRynNe6DDbFpxZ/04r4/7nJItB+o79iV33ecCKCi4xRvW1wfJOts5IWcKicjWZ+Nkhm96I87y5QKP5C0Xa9rn95GaKmLwMk+z2+T/XtwnOKc9nJHpExYSoo+x8T0UP9mNf9+XXnrLn50163lL7CANFWpFzpsRWio01f+NYybfpUVgIrqAeTfwyTlDaJMy/ems4lN6gVU7z8sAGU/+VWdwcpSv2Z125+eL29vVb2fkWNMmPbVtCZQ02thG3vaCEBVnbeqamdNIwJorsKP4zgjxDZI/epar3b7Nt/ZSXyzMuEnu6zpZFyRT7ZqnbAuGxEU8awTP9nK5jbcte+YwsmwjqKpCkBtGe0CNnjftu24eREmOY7jbHg2rfiT0lUvuTAvKC1gONx4fGWyyexSllnMLMGgRkz6fK2QCjhVIlDe3sE20ciyjkQXJe3OiVlRRGyaSr2WY4/ax+69O4BESOgueBj7aV+kn7G0M1k74Sd9XiQANWkRnwoq+U/zWosMKhOAYDzhYpopXvNgmh3AptVOfrDfgj4p3mbUcfrEJHXzVuMtrEadpG5g6LqaMu3v6jTqLzalqHtXKvxk/bFZCj5ZqlLw1xIu+DiOMxPcBxtiU4s/PcR+63Kw3Z1crDU8Y1QXBTRpMeiUNqJPVcHmfl2fGuFnlg5HGvUzafG+PE2OVxalMyQqqF4EGhyvvLBhRESXiO0REMdExKyGIuJY+zSePFkB6Igjl/nqbTuHau+MS751azb6p6jzWZEg01U0dgRPFfn6QkXnL/sU5JfH1Ef/NGG46DbBpvr9xhGAJv3MwPSjfsa3o7rrXVXUT9G2TcSkWXQmmwpmEK8ledJxFktE3C/8HFtE0oAjG8lbXFNn0m6sk9ZfbEt+Mm4Rws8P9h03c+Fn3OO72OM4zsxxH2yETS3+5MnX5ClKA+t3dmrQ/rOKadcUSkm7R+SFn/nNMK2tm6+8eJBNn0oZ1+Y0ymmrBGb9T048hZt4SASglFQAmiapuHXvnXsBuHN5V63wk98/pVwkaxl+n3tvmkQEjUPbaKGi2j7ZZdmoqKJzwWga2GhKp1Wur2OtCD91tBF+svvkBaB0jCYdN8dx5st5p76Lc68+G0hE754NOl+lZH2qrL80btp9SmW3wJzwk7+ON/ltyTfVyKffw/z8sSZMmvrV5hrvYo/jOM7i2bQtUF7yoAuBxBFIQpDLWqmr9nlKhJU+img6w9Qkvzwf9dPri0Caq6ORRv00dQhSAWUSAWaWVB0/Sf2K6CoRgLqyfgew/v4yrt1z1FRsOeLIZY44cpnDd97G4Ttvm0r0zaE79/SfFwkvKf10t5KUvrUm+s2SjoqFn6LtsuS/xUmx8OL3cLSderVNTYWfeZMXesYRfqooax8/zS5jU8Fs+g/HWceknVdjC+lQBZHKVf5T1bq2RDkBuew3pG2Udpyr6wOTRYm3JRv1kwovaeHkLEXLqqjz27btuLnw4TiOsxDcBxti00f+JGlfK0lobuj6lZ8ZKm/p2axANJRH+qTORDRyzuHizGUC0FCr0EzUT5Xdi6bMYWhTFLisjkxde/hpRf2k54oEGHRlRPRYlRFZJgUscN2eIzn56NvGPtc0KErrumvfMVM//jj7Vb3n+eifqrS3dLuRgssFqV910T9N3OG88JPvopY/b1ka2OhxRyNYmgg8dYWlx436mSSiZlqCT9taQm2KbDuOs1jyETNNmTQVbBZkJxPzUT+/deIn5mJDvsjz3fuOr9x+kgggF3Ycx3HWD5te/OmqN5JvDpTmhbehbYv2LFGISOpgrITuEE3IOlCLcIpm3U60/Lz1hYTHrZVT1ZI0xvqt0LuKwOLk5l/QsdmloOy5bQddkjpVKeN2/UoZLmxd1Q43H9be7uZ+WKzTyLLCc0qFKXtl22Vt7Xc0K6jZM4ti0U0EIKZ83nlGuqy31Kq1YK95vrnjjBD1Bdqk6cYgCrtZZ9R0Aq4sPb9o/7J1HcVDv6NVE3JNKYsoX6s0FYBc7HEcZz3hPtgw6+vKNGVedPIH+xE/Qy3RK4SgpqQpXR3Fpe1CU/JOxjSZ1ywTJCHG02DaKUQdDbeen2Yx6iT0OaKrTkgBi5IUMIxIwzfl1+05cmrnhVHxoIkIUyaeTDImHTSx8JTYUC/sTIOi+j1jHacqJTAfETRD7aFpesKia/1Mg3GiiBYt/DiOU8xLHnQhvVD0GRgpipySF2xi1F/WJAW/bl3eRyvyydr6afkaRvPkzuVdpdf0nsWVAk8+BczTtxzHcTYWmz7yZ9U64bGFniU38kViTV4AalM0sHRZw9n6ugiibEeJRZEKP2uhq8Sgk1e1s9bG1urOX8lxuur0hZCuYlbNWMGIM5EHX967M6kLVHCcbIHnOnqWRpQkUUapDf0ol5qaPNn0uCInsS59roiqosdF68o6rGUpi7jKk90ujf5J54+Lzp2NAspH4oyT7lW2TZUgVxcB1CRiZVERP1W2rbV0q8VH/qz//HDHmSU91PfDOrKR5htQncZel4Kf9b/yvlR/oq4kBX/kWFjSNTR0Kasin/I1zU5idcTEbKE8arxn8YjQs+WIm5L/Z2qZ4zjOPHEfLM+m/42PFIeQYwWHw4acjp6Vi0FFAlB22yY3SJW2hdSvNowTmjwtysSUSbtJrBWqBKBOSPmCiK4gMoF6AKyYQclnYZI25FX0sFqBok20T11aVhVFdiyiQHSZCJSO/7jfnEnTuMZNPRtOUai2YRZRP3Wiyriiy7TFo4WLUMbGCLtynBkRW8SKbek3rIiIqPraNk3Fn/ZE3CTMU/ipwiN3HMfZVLgPNsKmF39ii4gxVmxLMutEPHJTnM4UFV28y2acUmci61RkZ81TimaZxqkVlDpNWXvnxbTSvabNONEr9ccciCAxNiRidBTRIZnt26JEbFgl7kcB9bAhoSeNPhlHAKqKEvrmctJdrIkAVEbRuFUJNkORNzURL23Ii05tRaPiNuu5KKmS8S9s7z4SQdWMuve3TABqe1NSdpxI60sAqto3Tf1Kiz/n/56mDY7jzJYXnfxBzrvu54gtif7pkET/VAk8RTUZa6N/SkTlJv4YJH5VfkIuOV8MauZ3zTLFvwgXehzHcZw8m7rmD8C5J38IoO94pIUHi5hUVGnSgrhqdiii2iHKH2eeM03ziOSoO8e8okmyRYqL6CiioyjUAkoKYHeVpINV1X7ZvXcHu/fumNi+e+/cO/ExZsUktYEm68xWbUvavj37qDvepv/xDHSGhL/J2iNnqRNsIlnjGkALb/1u8fQfjrOB6JFt+T5c+6fXr804+qvbJN09/xtV1c59aL8CHyoiKQzd1r+ap/Bzz523sn3HV+Z2PsdxnDWN+2BD+P1Lhp5FtUX68s5HdqZpUmdgKGVM8dA2bY49T9Fnmq3C1xPl7eqjfuRYvxg0owLQLAsAw0AAmlYETh2zFN6ScZxGQelR2ohR0yhqXcWsBaUmreLrKLtZqruRWrj4Ao1v+BzHmS/nnvyhfvON7CRckeBTJgLlmaY/Vna8juLKaKPR7f23x3Ecx1ksLv4Av/8jH+nX/VmxzkiRvjxFjkeZo5E2MC1a3pRxblbKzjsv8oUE83/PirxQkE/hywozedKInaJHU7JFlLvaQlcdtmkLS+qwjQ5dKWnRPgfKIoCKCzxraOwm7YiWFUryAlRaFDv/GJd8LaJeRWG3cQWgTn9cyn80p/UJLzpHVPAoYji9raBYtkYfbRlXQGm63zxStOYpAhlgsU394Tgbjf3WZX+cPJr4YakvNtKQI1d7EQY+UdmjbP8i0uifwTniIATlj2P947vw4ziOM3/cBxvFxZ8MPQuzTRPf+I52jahyNKDe2RgnzHgjMVnKTzT0fxF1As+44lXSPS5iCx06Ko5gydaDadPxaxoURdUM1zEqEsk09CjaD2YfKQPF3cCmzTxeRxF1Qk92ecz4BafXKhsmQsfMQ44dp4bf/5GPAPSjflZtvJKURcLPrCjyy7qh0YPjOI6zBnAfbISZFnyWdDRwAXAEyb3JG83s7yT9MPAO4FhgN/BUM/v2LG2p4/kP+Civu/HRcy+W3Ja0wOAi27qn3Lm8i67KW4muJSYRfsq2SzuYNdm/o4jYkppNsURs80nJuvfOvdyxfHSwoVyoKWIaBbPbFH+uahU/9vmVFkGvqe1QYmdnKIps/TFJseM0KqhsgsMLKTuOM02e/4CP8pobHsOqdeiqlzSxUFQbxVzYebWgkHPZBFrW76uaZGvajOPs+32+dhvHcRzHWQSz7vZ1APhDM7tS0iHA5yVdDPw68H/N7BWSXgi8EPjjGdtSS4eYGA26fvW7MSXOQNlFP13f1NnIH6dJiHGbFu7zDjEujmaJC1O/5tXyvao1+bTq0zQVjVLhqauQFmbQo0eP+UT9HLpzD3ftO6Yw5a30NfTfpwhyn8+skBYTDwks6bHz3b/aMKkIVBSt1Oa8a5lxOsNViTRlwk42HayqU1hbAajJtvnirBtBYFrvIcKOMy+e+4CP8ab/fFRS9FkRHZJImjo/LMpE4dT5YvnflTYdVh917E0tXo3jOI6zaNwHG2am4o+Z7QP2hefflXQ9cCTwJODMsNk/Ax9nDYg/v3PSJTmnwxqnaLWZZWrqaOS3SxyWavrnXgNJIJMIQKl4M+1CwiOpSXOqRTQ4/6AZdweBkvbvs0z3+sG+40aEn/zrHhV0Bu9T0/o/HakfYVMlvjVlmi3jJ2WtRP20FX5SytocN2VWreKbsFEEIMdxmvFbJ36C8//zkWy1Hj1iUAQ26GJa5T+18cWyuKjjOI7jbAZmHfnTR9KxwEOAy4H7BmEIM9sn6T7zsqMpsUUwRu522SxTSq9/8504ME3r+LSN/pkHTSIsigSgpsxa+JkFVUJJsq5HRFIrJ0kDE0cftTyVc9+5vAuAbUq+1qmAUyV41Qk7eREne6w6cWetCkAD+W1+jBOxMxM7ZiCktDlm0W/htM+xJlnn+eGOswh6JN0zOxXTXk847otztMhxHMdZd7gPNoSsphbGVE4i3QO4BPhLM3uPpDvM7NDM+m+b2Q8V7HcOcE7480GAX+Un4zDgG4s2Yp3jYzg5PobTwcdxck4ys0NmeQJJHyZ5r6bNN8zs8TM4ruOMIOm7wI2LtmOd47/Zk+HjNzk+hpPjYzg5hwHbzezwWZ/IfbBRZi7+SOoCHwAuMrO/CctuBM4MUT87gI+b2Uk1x/mcmZ0+U2M3OD6Gk+NjODk+htPBx3FyfAwdpxn+XZkcH8PJ8PGbHB/DyfExnBwfw8Uy0zwiSQLeDFyfCj+BC4FnhufPBN4/Szscx3Ecx3Ecx3Ecx3E2K7Ou+fMI4BnAtZKuCsv+BHgF8E5JvwncCpw9Yzscx3Ecx3Ecx3Ecx3E2JbPu9vVJKK3S+dMtD/fGCc1xfAyngY/h5PgYTgcfx8nxMXScZvh3ZXJ8DCfDx29yfAwnx8dwcnwMF8hcCj47juM4juM4juM4juM4i2Ft9Q53HMdxHMdxHMdxHMdxpsqaE38knS3pS5JiSafn1r1I0k2SbpT0s5nlD5V0bVj36lBo2glIOlXSZ8IY/buke2bWFY6pM4yk0yRdJukqSZ+T9LDMOh/DBkh6Rxi/qyTtztQB8zFsgaTnhXH6kqTzMst9DBsg6aWSbst8Fp+QWedj6DgZJD0+fB9ukvTCRduz3pB0vqTbJX1x0basVyQdLek/JF0frnvPX7RN6w1JS5I+K+nqMIZ/sWib1iOSOpK+IOkDi7ZlvRL8/2vT+6lF27MZmXXB53H4IvBk4A3ZhZJOBn4ZeCCwE/iopBPNrAe8HjgHuAz4IPB44EPzNHqN8ybgBWZ2iaRnAX8E/FnNmDrDnAf8hZl9KNwsngec6WPYHDN7Wvpc0l8D3wnPfQwbIunRwJOAU8zsbkn3Cct9DNvxt2b2quwCH0PHGUZSB3gt8DPAXuAKSRea2XWLtWxd8U/Aa4ALFmzHeuYA8IdmdqWkQ4DPS7rYP4etuBt4jJl9T1IX+KSkD5nZZYs2bJ3xfOB64J51GzqVPNrMvrFoIzYray7yx8yuN7MbC1Y9CXi7md1tZrcANwEPk7QDuKeZfcaSAkYXAL8wR5PXAycBl4bnFwNPCc8Lx3QB9q0HjMGP/b2A5fDcx7AlITLvqcDbwiIfw+Y8G3iFmd0NYGa3h69XctgAAAtrSURBVOU+hpPjY+g4wzwMuMnMbjazFeDtJN8TpyFmdinwrUXbsZ4xs31mdmV4/l2Sm+8jF2vV+sISvhf+7IaHF31tgaSjgCeSTKg7zrplzYk/FRwJ7Mn8vTcsOzI8zy93BnwROCs8Pxs4OjwvG1NnlN8DXilpD/Aq4EVhuY9hex4FfM3Mvhz+9jFszonAoyRdLukSSWeE5T6G7XiupGtCSsYPhWU+ho4zjH8nnDWFpGOBhwCXL9aS9UdIWboKuB242Mx8DNvxv4BzgXjRhqxzDPiIpM9LOmfRxmxGFpL2JemjwBEFq15sZu8v261gmVUs31RUjSnwLODVkl4CXAispLsVbL/pxi6lZgx/Gvh9M3u3pKcCbwYei4/hEA2/209nEPUDPoZD1HwOtwA/BPw4cAbwTknH42M4RM0Yvh54Ocn4vBz4a5LfSB9DxxnGvxPOmkHSPYB3A79nZncu2p71RkhhPk3SocB7JT3IzLwWVQMk/Txwu5l9XtKZi7ZnnfMIM1sOZQsulnRDiJB05sRCxB8ze+wYu+1lELECcBRJ6s3e8Dy/fFPRYEwfByDpRJKwRSgf001J1RhKuoAk1xfgXQzCPn0MM9R9DiVtIanp9dDMYh/DDDWfw2cD7wkprp+VFAOH4WM4RNNrjKR/ANLCjT6GjjOMfyecNUGoU/Nu4C1m9p5F27OeMbM7JH2cpD6qiz/NeARwVqj5uQTcU9K/mtl/XbBd6w4zWw7/3y7pvSTpxS7+zJH1lPZ1IfDLkrZJOg44Afisme0Dvivpx0MtkV8DyqKHNiWZorAR8KfA/w6rCsd0MVaueZaBnwrPHwOkKUs+hu14LHCDmWVTNX0Mm/M+ks9fKuRuBb6Bj2FjQp24lF9k4Pz6GDrOMFcAJ0g6TtJWkoLoFy7YJmeTEXz7NwPXm9nfLNqe9Yikw0PED5IOIvhii7Vq/WBmLzKzo8zsWJLfwY+58NMeSdtD0XYkbScJTHABcs6suW5fkn4R+HvgcOD/SLrKzH7WzL4k6Z3AdSSV/5+T6cLybJKOCgeRdPnyTl/DPF3Sc8Lz9wD/CFAzps4wvw38XYhc2U/SXc7HsD2/zHDKl49hO84Hzg9tg1eAZ4YoIB/D5pwn6TSS9JXdwO+Afw4dJ4+ZHZD0XOAioAOcb2ZfWrBZ6wpJbwPOBA6TtBf4czN782KtWnc8AngGcG2oWQPwJ2b2wQXatN7YAfxz6OAXAe80M29X7syb+5KkHEKiQbzVzD68WJM2H0ruGxzHcRzHcRzHcRzHcZyNyHpK+3Icx3Ecx3Ecx3Ecx3Fa4uKP4ziO4ziO4ziO4zjOBsbFH8dxHMdxHMdxHMdxnA2Miz+O4ziO4ziO4ziO4zgbGBd/HMdxHMdxHMdxHMepRNL5km4PnWebbP9USddJ+pKkt87aPqca7/blOI7jOI7jOI7jOE4lkn4S+B5wgZk9qGbbE4B3Ao8xs29Luo+Z3T4PO51iPPLH2bBI+t4MjnmWpBeG578g6eQxjvFxSae33P5GSWcVrDu2qfK+EZD0J5nnB0m6StKKpMMWaZfjOI7jOI7jbHTM7FLgW9llku4n6cOSPi/pE5IeEFb9NvBaM/t22NeFnwXj4o/jtMDMLjSzV4Q/fwFoLf6Mya+a2YWzPIGkziyPPyX64o+Z/cDMTgOWF2iP4ziO4zibGElnSLpG0pKk7SG9pTIiwnE2GG8EnmdmDwVeALwuLD8ROFHSpyRdJunxC7PQAVz8cTYBSnilpC9KulbS08LyM0NUzb9JukHSWyQprHtCWPZJSa+W9IGw/NclvUbSw4GzgFeG6JP7ZSN6JB0maXd4fpCktwfH4B3AQRnbHifpM5KulPQuSfdo8HoeKulqSZ8BnpNZ3gmv84pwrt8JyyNJrwvOyAckfVDSL4V1uyW9RNIngbPL7AnnvCQo+hdJ2hGW/27I471G0tsrbN4ecoSvkPQFSU8Ky48NMwRXhsfDw/Idki4NY/tFSY+S9AogjfZ5S6M333Ecx3EcZ4aY2RXAhcD/AM4D/tXMNk1UtrO5CfcKDwfeJekq4A3AjrB6C3ACcCbwdOBNkg5dhJ1OwpZFG+A4c+DJwGnAqcBhwBWSLg3rHgI8kCR65FPAIyR9juSH6yfN7BZJb8sf0Mw+LelC4ANm9m8AQTcq4tnA983sFEmnAFeG7Q8D/hR4rJndJemPgT8AXlbzev6RRF2/RNIrM8t/E/iOmZ0haRvwKUkfAR4KHAs8GLgPcD1wfma//Wb2yGDPe/L2SPqfwN8DTzKzrwfx7C+BZwEvBI4zs7trfsxfDHzMzJ4VtvuspI8CtwM/Y2b7leQFvw04HfgV4CIz+8sQkXSwmX1C0nNDtI/jOI7jOM5a4WXAFcB+4HcXbIvjzJMIuKPEP98LXGZmq8Atkm4kEYOumKeBzgAXf5zNwCOBt5lZD/iapEuAM4A7gc+a2V6AoFYfS1LE7GYzuyXs/zbgnAnO/5PAqwHM7BpJ14TlP06SNvapIBxtBT5TdSBJ9wIONbNLwqJ/AX4uPH8ccEoa1QPci+QH9pHAu8wsBr4q6T9yh31HjT0nAQ8CLg7LO8C+sM81wFskvQ94X4XpjwPOkvSC8PcSsItEdHuNpNOAHkl4KCQXhfMldYH3mdlVVePiOI7jOI6zQH4YuAfQJfFx7lqsOY4zH8zsTkm3SDrbzN4VsihOMbOrSe4Nng78U5hkPhG4eZH2bnZc/HE2A6UhOcDdmec9ku9E1fZVHGCQSrmUW1fUVk/AxWb29BbnUMmx0nXPM7OLhhZKT6w5ZuqgFNoj6cHAl8zsJwr2fSKJuHUW8GeSHmhmB0pse4qZ3Zg79kuBr5FEZUUkM2aY2aVKugk8EfgXSa80swtqXofjOI7jOM4ieCPwZ8BxwF8Bz12sOY4zG0JGxJnAYZL2An8O/Crwekl/SiKAvh24GrgIeJyk60jus/7IzL65EMMdwGv+OJuDS4GnhZo4h5OIFZ+t2P4G4HhJx4a/n1ay3XeBQzJ/7yZJsQL4pczyS0l+FFFSAPCUsPwykjSz+4d1B0s6kQrM7A7gO5IeGRb9amb1RcCzQ7QMkk6UtB34JPCUUPvnviQ/2EWU2XMjcLiknwjLu5IeKCkCjjaz/wDOBQ4lmfUq4iLgeWE2AEkPCcvvBewLUUnPIIkqQtIxwO1m9g/Am4EfDduvpq/PcRzHcRxn0Uj6NeCAmb0VeAVwhqTHLNgsx5kJZvZ0M9thZl0zO8rM3mxmt5jZ483sVDM72cxeFrY1M/uDsOzBZlZaH9SZDy7+OJuB95KkJ10NfAw418y+Wraxmf0A+O/Ah0Mh5K8B3ynY9O3AH4UCxvcDXkUivnyapLZQyuuBe4R0r3MJwpOZfR34deBtYd1lwAOo5zeA1yop+PyDzPI3AdcBVypp//4Gkkimd5Pk3KbLLi96PWX2mNkKiZj1V5KuBq4iKezWAf5V0rXAF4C/DeJUES8nmQm4Jtj28rD8dcAzJV1GEgqaRiGdCVwl6QvAU4C/C8vfGI7hBZ8dx3Ecx1k4ZnaBmT05PO+Z2Y+Z2ccWbZfjOE4emZVlkDjO5kXSPczseyFS5bXAl83sbxdky8eBF5jZ5yY4Rvp67k0iPj2iSgBbTyjpqna6mX1j0bY4juM4juM4juOsRTzyx3GK+e1QAPpLJKlJb1igLd8iKZR21gTH+EB4PZ8AXr4RhB9JB4XX1AXiRdvjOI7jOI7jOI6zVvHIH8dxpoak3wCen1v8KTN7ziLscRzHcRzHcRzHcVz8cRzHcRzHcRzHcRzH2dB42pfjOI7jOI7jOI7jOM4GxsUfx3Ecx3Ecx3Ecx3GcDYyLP47jOI7jOI7jOI7jOBsYF38cx3Ecx3Ecx3Ecx3E2MC7+OI7jOI7jOI7jOI7jbGD+P2Zk7l8vH8HyAAAAAElFTkSuQmCC
+"
+>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Mapping-pixelwise-operations">Mapping pixelwise operations<a class="anchor-link" href="#Mapping-pixelwise-operations">&#182;</a></h1><p>We will now demonstrate how to apply a pixelwise function over an entire dataset using the <code>apply</code> method provided by <code>nd</code>.</p>
+<p>In this example, we use <code>np.argmax()</code> to find the hottest month at each pixel.</p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[14]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">hottest</span> <span class="o">=</span> <span class="n">sst_celsius</span><span class="o">.</span><span class="n">nd</span><span class="o">.</span><span class="n">apply</span><span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">argmax</span><span class="p">,</span> <span class="n">signature</span><span class="o">=</span><span class="s1">&#39;(time)-&gt;()&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[15]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">plt</span><span class="o">.</span><span class="n">figure</span><span class="p">(</span><span class="n">figsize</span><span class="o">=</span><span class="p">(</span><span class="mi">16</span><span class="p">,</span> <span class="mi">8</span><span class="p">))</span>
+<span class="n">plt</span><span class="o">.</span><span class="n">imshow</span><span class="p">(</span><span class="n">hottest</span><span class="o">.</span><span class="n">where</span><span class="p">(</span><span class="n">mask</span><span class="p">),</span> <span class="n">cmap</span><span class="o">=</span><span class="n">plt</span><span class="o">.</span><span class="n">cm</span><span class="o">.</span><span class="n">get_cmap</span><span class="p">(</span><span class="s1">&#39;gist_ncar&#39;</span><span class="p">,</span> <span class="mi">12</span><span class="p">),</span> <span class="n">vmin</span><span class="o">=-.</span><span class="mi">5</span><span class="p">,</span> <span class="n">vmax</span><span class="o">=</span><span class="mf">11.5</span><span class="p">)</span>
+<span class="n">months</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span><span class="mi">12</span><span class="p">)</span>
+<span class="n">month_names</span> <span class="o">=</span> <span class="nb">map</span><span class="p">(</span><span class="n">calendar</span><span class="o">.</span><span class="n">month_name</span><span class="o">.</span><span class="fm">__getitem__</span><span class="p">,</span> <span class="n">months</span> <span class="o">+</span> <span class="mi">1</span><span class="p">)</span>
+<span class="n">cbar</span> <span class="o">=</span> <span class="n">plt</span><span class="o">.</span><span class="n">colorbar</span><span class="p">(</span><span class="n">ticks</span><span class="o">=</span><span class="n">months</span><span class="p">)</span>
+<span class="n">cbar</span><span class="o">.</span><span class="n">ax</span><span class="o">.</span><span class="n">set_yticklabels</span><span class="p">(</span><span class="n">month_names</span><span class="p">);</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+
+
+<div class="output_png output_subarea ">
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA3IAAAHPCAYAAAAWHOhjAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde5wlZX3v++9vgA2GHhkJ4AEVx+SAbjAEdUKOMXE3aoxnx4Qh0YBKAgmxY7bGbaJRTOIlF3aI22viLX08KoYoYmJGNCoYYydha4BBEdR4ixBFOcIIrbS6UYbf+WNV0TU1tdaqqvVU1VNVn/fr1a/udauuVatWree7fk89j7m7AAAAAAD9saXrFQAAAAAAVEOQAwAAAICeIcgBAAAAQM8Q5AAAAACgZwhyAAAAANAzBDkAAAAA6JkDm1qwmT1B0mskHSDpTe5+QVP/CwAAAEAcnvD4J/ieb+wJvtxrPn7NZe7+hOAL7qlGgpyZHSDpdZJ+WtJNkq42s0vd/TNN/D8AAAAAcdjzjT26+qNXB1/ulkO2HBF8oT3WVNfKUyR90d2/5O7fk3SxpNMa+l8AAAAAMCpNda28n6SvZC7fJOnHp935iCOO8O3btze0KsAM658od7+td09+H/CI5tYFAJpQ9jiH4dv2sHqPm7YPzVve+if2vw/7Yy3X/Pvde9z9yK7XA3FpKshZwXW+zx3MViStSNKxxx6r3bt3N7QqwAy7tk5+77xj38tF0vsAQJ/MOq61rcpxNKb17rtFP7+yr0XIZaE0O33jP7peB8SnqSB3k6QHZC7fX9LXsndw91VJq5K0Y8eOfUIeAAAYuXxgIAD0G68fEFxTQe5qSceZ2YMkfVXSmZKe2tD/AgAAWUNsNBdVgob4PEML1ZtkkeXwOgGNaCTIuftdZvYsSZdpMv3Am9390038LyCI/IdMma6WAIBqph1r6yLctaPO69TU68BrDtyjsXnk3P39kt7f1PIhaT05FXEbPVMbx/lxABBe6GCXXQaN+/7jtQRmaizIIYBZQW29aDwZ1FL0QcGHBoC+6vPxKz8A1SIIAd1r4jXg9QTuQZCL2axKG1W4MPKNheyHDlU4AOhGyGNwdjljCQExfH4VrcO0z9h5o2ISyoFCBDkglf3wiOFDEADGjC/U6olxmzWxTpwrBxDkAAAYjKE1ZEN2tZy2nCFtsxhDXJFZVdJZAX7e8xtj9RWjRpDrGwY4AQCMTZPVObrtdaupUxoIdRgBglxflBn4hHAHAMOya6u0vCGtLVV/7PLG5t91Hp8q07huo6HcxAiX+eXR4G9PPrj1pZoIRIQgF6uyo1KuGwEOAIYmDXDLyeVsKMvLhrRp9yu6PuRnx6xGeFPhqOlg1yf5qmIftkVb60g4HxUz2yvpekkHSbpL0oWSXu3ud3ewLhvuvsC3aPMR5PqG4AYAwzcruNW9b1efHW11cSPYjfM5z0KIG6PvuvvJkmRmR0l6u6TDJL2k07WqyMwOdPe75t2PIBez/IduWqXLhjlCHQD0W1Pzgsb4+dDm+WhjacQT3jZlu2uO5fXHVO5+i5mtSLrazF4qaYukCzTp63CwpNe5+19Kkpk9X9IvS7pb0gfc/Twz+2FJr5N0pKTvSHq6u3/WzN4q6buSHiLpgZJ+VdLZkh4p6Up3PyddBzN7haRTJd0u6Ux3v3XOcm+T9DBJH5f03HnPkSAXI6puceJ1ARC7vhyjOB8NoaX7E/vV0B1hZrszl1fdfXXand39S2a2RdJRkk6T9E13/zEzO1jS/zKzyzUJZDsl/bi7f8fMDk+XLekZ7v4FM/txSa+X9Jjktvskf/+8pPdKepSkX9ckNJ7s7tdKOlTSx939uWb2Yk2qgs+as9zjJT3O3feW2RgEuRhN+yAO/QFNMCmvqW/MAYxTyGNKX4/jhLnFUY2bYD8akz3uvqPiY9ID7uMlnWRmT0ouHybpOEmPk/QWd/+OJLn7bWa2JOknJL3L7J7j9cGZZb7X3d3Mrpf0dXe/XpLM7NOStku6VpPq3juT+18k6d0llvuusiFOIsiNW18//NuQH01r3rZi4loAZZUJcekAJk0PUoL+4jNnE90pMYWZ/ZCkvZJu0STQ/Za7X5a7zxMk5Q+sWyStp+fbFbgz+X135u/08rR85SWW++0p1xfaUuXOGCiqTfta9IPgKJv85C8XXQdgPNZt/vF2bWnfUSjTy2tLkwA3lBC3ayuNbgCNMrMjJb1R0mvd3SVdJuk3zeyg5PbjzexQSZdL+jUz+4Hk+sPd/VuSbjCzJyfXmZn9aMVV2CIprf49VdIVgZZ7DypyKG4YjL3CNO25z2p4pLetLkkrG8VBLX9d/vItA2mkAU0qCkN9DzhF87wtb/T/eU1DBaU8JrYur0x3Xbbn0N3LzK7V5vQDfyXplcltb9Kk2+PHbdKv8VZJO939g2Z2sqTdZvY9Se+X9HuSnibpDWb2B8nyLpb0yQrr8m1JJ5rZNZK+KemM5PpFl3sPmwTUbu3YscN37949/45AV+oe7FcqDCEuEeSAMqZVtWIPPUXrXRTgxvQlGg3p2WZ9qTim/aSKKtNQ9Gj/s9M3rqlxblhndjxih1/90auDL3fLIVt6tR2aRkUO86WNj9gbSXVM+zAMdXBfLWikzQp3RxlhDphnm/enS3iV9Rxbw7xHjegoEeb2xf6EESLIYb6hBbjswT7fxYIPRaAfhnJcGnL3yVlodJfDdqom32WXz3QMHEEO4zLvQ7GND830HLppqMoBwzCrGjfG8IawCCn7ym6PMtuGkIwBIMhh3DiQA2jCEAdkqYvjbFgEuHrYDzFATD+A8WjzIL6ysflTpOjcuSymJgD6ixCHphDi6iHEYaCoyPUFDYPmhRgOuyi4pdfNC295dLEE4rZu+x6H+zqa5jR1zxum0RweAW62/Dlx2X2X/REDRpCLXbZh0NfGQAyOsuIgFfLDcd5UA1WnIpAIc0DM0mPy0AKcROM3FgS4csrMH1f0GIl9Hb1GkItZX4bXjl1RiAv94VgnpAEYrj6FuFkN2YHOydULhLjqsvvgtP2R7YoBIcjFiAC3uPQcs9WlzRA3a2LVutoIcOlzoTIHxCd/vO5TgEvlj41Vgl3V/0HYm4+gUc+s/biJz38gAgS5GPWxIRCL9KBc9ny02ENcVp0BUAh/QHuGcuwuavQucqwkmABAIwhy6LcqjYuQ37x10ZUyG8oY1RLoHr0nqqH6UU7dQWbGZtZ2ohqHkSDIoV9iOPB2HeIAdI+BqOaHjRiO131EiCuvKMzV2e/o+oueIsghfrEdWFeX+jG4CeEPaN5YQlw6KiDTESA2s/ZLQjEGjiCHOMX+wZ+eg9dWoKMrJdC9sVfhaBTHp8pn5awuhiFe2yrLyc/zVuX/p/efNuVAmeratK6XdaYxQKG9t+zV+uu+1fVqDB5BDnHp2wG07UBXBXPQAeFwPlw1fTuWx6SpbVd1NNI6XRbrTleRn9C7zLLzt+UfWyYcxv7lRIxtC0SFIIc4xPyhX+Y8kOwomaEOvCGWWebDEcBsY6/EjQHnSO0vxLYo8xnURXfd2D8TCXAoiSCH7sX4wbnIQT7Gc+gYBQ2ojiocEEaZil/Vxw9VbO0HRI0gh+7EemAu8+Eyb91DhLnQB3PCHFBeUYijGjdcsX4ejVVXr0db/zf9fM/PeUuIQ0UEOXQjtg/NKidolxXb+XOEOKCcXVslJe/f5Q0CXBWxHdtnoTtld0JOOh/qs63tEJf/G6hhS9crgBGK7UOziRCXtbq0/7dubT4eQHn59zkhDggnHW0y5PL6hs9zBERFDu0ZW4DLW3TwkjrdNVc2+NAA6upjI7ErsR3fy+jjOvdZ2++nmE8niPFcevQSQQ7tWOQDM2T3l6oH9aY+6OsexOs+LtYPMyAWVYZNx/5CdpXrqzF21Zz2nLv+rI05xAEBEeTQrLIH5+wBt6kPwdgO6mVC2aInQlONA+Zjmo5uDSEAMan0prbeR7MmOAdGgiCHZsw6kM47yOc/BOsclEN9kIQYwXKWqkFrVvibtSwaqsC+st/Y877oxlC2e9HzGEI4bUvIz/g6y2rzNaI7JQIjyCG8ddM9I75lNfWh3XVjoO0P7EWqbHQ3AWhct4FtPF5FXxy2sT/Eus8R3tAgghzCyc67tLwhrS11309+TPLbmm0JFOPLjObN6l44hPPp2IcmZr1uTb6mfdhfCHBoAUEO4eSH6d5ZYxnZOZuKDtQxf3iGOi+i6edIVQ5AG6r0VqArIkJqe1RqieCGThDkEJdsGEwPxOvWn7mcFm2MDLX7KQCUEftAIVWOpTE/j7Fpqrsn4S06ZuaSXunuz00uP0/Skru/tIN12XD3RkedI8ghfn0JcVllTsQmXAEYo7JD1bd9jhWGY9r+QgVuDO6U9Atm9qfuvqfrlanLzA5097vm3Y8gB7SpzfBGUATQR0VVuTqhbt4xcOzncKE+QlzM7pK0Kum3Jf1+9gYze6CkN0s6UtKtkn5V0jclfVLSD7n73Wb2A5I+J+mHJB0r6XXJ/b8j6enu/lkze6uk70p6iKQHJss5W9IjJV3p7udk/ucrJJ0q6XZJZ7r7rWb2wzOWe5ukh0n6uKTnznuyW6ptGwCDRcMDQBPqfKk06zE779j/9vQ6vsBC0whxXTvCzHZnflYK7vM6SU8zs8Ny179W0tvc/SRJfy3pz909DXL/JbnPz0m6zN2/r0kg/C13f4Sk50l6fWZZ95H0GE0C43slvUrSiZJ+xMxOTu5zqKSPu/vDJf2TpJck189a7vGSHpd2DZ2HitzY9Ol8M7SLBhCALtQd2KpMl8wq/7PO/wqxbPQHIS4Ge9x9x6w7uPu3zOxtkp6tSeUs9UhJv5D8/VeSXpb8/U5JZ0j6iKQzJb3ezJYk/YSkd5ndMyr7wZllvdfd3cyul/R1d79ekszs05K2S7pW0t3JsiXpIknvLrHcd7n73plbIIMgNxbZqQEA7PulRv79wZcdQFgxDGLS9iBUjMQ5LIS4vnm1Jt0T3zLjPumH/aWS/tTMDpf0CEn/qEk1bd3dT57y2DuT33dn/k4vT8tXrklvyFnL/faM9d0PQW4stjlhDvVM22/6Hnay65/9m/cJ0IwqlbIy06RUmUqlTphaZB7U7GOHMG/e2BHiesfdbzOzSySdq8l5cZL0UU0qbn8l6WmSrkjuu2FmV0l6jaT3JRWxb5nZDWb2ZHd/l03KZye5+ycrrMYWSU+SdLGkp0q6IqkWLrrcexDkxqTvDW90p6hylf69lhtZdznzgVcUkGLfD2NfP2DIspW7MqNbzgtzXQQmuqkPCyGuz14h6VmZy8+W9GYz+11tDnaSeqekd0lazlz3NElvMLM/kHSQJoGsSuD6tqQTzewaTQZVOSPQcu9BkAP6rKnpDNLlLuc+wIoqu8sb+4e5ey5v3X8Z2S6NRXP7AECRWUPKhz6G1DnPjuMY0LnsvG3u/nVJP5C5fKMmA5QUPe5vJFnuuhskPaHgvufklvnQKbel6/KiqsstiyAHDEXZb6+n3TbvsamiitXOgsvZxtW0QXaWN4qvZ1AeAF2pGsgW6YKJuFGNQ+QIckBfVP3wn/UtdT5kSZMqWshvlLPLmhbK5oW4ddu32sc33sDw1RkYpYmqHABEjiAHdGFWxSnkt7XTKnDZy9mg1MaAAPPsNwhJZp3mrR8NOWAY6gwQUndKgfzjyvRc2JU7LnU5+Timm1VRW10qvp4qHHqEIAd0YW1p/+6IZeUbDLMaCEUBLnSDoqnz9AAMRzbs1D03tih41Ql8IY5T2XXhuBeneYEsvT0NdDEHuNUl6fSI1w+dIcgBbShqxORvb0uTcxtVCZWLLm/W/WlYAfFJj4OLvj8Xefyi/7tOcKMa174qoSzmACdNrxwCIsgBzZs2lHb+9irLm9WQKNvIaHtuo6ohi8YPMAxtV62aHKxkVjf1PI5h3Yg9mFVBiMMcBDmgK2P9kG+jKybdnYB4jO29ONZjewwIcRgZghzQlDaqW6F1VaWbtw6LLHtsjUigS0clo+DeMqDpQ4qOJYS1+MwLcflgtEjoC7ksYAEEOaAp+Ymy22oEhK5GNXlOHYD+O8r2vTykEJfFMbC/mqxuNRHiqMahJIIc0IR0brbl5AC/1sJBuenKU5tBNPTy8utOlQ6oLx/c6t6/amO17fctwa1f2gw/VOAQCYIcENp6rtGyzSdTDbTZHbJpTUxjkF/+NHX+bza8EeKAZs3qXple12S36lAYyKRbKxvjrEyN8TmjNoIcEFJRiGsC3R0BtKlqFa7oMdO6XMYW4BAHAg0w19wgZ2ZvlvRESbe4+0OT6w6X9E5J2yXdKOmX3P325LYXSjpX0l5Jz3b3yxpZcyA2TYS4MhPgdtVVsMmqXBMDlTBxOTDbrLC2ulStO9m88+T69B7kCzMAkSpTkXurpNdKelvmuvMkfdjdLzCz85LLLzCzEySdKelEScdI+gczO97d94ZdbSBy+RAXqiHQp8ZPCJzPBiym6ntoVhUkvW1WoBvKQCeEN2Ah3/v/DtBXXnZY16sxeHODnLv/s5ltz119mqTl5O8LJa1JekFy/cXufqekG8zsi5JOkfSxMKsLRCpbjQsZ4spUkboIOm02cvIN0RCVQAIixiCtsK3MqbQV/T3LtOpcX0McoW18GKwEA1H3HLn7uvvNkuTuN5vZUcn195P0r5n73ZRctx8zW5G0IknHHntszdUAIpDvUhnSvLDRVRhp+xy9ojCXvS3EMoGhSYNVUZfJRc8/SsNcX8ObRIAbqyohLvs+IfwhQlsCL6+oRVt4lHf3VXff4e47jjzyyMCrAbRg3TZD3Dbf/EH8dt5BiMN4LRri0vdPn0McME/+fcLgK4hQ3Yrc183s6KQad7SkW5Lrb5L0gMz97i/pa4usIBC1WcFt0W97CRr7mlZBq1odZLt2r4nBbDDbrOpcWX18vai6IW/euZ6LnicKtKhukLtU0tmSLkh+vydz/dvN7JWaDHZynKSrFl1JIDpddqdEsbYmLMfimp6HEJuOsnFVztivUNYiFbZ5j60b9Kj6oaIy0w+8Q5OBTY4ws5skvUSTAHeJmZ0r6cuSnixJ7v5pM7tE0mck3SXpmYxYicHJdqechsZEvDg3Lg7LfKPdqEUqbzGZ9n7lGIuYVZ2uI30MUFGZUSufMuWmx065//mSzl9kpYCozTsPjgZGM6qELxp+8dq1dRLiOJ+0OfkQl7+8slG+0dj1lx5U2tGlNIzVCVllwhzhDQuq27USAPqlzkib60bgCI1KXHh1qm9FDcyYG5VHWdzrh+HJvkeqfPlRBvsyAiHIASHxjXF4oSsCZZe3a+ukU3mZrrQob5s3e47p0JWZWzKEpitxs46VRV+60PBFl+rsf4tU84CSCHIA4tVVt651m4S4FCEOIYU6T3PX1tmVgqLbcpW462yyb5/kmXDddXdKvhBDDOoGsOx7jBCHhhHkgJh03YCqounGVpfbou/BLfYBXfq+fZtQ9JqVeY+VGSo9d911vzFj34h5vwH6gPCGFhHkAFTHN+ZxozEep9jfN+w3ANArBDkgFn1pRMXeGB0LJtXut1lV0/S17duAJGVxDAGAIAhyQJGqA1ws0jAZSkO8TrewssvC9O1JoOuP/LQLVd8jIULcyobUxVgzhDcALTCz+0t6naQTJG2R9D5Jv+vu35ty/+dIWnX378xZ7oa7R/dNGkEOQHlFjbFpAWLnHTTegCry75chVN+AJuWr1rxnRs3MTNK7Jb3B3U8zswMkrWoyv/XvTnnYcyRdJGlmkFtwvQ5097uaWDZBDuhazANT5IeJX87dPq9iSZjbVGa49VDLj3V/Gqvs+2jdpLWRNTY5BiC0aRNtM+T/2D1G0v9297dIkrvvNbPflnSDmb1U0h9K+hlJLun/0aR/wjGSPmJme9z9VDN7iqTfS277e3d/QbpwM3uFpFMl3S7pTHe/1cx+WJMK4JGahMGnu/tnzeytkm6T9DBJH5f03CaeMEEOKFJlVL0xNlKqbJ+xhrkqzzl/37pBjAAXn11bJUXUqFxdkn6jpf81xvc94hB6Am/0xYmSrsle4e7fMrMvS/p1SQ+S9DB3v8vMDnf328zsdySd6u57zOwYSX8m6RGahLXLzWynu++SdKikj7v7c83sxZJeIulZmlT8nuHuXzCzH5f0ek0CpSQdL+lx7r63qSdMkAOAuppqqGartDSG+6UHr9dJbvfMH5e6zlwndbQ+QCXTqnEYiyPMbHfm8qq7ryZ/mybVtjyT9GhJb0y7OLr7bQX3+zFJa+5+qySZ2V8nj9sl6W5J70zud5Gkd5vZkqSfkPSuSa9OSdLBmeW9q8kQJxHkgMUtWnGKtYqS71YpMf/XrNd5uaBxsUgXujr7VMzddIdg3YrfA6HCW1vn+6wu6SRNJhPfJ9AdZdItucFYqu5PPQiyGAGqcUO2x913TLnt05J+MXuFmd1b0gMkfUnFIW+fu1dYD9dkMJV1dz95yn2+XWF5tWxp+h8A6Kltvm+jdcwhbtfWeg3UonCH/mrz3LauGqJH1RzSsu57BKiiTDWOEDdmH5b0A2b2K5KUDHbyCklvlXS5pGeY2YHJbYcnj7lDUnrwulLSfzGzI5LHPkXSPyW3bZH0pOTvp0q6wt2/pcn5d09Olmlm9qMNPr/9UJEDFjX0xstYA1zV13Vtad/gNrYBLcaiyfd72w3Q3Ply15nrJLfNMLe6NL8qlw1+NKDRNfbBUXN3N7PTJb3ezF6kSfh6vyaDl+zV5Jy168zs+5oMdvJaTc5x+4CZ3ZwMdvJCSR/RpDr3fnd/T7L4b0s60cyukfRNSWck1z9N0hvM7A8kHSTpYkmfbOHpSiLIAYsZeogLpU8DnqTrubxRPYx1Ed7oStmOdVNUg5a0Ia1+7Ox2NQBJnBuHUtz9K5J+bsrNv5P8ZO//F5L+InP57ZLeXrDc9APgRbnrb5D0hIL7n1NlveuiayXQtb4EnDFJK2vLG5s/MSLEtaPofNG+W9kobBjnB0GRVK67JZUQNI19DNgPFTmgrpABjEEqNnW5HdZt/7ny5llkfevuQ+wr7UlD3AC7yhaGtmlmhTka2IhBl/thUbWQ9wVaQJADAKl81SVkiMp3OS1aNiG/O0OsxElhu6jRWEWb0v0t9m6WvC/QEoIcEIuxN9i7fu7bvLjhvrY0WbemzhOa97y73i5jNNQAl5OfT+4kr/i8aayiK6tL8Yc5oAUEOQDt6EMgKRqhk4EeMMBulanK4S1FiENMut4f88FyZaP7dcIoMNgJAABjQgMTCC//vqJiiBZQkQNiMvbulUCXRtKlcmEEQcQgxv0wW5mLcf0wOFTkgNgwHQEQl1inn+gCjVMsIp32Ysr0F4PAewQtoiIHAMAi1bg06A34XDoapyilajgb6rD9Q3gO6AWCHFBXfuj4UPj2Px5FUwOk19EFdjiyIW6RMFb03u1zuKMxiipCVdgYKAQojSAHxIQQ164qQZwAN1zZqSeWN6qHr7Wl6e/dOstrw6z5uGhEow6mBABaR5ADYkGIa9ai1VMC3LBlp55YTkJdlQA2L8xVXV5bCG0IhRAHtI4gBwBAkarVtBiDGtCUpoIbXy4ApRHkgFik3+gXTUrdVyGmU+h6FE8qcePB9ANAOU2EOALcoNxL1+gk55jaNIIcEJO1JWln1ysRQNfhKwQC3HgQ4MrJN95peI8TXSiBaBDkgFgMrRqX2rV18xyhKs+vyzBIiAPQd6GDNwEOiA5BDujKkAc3WSQIdRXgCG/jU6YSF+uok12gAtc7t73g9nv+PnzlPvG+hrGuFxA5ghyAeKybpJY/0Alw45VWiOcFOsIc+mh1SYev3Ee3veB23fSybTp8Wlha2dB1tm9viZPc9g9X2cshq3NjCXHMj4cGEOSAWAyxW+U8+1XfWvyQI8AhVSbQZSvohDrEaEq4uull23TSX07v6XCdefVBKWbNQ1h1GUNVtG3S64b+3NEaghywiDQMLNIdcIwBTmq/+kZwwzzZicFnoUI3HPku7n15XSsEqJPcpJUZt6uDwX7GHmSoziGQLV2vADBKQz4/bp5122wst7UdCHGoa21pEvDyX7iM+T08BMsbxa9hen1sr+/KxmZ4i2nQEcJIPWw3BEJFDmhbtoEwlGrcuhU/lzSwlT0XKQRCG0Ipqs60uS+XxbQA1ZQNaen9uqjSdR3WquxD+ftm1519EWgUQQ4IYecd5bpXxvYtbwhpg3ZWw3beuUeLNpQIbwglG9TSfTOm0Jaa1dDnPJyw2u5Km3/9sq911wGvDPa7idWlfrxe6DWCHNCVvlfjQjZu6zSUCG9oQ4xfvpRtHBLo9lf39WwzzPF69d+89yjnyCEQghwQSpmqXN/DW6qJCkWZhhLhDV3Kvn/b7m63yDf7BLow2u5q2WU1h6DRPLYxAiDIAW0ZUggJfZ4QAQ6xieVLF7pmxafJ6lxMrzdBA4geQQ4IaWyBI9/YDV2pG9v2RDPyg+70QegGPQ3ysN1kuxwIBeGFnieyzvlxBGfUQJADEE46D1e2wVw33BHiEMra0uxG/K6tk9tnBb1F5oqsKmSI63PDkC6h6EIX80Rmp5Zgf0cFBDkA3Ukbzju7XQ2MwNpS8X62btJy5u/s/fus743BMoNFpLp8rkOeHL7v+1AV+S97Fq3QVR2QCEGZ2e9LeqqkvZLulvQb7n5lxWUsS/qeu3800DrdKGmHu+8JsbwUQQ5AWPmqRp+6s2HYCqtqS1OqcS1W4LIWbdgNsfGdr1LktxFVDISQDWyLdJ0lnHXKzB4p6YmSHu7ud5rZEZL+U41FLUvakBQkyC3CzA5097uKbtvS9soAABCVWCoqhLhNTTyXWF7nWYb0GvbZ2lL1/WVlg/dwHI6WtMfd75Qkd9/j7l8zs0eY2T+Z2TVmdpmZHS1JZrZmZq82s4+a2afM7BQz2y7pGZJ+28yuNbOfMrMjzexvzezq5OdRyeNfamYXmtnlZnajmf2Cmb3MzK43sw+a2UGZdftdM7sq+fk/k8fPWu6qmV0u6W3TniwVOQDAsNQ5n63sY9JzN0OeMxfiG/whNgCzE2KH2EZNzQkYuntldqCMoknBUU0bA9PwHm7TEWa2O3N51d1XM5cvlwktk2kAACAASURBVPRiM/u8pH+Q9E5Nqmp/Iek0d7/VzM6QdL6kX0sec6i7/4SZPVrSm939oWb2Rkkb7v5ySTKzt0t6lbtfYWbHSrpM0n9OHv/Dkk6VdIKkj0n6RXd/vpn9naSflbQrud+33P0UM/sVSa/WpHL4mhnLfYSkn3T3707bGAQ5AEAcdm2dPchNmwOOtGWo3+CHDDdlRgCc170yxondZ8k/l7YDXaz7VVVtvO6EuLbtcfcd02509w0ze4Skn9IkXL1T0p9IeqikD5mZJB0g6ebMw96RPPafzezeZratYNGPk3RC8nhJureZpR9KH3D375vZ9cmyP5hcf72k7fn/k/x+VYnlXjorxEkEOQBA17IBLfawFkslLsaGX77R3PZAIGM4V67OsPZ1/gfmo0oaLXffK2lN0loSrp4p6dPu/shpD5lzWZqcjvbIfLBKAljajfNuM/u+u6ePv1v7Zi0v+HvWcr89ZX33WSkAANq3a2u5YLTzjsnP8kb8lZU2GtkxNbTT12Ta65K9veinjCrbtKvGdZv7ZVOvf2z7Vkghv1AI1dU3v0wEYWYPNrPjMledLOnfJB2ZDIQiMzvIzE7M3OeM5PqflPRNd/+mpDu076hXl0t6Vub/nFxj9c7I/P5YiOUS5AAA7dq1NRn2v0Yw2+abwW5MYmxkx9htbdo2aqMy2OcwF9u+FUqdQUtmIXD1wZKkC83sM2Z2nSbnrb1Y0pMk/ZmZfVLStZJ+IvOY283so5LeKOnc5Lr3Sjo9HexE0rMl7TCz68zsM5oMhlLVwWZ2paT/Lum3k+sWWq5tVv+6s2PHDt+9e/f8OwIA+ietumWH+c9PHD/rsdNCW+zdMMuKZU60qkIEl2wje952KNOInrf92ghbXU0mXVef9rmutBHg5rwOdvrGNbPODYvNjoPMdx8efrl2i4JuBzNbk/Q8d+9lEOEcOQBAs4qCWNn5BYseO5QAl+prQzo/iXKdx6fKhNl5A37Esh3bPjewjfPmxorBZRA5ghwAIG5DC25DUjfM5YNOlYZsUXAp+/hFw2dZbQx5n1W3ggmMnLsvd70OiyDIAQDism6bf/dhEuexWTSkhHhN+1LBaLs6l9WXbRQrgjB6gCAHAOge4a0/Fnl9Ynht03Voa3CStqtzWAwBDj1CkAMAtC8Nbvc0bmnk9ta8YBRrgCHQIa+rEDeGORDRCIIcACCM/EiU2SpbHo3Z4Wk7GIXS1nlzKQIdgECYRw4AsJh12wxt6d+zBiihATts2de3L691F+vZt8A7dHSpRA9RkQMALKaoCle3kTrrcX0JBejna9V2ZQ7x6CrEMXUEFkSQAwC0Z1YDn0Y0xqbLUS0RB86NwwLoWgkAiB+NXQBNoCKGHptbkTOzB0h6m6T/Q9Ldklbd/TVmdrikd0raLulGSb/k7rcnj3mhpHMl7ZX0bHe/rJG1BwD0x7wwRljDGFGVGycqcQigTEXuLknPdff/LOn/kvRMMztB0nmSPuzux0n6cHJZyW1nSjpR0hMkvd7MDmhi5QEAAIIhUAHokblBzt1vdvePJ3/fIenfJN1P0mmSLkzudqGkncnfp0m62N3vdPcbJH1R0imhVxwAACC4taX2Ax3nh3ajy0FOgAAqDXZiZtslPUzSlZLu6+43S5OwZ2ZHJXe7n6R/zTzspuS6/LJWJK1I0rHHHlt1vQEAAJrTxYThVASHbywh7oFbpFccGn65O+8Iv8weKz3YiZktSfpbSc9x92/NumvBdb7fFe6r7r7D3XcceeSRZVcDABCj7Fxy01B1CGt5Y/MHzUkrdG2ELF7LYRtLiENrSlXkzOwgTULcX7v7u5Orv25mRyfVuKMl3ZJcf5OkB2Qefn9JXwu1wgAARK9Mg7xOMJi2XKo57Wi7Sjc0aVfGGAJN290qY3jOGJwyo1aapP9X0r+5+yszN10q6WxJFyS/35O5/u1m9kpJx0g6TtJVIVcaANBDYwkaTTXy5y2XMNee7HYu2u4EvX1lQ1Msgaatybhjeb4YpDIVuUdJ+mVJ15vZtcl1v6dJgLvEzM6V9GVJT5Ykd/+0mV0i6TOajHj5THffG3zNAQDok0VCFsEgXunrWiWsZF/PMYTvWMNM02Eu1ueNwZgb5Nz9ChWf9yZJj53ymPMlnb/AegEAhmQMjdVUl8+Vqlx3qjTaeY2GjxCHFlQatRIAgHvMG9wEAGLS1jl6hDi0hCAHAEO0btK2/QYMDrv8sqg+LKZqt8qi+/MaAO0ELEIcWkSQAwAgVqHOjaPLJdAsAhw6QJADgKHIVuHKVOOartphMaEHOEmXR6AD6iOwISIEOQAYq21eL8xVPTeOahCAWBHM0GMEOQDoq3ygqltdS5cz7/EMbtKepqYbIFADwGBs6XoFAAA1bfOwXSPXbfOn6Da0b21psfBFcAOAwSLIAQAWQ1gILx/gQoU5JhYHgMEgyAHAENStzJXpTkk1Lg5U5gBgLjM73czczB7S4v98jpn9QFv/L0WQAwAsjqDQvDrVNCpwzVvZ2JxoGkAMniLpCklntvg/nyOJIAcAqCCtli1SOSs6127dpF1bF1s3hLNIIFveINA1aXWJkQ+BSJjZkqRHSTpXSZAzs2Uze1/mPq81s3OSv/+rmX3WzK4wsz9P72dmLzWz52Ue8ykz225mh5rZ35vZJ5PrzjCzZ0s6RtJHzOwj7T1bRq0EgGEIMehJuow60wvMQrVucWtLTA4OANIRZrY7c3nV3Vczl3dK+qC7f97MbjOzh09bkJkdIukvJT3a3W8ws3eU+P9PkPQ1d//ZZBmHufs3zex3JJ3q7nuqP6X6CHIAgGJUceISctCS7OMJdQD6Y4+775hx+1MkvTr5++Lk8t9Pue9DJH3J3W9ILr9D0sqc/3+9pJeb2Z9Jep+7/0u51W4GXSsBYAhCDUrCwCb9EDJ8EdjD45w5oHVm9oOSHiPpTWZ2o6TflXSGpL3aN/Mckj5kxuLuKnqMu39e0iM0CXR/amYvDrLyNRHkAGAoQnavzFpkLjOqPc1ZdI65LMLcRDpwSYgBTAhzQNueJOlt7v5Ad9/u7g+QlFbbTjCzg83sMEmPTa77rKQfMrPtyeUzMsu6UdLDJSnpnvmg5O9jJH3H3S+S9PL0PpLukNT6ieV0rQQATFc0l9msRj/BDUOyslFvIBMGPwG68BRJF+Su+1tJT5V0iaTrJH1B0ickyd2/a2b/TdIHzWyPpKtyj/sVM7tW0tWSPp9c/yOS/qeZ3S3p+5J+M7l+VdIHzOxmdz81+DObgiAHAH22zSfdIUNU44pUGRiDENdvDIICoMfcfbnguj/PXHx+wcM+4u4PMTOT9DpJu5PHfVfS4wvuf6Okywr+z19I+ovqa70YghwAYFPROXJ0uxuP9LUeY6CjKyQwRk83s7Ml/SdNKnV/2fH6VMI5cgDQd2lVLi/UACiIWxOhi/AOYATc/VXufrK7n+DuT3P373S9TlVQkQOAPijTfbLL0NZ1BScfPGbNu9b1ujYh5Dxz6fIAAFEjyAFAH2RDXBrYstdNq8pVUffxTTX6Fwkmsx471HPB8s8p302yKOxiNgYtARAxghwA9E0TA5vEFOKa7tY3lgCTf57ZQDeWbbAIQhyAyBHkAKDPupwEvI+TUhNg2AZlEOIA9ABBDgD6rKjL5TRF59mNPcTR3RDSviNWEuIA9ARBDgCGYtbolXUMMdTMC41lQuUQt8uYMe0AgJ4iyAFAnywy+Xeoalzbyo7IOG2wj2mX6ypaDuEOANAy5pEDgD6ZFeKmBbNtXj3ExRJM0vVYW6q+TrE8B/QH3SoB9AgVOQBAt7IVt7rha9rjqiyPSbABAD1CkAOAoZpWvSvTpbLtIerLDERS9nGLrEOdMNeHyh+DukxHFQ5ATxHkAGAIQp/v1nVDf1agim0C8tjnZaPSCACDRJADgD6ZNthJet20QNeXgU2maSMoVZkwu2gglRjD3LQQF+v6AhiGrXdLy3d0vRaDR5ADgD6pO2JlFbE08LtajzL/t865d20+H6pwADB4jFoJAH1XZiLwssYe4kLLBqq2whUhDgBGgYocAAxBiK6TQwlPsSgKVPNC1iKvAQEOAEaFIAcAQCiLhqns48uGuqGOtAkAmIkgBwB9N22gk6pVuj4MgNHF+WZlNFENo8IGAJiBc+QAYCjaGAilS7EGm1jXCwAwaFTkAACbYq7KxbBeQwhtMWxHAMDCqMgBwJBs831/6hhCWEExQhwADAZBDgCAMvoecAlxADAodK0EgCHb5mGmJhiDMkFtWhiKPeQR4gBgcAhyAIB+qjNUf5ll1ZH+/9gDHQBgMAhyAIBmNDVwyqyJtmf9v0VCVtnnsbYUX5ijGgcAg0SQA4Ch6rJLZRpm2q6aNREeqy5vWnWOqh0AICCCHACMTdOBouugUhTm6q7TIqFw2mPbPM+OahyAETGzDXefeuAzszVJz3P33e2tVXMIcgAwVEUDnWQb9jF2A5ym6npWuX9+Owwl/AzleQAACjH9AAAM2by55Npq7McYKtaWNtcr/TvG9axjKM8DACoys2Uze1/m8mvN7Jzcfc41s1dlLj/dzF7Z4moGQZADgKHLhrl5lapFw0zR8mMIFfl1iGGdAABVHWFmuzM/KzWXc7Gknzezg5LLvyrpLWFWsT10rQQAhDFtcI9Qy5sm+39mPSb28Nanrq4A0I097r5j0YW4+7fN7B8lPdHM/k3SQe5+/eKr1y6CHAAM0awRK/ODgYQIEF3M6Vb0fwhD8QdWAGjWXdq31+EhU+73Jkm/J+mz6mE1TiLIAUD/hZxmoMrw/Yt2o2xqJMlsmBtbqBnb8wWA/f2HpBPM7GBNQtxjJV2Rv5O7X2lmD5D0cEkntbuKYRDkAKBv1m3f897S0SnzA5s0NY/ctADWVIirE076FmgWrSL27fkCQGBmdqCkO939K2Z2iaTrJH1B0idmPOwSSSe7++1trGNoBDkA6JuikSjnjU5ZxaxqVtuDmQw5oITqAjrkbQT0zUrmfb3Ke7NlJ0r6d0ly9+dLen7+Du6+nLvqJyW9Kn+/viDIAcBQla3QTQsURYOXtBkaCCgAgBLM7BmSni3pOSXvv03SVZI+6e4fbnLdmkSQA4AxqloNajtUEeLKq3JeIwAMkLu/UdIbK9x/XdLxza1ROwhyAIDpoz02NafcrNElCSUAAMxFkAOAMctPQyCFqfCU7a45bV0AoG9WRj71CVq3Zf5dAACj0kWgIsTVx7YD4kSwQ8OoyAHA0E0b5CSGABDDOvQN2wyID6ENHaAiBwBD1tRccvMQNuYbw/x4AIDGUJEDgL4pCmdtTQYeEqFk3/MSy94XAAAR5ACgf9LQlg1rZYNb+thdW8OuU16oya7Hokygy95GqAOA0ZvbtdLMDjGzq8zsk2b2aTP7w+T6w83sQ2b2heT3fTKPeaGZfdHMPmdmP9PkEwAARIYQV1/ZgLa8wXYGYjHr/DjOnUODylTk7pT0GHffMLODJF1hZh+Q9AuSPuzuF5jZeZLOk/QCMztB0pmSTpR0jKR/MLPj3X1vQ88BADDNfsGgwUocwaJ96TanQge0h3CGSMytyPlEuscelPy4pNMkXZhcf6Gkncnfp0m62N3vdPcbJH1R0ilB1xoAMF+Zxj3hCwCAXio1aqWZHWBm10q6RdKH3P1KSfd195slKfl9VHL3+0n6SubhNyXXAQBCmXdOXNkKTVeVHCpIAAAspNRgJ0m3yJPNbJukvzOzh864e1Hrwve7k9mKpBVJOvbYY8usBgBg3SYDlmRHqUyvS//uIiRR2Qtnbana9iQUA3Fb2ZBWx/U+ve2Ag/XXh21vYMmfa2CZ/VVp1Ep3XzezNUlPkPR1Mzva3W82s6M1qdZJkwrcAzIPu7+krxUsa1XSqiTt2LFjv6AHACiQn2Ygrw+N+j6sY9eyYY7tBQAoUGbUyiOTSpzM7F6SHifps5IulXR2crezJb0n+ftSSWea2cFm9iBJx0m6KvSKAwAy1m1zSgGqY8OwtkSIAwBMVaYid7SkC83sAE2C3yXu/j4z+5ikS8zsXElflvRkSXL3T5vZJZI+I+kuSc9kxEoACGTX1v2DWraxT4gDAGAU5gY5d79O0sMKrv+GpMdOecz5ks5feO0AYMymTdo9q9sd58cBQHxGeJ4cmldq1EoAQGTodgcA/cL8cwiMIAcAMdm1dfNnnhgqYVXXgfAJYMwIcwiIIAcAMSgb3lJpgIohzKFdvOZAvxHmEEil6QcAAB2Z1njvssJFoAAAoDNU5ACgS2UqcTGGuDr/v+v1HQq2I9B/VOUQABU5AOhK3fPgyjbkY5hQmtABYGiKRp+sE8wYyRILIsgBQBfKng9XNwjF0O2REAcAs6UBkECHGghyANC2KoOa1NFVJY7gBgD1EOhQA+fIAUCb+hriZlX4mNMOAMLg3DlUQJADgLb0NcTNQoADAETCzEaVhAlyANCWJs5bW97Y/GkSgQ0A2kFVDiUR5AAglHQqgezPum3+hDYtvMUw0AkAAB0ws2Uze1/m8mvN7Jzk7xvN7A/N7ONmdr2ZPSS5/lAze7OZXW1mnzCz0zpa/UoIcgCwiGxoyysKVKFCFmENAIaLqlyT9rj7wyW9QdLzkut+X9I/uvuPSTpV0v80s0O7WsGyCHIAUNesc96anMSbEAcAGKcjzGx35melxjLenfy+RtL25O/HSzrPzK6VtCbpEEnHLrqyTWP6AQCoo+mBS6YhxAHA8DENwTR73H3HnPvcpX2LVYfkbr8z+b1Xm1nIJP2iu39u8VVsDxU5AKhiWjfKPAYHAQDUQYhb1H9IOsHMDjazwyQ9tsRjLpP0W2ZmkmRmD2tyBUOhIgcATVlb4pw4AEB5hLjazOxASXe6+1fM7BJJ10n6gqRPlHj4H0t6taTrkjB3o6QnNrWuoRDkAKCs2LtTUgUEgH4iwIVwoqR/lyR3f76k5+fv4O7bM3/vlrSc/P1dSb/RxkqGRNdKAGhSNlzVCVqEOACIX90gtrpEiAvAzJ4h6R2S/qDrdWkTFTkAmGfRSlzdkEWIA4D+WF0qP20A4S0od3+jpDd2vR5tI8gBAAAAIWQDWlGoI8AhIIIcAMSCAU0AYDgIbWgYQQ4ApmlzcJO6IY5ulQAwTGW7aWK0CHIAUFc+fLUdqghxADA8BDiURJADgKwyVbjQXSDpUgkAkAhxqIQgBwDS/AAX28TeXVbj0udARRAAmre6JJ1OwMP+CHIAMEvoatna0nAqcMsbhDkACI1BUlASQQ7AeK3b5t/L2gwldYJW04GGwAQAw0eIQwUEOQBIxRjg2vofdVGVAwCgEwQ5AOORrcCFMMYQN5RuoQDQBwx+ghm2dL0CANAra0ubP4sso+xtMQWnmNYFAICRoyIHYBjWTdrm+18XUsjq2LRlxRqWZq0X3SsBABnr371T7/3U57pejcGjIgdgGPIhLrSugkoMASnWcAkAQ0a3SsxBkAOAeQhxAIA2EeJQAl0rAQxLzN0pY/x/8wxp3ru+yG7v2PYHAEA0CHIAhiF0gJNoRKfmhTm2U3MIdcC4UIlDBXStBIC8RUelHIrljc0gwfZoB9VPAEBJVOQA9F/IahyBZf8wQTWuHfNCHKODAgAyqMgBQBYVEbQtW/kEAKAkKnIA+qmJc+IAAOjSalJ151w5lEBFDkA/NT1vXJuoyIwb3SUBADUQ5ACMW74R3XajmgCHKthfAAAJulYC6J9Q3SrT0NZFRYQGOepi0BMAgKjIAUCzikaAjDnEVVk3wgQAAJ2hIgegP/o2zUAaisqEI0LReNUJ9lTlgOFioBOURJADMDxFDdxsY7mtBvDa0v4Tag+lGof6Qm1nwhwA7MPMXNJF7v7LyeUDJd0s6Up3f2KnK9cAghyAYZnXsO2i4RtzY5vwVl3dCivbGgCa9m1JDzWze7n7dyX9tKSvdrxOjSHIAeiPbb7ZvbJqOOpyQJOYGvAxrUsfld1+bW3nfMUXAPABST8r6W8kPUXSOyT9lCSZ2SmSXi3pXpK+K+lX3f1zZvYvkn7L3a9N7ve/JP2mu1/XwfqXxmAnAPqnD43W2AJT7IOsYDG8tgCQuljSmWZ2iKSTJF2Zue2zkh7t7g+T9GJJ/yO5/k2SzpEkMzte0sGxhziJIAegT0IOdtKk2BrVTaxPH8L02MS23wFAeEeY2e7Mz0r+DkkA265JNe79uZsPk/QuM/uUpFdJOjG5/l2SnmhmB0n6NUlvbWj9g6JrJYC4ZcNbnfDQdtezmBrTMa3LUGQHsAGA0Bixcp497r6jxP0ulfRyScuSfjBz/R9L+oi7n25m2yWtSZK7f8fMPiTpNEm/JKnM/+gcQQ5A3BYJYE01uKeNFhhLA7/p9Rh7NS7mMMdIlkB/EeJCerOkb7r79Wa2nLn+MG0OfnJO7jFvkvReSf/i7rc1voYB0LUSQNx23jH5qSpbiQvdsKWhPG6xhjgA/UWIC8rdb3L31xTc9DJJf5oMZnJA7jHXSPqWpLe0sIpBUJEDMExthy0a94gFVTmgXwhxwbj7fgc/d1/TZhfKj0k6PnPzi9I/zOwYTYpclze6kgFRkQOARS0a4vrW6B5zaB3zcwcQHiEuCmb2K5qMbvn77n531+tTFhU5AHHbtbXrNZgv5nOmmjKUqs+01y3/3Mb2+gJoHiEuGu7+Nklv63o9qqIiByBudc+RG6s2A0ffw01sk3sDGA9CHAIgyAFACDFUp7oIHEMMOTG8losa4usCANgHQQ6oog/d/IC2LW/0LziU7VIJAECkCHJAWW2FOMJi/GINLk1MtVBFul1i3DZZRes3a9v1NdzF/joAABbCYCdA09JgNu08L4JbOTvviGNbZRvHIQb86GtImCcfImJ5ntNC3DxjHNAGABA1ghz6Z9fWxQe/yAaCWcsqCg7zgtm0x8YQQrC4PjToY1zHGEa5jG2btCGG7Q4AaARBDv2ShqGyYSp737q3z3pc+v9Dh7RpQXPdJr+3edj/N3ShG7PZoLRIOBhbAzvdVkVBs+ltsWiIG2MIBDBdftTJ1QrHMEasRCClz5EzswPM7BNm9r7k8uFm9iEz+0Ly+z6Z+77QzL5oZp8zs59pYsUxQrOqY13ZtbX5dcguf2wN/xBCBK4isXepjHlfKXotmjy3buwhru/rD/TByka5gEaIQ0BVKnL/XdK/Sbp3cvk8SR929wvM7Lzk8gvM7ARJZ0o6UdIxkv7BzI53970B1xtjMyssdR3m2rBfmAvQvXQM8g3YsXUzi7GL5TzZ9Q3xWo09xKViPWcR6KNZYSy9rUqFDqipVJAzs/tL+llJ50v6neTq0yQtJ39fKGlN0guS6y929zsl3WBmX5R0iqSPBVtrjE82tEzrVpkPdNluj011gexSiHMF0+XkDTUkjrHxmj7nPgaSNoL3GPcJaXxfagBtmxb2VpeoyiGYsl0rXy3p+ZLuzlx3X3e/WZKS30cl199P0lcy97spuW4fZrZiZrvNbPett95aecUxYjvvmB80hhpE8poKpkMJvNmGamyN1raH6Y/t+Ze1yDaa99h526SP4beKPkwVAcSobrUtfRzVOgQytyJnZk+UdIu7X2NmyyWWaQXX7Tcyg7uvSlqVpB07djByAxY3LbzFMmx9jMp0WY0pFNeprMYeYNqsjPS1Okf1qFmhu7MCY5CGsbrVNSpzCKBM18pHSfp5M/uvkg6RdG8zu0jS183saHe/2cyOlnRLcv+bJD0g8/j7S/payJVGBfO634XqnofuVH0Nq4baGANdLEKdg9Z2UOnbuXNVtk2fnleMCM1ANWUD2ciqcLcfcoze+eBnNLDkFzewzP6a27XS3V/o7vd39+2aDGLyj+5+lqRLJZ2d3O1sSe9J/r5U0plmdrCZPUjScZKuCr7mADaVDWdVQhzdrsoJ1ehlWy8u5DYc8+vBex+oZnVp/6CWXld0GxDIIvPIXSDpEjM7V9KXJT1Zktz902Z2iaTPSLpL0jMZsTKQRatn0xrxZSfHLrvsokFGujTmbpUhn3ssr2eMsmEuxDldVEQ2NbktqD7Nxv4IVMNccmhZpSDn7muajE4pd/+GpMdOud/5moxwiVDqdoer+thFQ10so0N2/f+70MZz7ks3yy7P+QlxHhoBY6LqNgi17bEv9kcgHAIcAlqkIoc2NNFlru7/ntZ4L2rcx1aVQ3V9bbjF0hCftv3Krh+N5/qqBLpY9peYsR8Ci5sX4OZV807nWIX9EeRil69wdVlpiqnKNS8gMlLlsPX59e16oBGCC6ogxAHNmxfiqOJhCoJcX/Sh4VrmHDwpTIWOKl/7sgFg3aRtzBpSW5kw10QDekwhbkzPtYq+TkEBDNnKBgOioBaCHNoX8jyrWef05S/HHoRjVtToW0+mjOwq0E07H7PrilcIVEEm6nQv7ftr36TsthzC+wQYkmyYowKHkghyaF9X1bRYBmJB89JGaqyBiAZ0eWVfR7ZpdfPCXKzvH6BvygYzAhwqIsjFbuyhI3suXP68uPy2aaILJ+brujI3TayNUAJHdfPCHNu0HLYT0D7CGRpEkIvZUENc0fMqCl1NDfDSh/MNY1OmG1ZXgY7XcxymhTnCSXixfgkCANgHQQ79VKbhztQHYZU9p4btjqYQ2ppFgAOAXiHIxWpsFYam5ssrGgxlbNu2C22HuT5V5Rg1ELEhwAFAL23pegWA1uza2p/GfqwYdCKctaXi7UmjGm1ifwOaxbQCaBBBLiZp0CBsYAja3o+H0J2zyUY1ARt5hDigeQx20jozO93M3MweUuOxbzKzE5K/bzSzI8KvYTgEuVgQ3tAXMTf++hzmCHFoU8zvYwBYzFMkXSHpzCoPMrMD3P3X3f0zzaxWeJwj1zUCHPoo5vO8+nS+nBS2QR3j64G4EOAADJiZLUl6lKRTJV0q6aVmtizpjyR9Q9KDJf2zpP/m7neb2YakV0r6GUnPNbM/kfQ8d9/dxfpXRZBryrTBHvrUG4DJewAAIABJREFUwATmiSnQrdvsqQ/SdVykIZt9nrE1iGN4DYYm+xrHuH3n7YMx768AUM8RZpYNWavuvpq5vFPSB93982Z2m5k9PLn+FEknSPoPSR+U9AuS/kbSoZI+5e4vliQza/wJhESQa8K8iaqBockGuq4ajLFNSN6mGENG3+X347LTb7SlzPuM8AZgePa4+44Ztz9F0quTvy9OLv+9pKvc/UuSZGbvkPSTmgS5vZL+trnVbRZBLiQCHNrWZXAqEtO6NCG2xrwU3/oMWSyv/9DfZwBQg5n9oKTHSHqombmkAyS5pPcnv7PSy//b3fe2t5ZhMdhJSH0eaAH9FUPDMkYrG82MFhZTI5rXvhkxvcYA+osRK9v2JElvc/cHuvt2d3+ApBs0qb6dYmYPMrMtks7QZDCU3iPIAUNAg37Tuu374bmyEeb8uKy2G/rLG7zGAADM9hRJf5e77m8lPVXSxyRdIOlTmoS7/P16ia6ViyjqOln07QuTQaINsXWz7KpCvc2l1a2b78XVJUk9DEFFwS3/GsfS1Q8AgI65+3LBdX9uZtdpMhLlGQW3L+UuL2f+3h5+LcOiIhdKU924gFnywY1G/cTyxiTArS6Fr8a1Ydrr2KfngObwPgf6gS/y0TCCXBX5ClxacSDAoUs07ost57pU9uXLlqJG+trS9NeZ1z88urICCIUw1zl3X3P3J3a9Hk0gyFVR1FWsDw1DDB+N+X1lpyJIQ1wfTAtx6EbMgS7W9QKwvzTMpT1F0h9gQZwjV9dRJSYM5E2KNsXU4I9hBNdtvn8VvW/vyZhe0zGrG5qKXr+QAayP3YaBsSr6/Fnt0ReNiBJBrqxsg3Dem65vjUWgSevW/WTdfXlPhhq8JNuwp3LTnbYGIMq+xoQ6oF8Ic1gAXSurIsQB1XQZ4voYYtLz4fo6VQK6FXN3UADFaDuiJoJckV1bN3+yCHFAPeu2+dOmriuBbcg32ouCG2GueWW3cTaohwzseYQ5oF9oQ6IGglyRnXds/qSBjhAHlFc0x+I27yZYxXC+XlOqNNYJc81Jt23dbdxkmCPQAf1BWxIVEeTKoO8ysJiuK2NDC3M00OOVrbJVCWhU5wBIhDlUQpALgTcdsL+i7slY3CKN8rarcm10IYxVU9W5utuTMAf0R75dSTsTUzBq5TxU4wDEYl5jPIawNGsdQo3KGZPQ23zW9sn/r6rbs61RNAEsjvCGEghyi+KNBqBpIScKbzJMERKaE2rbEuYAYDDoWjlLmUm/AfRDX8+Tmxa6YqtsjTEctFmNC3F/AMCgUJFbBNU4YL5dW/sbomYpM+x/6P9RdHsMASqGdWhal89xDNsXwLDcebR0w4saWPCLG1hmfxHkpmGQBmB40ilF6poVrLqaCqCLMDe2YNHW8x3bdgUALISuldMwyAkQDl+MNKtqF7tFzq8bW9go83z7Nh1En9YVADAVQQ7AMKzb5KcPmmhIN904DxXg+hQEY1/XRdavzvl4fQusADBwBDkA47LI+Xqhu0SGnk6giUZ2E1W42AOSFM9k3k0qu7/k70eYA4AoEOSmYSATIKymulfmK3FNV+W6Hqkw1PLKPI8mw0kfg88YEdoAIFoMdlKE83mAZjQxguU23wxva0vllr/ooCdFIaTpudmaqrZ1JeaAQMgEAPQAQW4RKxtU7oCYdDXNQRuhJBsuZv2/2ENIzAFOin/7tSH21wgAIImulYtjdEugmrQr5LrpIj0kzDK3eXcN8OWNyf/f5tUfmz23aucd5YPotOcacwhhoIxmpPtQ3dc++5rwGgFArxDkilT9Vp8wB1R20bYHh11gV9W4bAM6DXTZn2xDO39dkUXDXKz6MOVB37ZpXtH6lwl6BDgA6CW6VoZCN0ugnLUlGo1F1m2zqpdun3nBom/Bo2z30KL7s9+UM2ufCLUN+7bfAcBAEeRmWV2qVm0jzAHjUlQ9mzWIyrwBVtJBW9JAt7Pk4/po2oAxXYWEsYSTRcPcWLYTAPQAXSsBtC/TGLxIDwl3rlzXhhi42kSIa8fYni8ADBRBDkAnztr11X0u9zLM7dq67w+a1UQAGXqo4fw3ABgsgtw06QhydJUEGnPWrq/qrPXPtf+PCV39FSp4tTmISldmjUg5hucPYHTMzM3srzKXDzSzW83sfYGWH9U3YwS5kAh9QHVrS92EudjQqC5v0SH3h7it06CW/Zl2v6whbgsAY/ZtSQ81s3sll39a0ldn3H8/ZtabMUQIcmUQ0IBmJWGul90rQ8o3qumyOV/VIDLU4LLI8xrqNgEwVh+Q9LPJ30+R9I70BjM7xcw+amafSH4/OLn+HDN7l5m9V9LlZrZkZm8xs+vN7Doz+8XMMs43s0+a2b+a2X3bfGJ5BLlQCHvAYmhMTrAd0LSial3ZKifzpgLo1hFmtjvzs1Jwn4slnWlmh0g6SdKVmds+K+nR7v4wSS+W9D8ytz1S0tnu/hhJL5L0TXf/EXc/SdI/Jvc5VNK/uvuPSvpnSU8P+uwq6k3psDM775COsvn3Y+oBoB9ir3B1NbE5+q/pufbWlqTV5hYPACXscfcds+7g7teZ2XZNqnHvz918mKQLzew4SS7poMxtH3L325K/HyfpzMwyb0/+/J6k9Hy7azTputkZKnJl3OLl7sc3lcBCOFcOtZStYo6t2jmrysZolgCG7VJJL1emW2XijyV9xN0fKunnJB2Sue3bmb9Nk6CX9313T6/fq46LYgQ5APEYW0O7SOwVw1hlQ8uY96P0uee3wbRtQqADMExvlvRH7n597vrDtDn4yTkzHn+5pGelF8zsPkHXLhC6VoZE10pgceumi7Y9WJJ0lj7b8cp0hDC3OMLcvuaFtT6EuaJeL3zuAijg7jdJek3BTS/TpGvl72jzvLcifyLpdWb2KU0qb38o6d3BV3RBtlkd7M6OHTt89+7dXa/GbGXOk+MDBQhjeeOeMCcFDnSLhqTljf0bymkjeMzhAXELFdS62sdnnbrAZy+GbmVDdquumXduWEzsoTtc726gbf9g69V2aBoVuVD4IEFIdc63HNI+uLaks5Y3z5e7aNtDwoS5EJWuooYsAQ59ku6vdcJdF19azDseZm8f0nEQAOYgyAGxqTtoTvq4oTRkMg3Fs5Y/Fy7MAWOWDWBNj3JZVv6Yt8gxjFAHYEQIcmXM61bJhwVCCTHy6RAbMmtL0s4Fl7FukgayPYCqplXQ2ghzVY9r2el8FjkmDvFYCAAZBDlgyAY2v+FFeoikBc6ZKzq/rW3pPHF1u3lm55ljUBSEUDXMTXsPhZ6CJ+TyOMcObRla7xhEjekH5qEahzasbDQ3DyHzG27qOsQBsSrz3pg1tUMbIW51afOn6f8FLCrU5zr7J2agIpfatXXfb8qz33oDTWnrAD2AytxZu76qi3beT9KkMle5KhdLiFu0ikYVDk2ZVZkrev+02cDMH79CdL3MGsAxcpCGMOXEIl18CXGYgyA3TZnpBoBFtH2AHkBDJQ1zDHoCNCSWAVCyio5bNHCHq+4opSEHzWnKAD6HEZdSQc7MbpR0hyYT4t3l7jvM7HBJ75S0XdKNkn7J3W9P7v9CSecm93+2u18WfM1D23lH9W+6eTOiruUN6fPJ32tLVOYqOGvXV6sPfEIVCygvH+a6rmanxy3C27DVeX1nPSbWc9XKfg6zv6OEKhW5U919T+byeZI+7O4XmNl5yeUXmNkJks6UdKKkYyT9g5kd7+57g61108q8eWI7MKA/8t92h/r2e9o+mR/gI4YBPwLbbxCUWIJbvot2LOsFzBPbMYJG7bA1+fq2/QVmmS8dyqwTX16ghEW6Vp4maTn5+0JJa5JekFx/sbvfKekGM/uipFMkfWyB/9W8Kg0sQhzqWslU4uqqsv+lIbEoPMbWUKti2nms69bf58VolOhSnYm+Z3Vr66MB9FhAj7C/IYCyo1a6pMvN7BozW0muu6+73yxJye+jkuvvJ+krmcfelFzXD0P4MMIwVR2tbV6lL7bzYKratfWen7N2fXXS5TK2EEcgQx9kjwV1jwtDaZDSBkAIId4P7IsooWyQe5S7P1zS/y3pmWb26Bn3LRolxPe7k9mKme02s9233nprydVoUNlRKofyYYV4NBU+yiy372Gub2YdZzLBdOH/wai7WMTYwxyGJ9ZQNG29Yl1fRKdUkHP3ryW/b5H0d5p0lfy6mR0tScnvW5K73yTpAZmH31/S1wqWueruO9x9x5FHHln/GbSJDyksKr8PlR3opO6+R5jrFoEKfVA0P1yd48JQGp9DeR59wfbeF9sDFcw9R87MDpW0xd3vSP5+vKQ/knSppLMlXZD8fk/ykEslvd3MXqnJYCfHSbqqgXUPiy5QaEOdxtGiXyAUhbmhnTMXo2khrs4IuVX/J8cz1JEeA7Ln1s6aADz0XG5Ak9o8J63ue2JI76XPr0un7up6LQavzGAn95X0d2aW3v/t7v5BM7ta0iVmdq6kL0t6siS5+6fN7BJJn5F0l6Rn9mbEyllvIKpx6EJT+13RXFExh7mhBZQmwxzQtPSzckiNzjwGohimNl7Xqu+LIb+P0Li5Qc7dvyTpRwuu/4akx055zPmSzl947QCgj8p0qWwizM1b3tAC8Zg1OUdWjJOCdyHWeciGpu1h9pt8XQllaNki0w+MBwdxNIWD/vBwXhya0PaxYlZ1fmxdKqnONa+LfSpkoBvLewHRIcileBOOWxcf1GtLktjvSqGCFAbbcThiCBZMWIzQ+hLo2O8RCYIcDRt0dUCe93+bbqjRfaoZ6TGFyhyaEkOIS40hzNVp4Jd9THbbxfS6dq3LQAf0SNl55MaLA+vwVZ1oO4Qyg4q08aGSXY9YBzrpqzJzwhH2MAR8Tk5kj9krG7OP4UW3z3sMAORQkUsbUitF85gDDWly7riqZs0fRbhb3K6t+w8ysrwhbfPu1gn9Q1jqpzrTNHBOHoCSqMgBbTu+6xWogK6XYeSrc7EE5J13UBUE5lm0SkalrT4CLTATQW4WDiAILZYGPLpDeMIQDf3zcl4QCx3UCH6bhr5vAQuga+U0HDjQhD58ODMISru6nNut6v/MBtCxDxQ1tjnGxvZ8y+jD8byMPnTlHMOgOkANBDkgRl1/qFI5HBca6dXkB7UY+nYr83zH0MjOvk/G8Hyzuh5lGUAhglwRDkjoWloRI1ANT3bwk67VbYz2rRqXH+I99JDvYwhzWWMLMXlDe/7z9t0yz5cvg4BOcI4cEJvsByFdHBGTMlMqxKZoiPdZl8sYU2N1aKEF1VR9/dlfgFYR5PLG9AENAFlDaISlIwSOYaTAJp/f8sbkh8/E9nUxt2mRuvtXE/vl0N/LCMbM9prZtZmf7TPuu2ZmO9pbu/DoWgkA2NTnboKLNDyrPOei/9PVdgv9f+kFgBChKb+MuvsoAQ7VfdfdTw61MDM70N3vWnAZB7j73lDrlEWQy+pr4wX9UeYk+bRhRoNquNo4T67sCJO3JBOTH2Wb1/UxzLXR4Cv73m1Dledb5pzA9D6fr79KiFTRvjJvP+hyHZpeF4yOmT1C0islLUnaI+kcd785ufksM/tzSfeW9GvufpWZvVTSMZK2S9pjZpdL2uHuz0qW9z5JL3f3NTN7g6Qfk3QvSX/j7i9J7nOjpDdLerykD5jZL7r7w5PbjpN0sbs/YtHnRpADYre8waAnQxTDuWazGlJ9CnOhKgjztkeI5YRQdJ5f2Yb5vOdxvPb9IonGdPsW3YeqDE7SpRjWAUN0LzO7Nvn7Bkm/JOn/b+/uYy2rzjKAPw8DCmVANMMgDKRDzTAI5FJkJEAJGduqNBq5jUWovQ1g4x2TarFqTNEmEk2NJsTYGFuYIm2TQSoCHdE/hApMNDWCw9cdpzAtFtIyxd4BC53BUj76+sfZ+86+++zvr7XWPs8vmcy9+5yz9zr7rr3Pes+7Pv4KwOVmdoDklQA+AeDXoucca2YXk7wUk8DrnGj7+QAuMbPvkbym4Hh/aGb/S3INgPtJzpnZUvTYq2Z2CQCQfDfJt5vZ4wCuBfC5Lt6sAjmRIemDS4aSDBSL1qqLt2Vli30M5hYPYYm2atMcmPPk+vvuZGr9Ps9bXlmyZg30aYyTDEN/Oxm/dSR3J37fbmbbE7+v6lpJ8hxMgrMvkQSANQCeTzz/dgAws38leTzJE6Lt95jZ9yqU51dILmISU50M4CwAcSD3d4nn3QLgWpK/A+BKABdU2HcpBXIiIVBWTlzpeqr+FuVYoqGrmK2WJuuGNQnmEkHq3M0ZQXcomRYRkf68YGZ1JighgL1mdlHO45bz+yuJbW9g9QSRRwMAydMB/B6Anzaz75D8XPxYxj7uAvBHAB4A8IiZvVjjPeTSrJUiQ4oadku0qaxCKY2ZkxlW+3rpWpMgtu7MmdvXYs6IOUuNV+xgBs74nuP8PIqIDGsfgBNJXgQAJI8ieXbi8Suj7ZcAeNnMXs7Yx7MA3k7yCJKn4XA27XhMgrWXSZ4E4D15hTCzVwHcC+DTAD7b7i0dpkBOZGhRY60RBXPSRNX133ydfGDI47rOaMV/gw6XT1DwFiDX9VBkJMzsNQDvA/DnJJ8A8DiAixNP+Q7JfwdwE4AP5ezmy5iMt9sD4EYAj0b7fgLAYwD2YjK+7sslxbkNk4zffY3eTAZ1rRSRsBWN/5IwpcfBDd2dsusxbl1NpCIiIoXMbOpmG00wcmnG9q05+7gh9bsB+EDOc6/J2b4xY/MlAG7tcikCBXIiLmxfi7nFgtbp4qH8acBDHy+XN+2+ArFhZU2OMX8QmMfqpQiyXtfnWLmMyUzKLNGaZ7kLytHL/gYeZzg1MUzX50lmT9s1F0VmEMkvAvgJAO/scr8K5EQc66UR6quitdOqBHhZ2TcFgPUlG1cNJ+WoNN19g6Bl9N0AHTZs4/vMTN1zZkkfdavtFw9NJgoSGSEze28f+1UgJ+JK2QfcrhEsCt7Fotd5+6iybwV507LqXLytKEuc95rkmK6yY1UZg9cgvlBQUk0ySF6ZHVPnLmxdB0m+LTciIoUUyIn4qqh7pS+6CNT6PO78QQVzsboNvuWo0V/UzbLufkue2yQb11cgMpYuiXPG8Wc5x0pjK0WkhAI5EccKG4h5WTnX4+RcBXBNJLtjJss9SwFeIA2+ZNc/V/KOXVamUAM98VxWMBfI9RxMOUUCpkBOxGe+ZeVCCuDS0mWf1aCuqrJMXCCyArA+gq5Qxp2FUEZJCSkgSk5WlKhqqnci/dA6csBoGiwSoCrjEc7I2T7U+Ln5g4f/jdWY31vflu1wN8wONJmxsu5jTbNuoVNjWkq1CBqXth0c/TUk4htl5BTESQiKuljGj3dlVoOarC6YytRVlw7mHN5bqzQm+2hw+pqV87FMEpAqS2c0nKjIlarXv64d8Z0CuaS+10cSaSrrW9I+ulx2HMTtwJlYeGlffqCZDphmNYgMWRywdZiVqyPd0HKdEfA1mJNxyqvvdevgqnqbbAslu0puA+Zunv5ya2nbwWCCOC/WqBTpkAI5CUfL9am81GbsQ5yl6yIb10MAB6A4iAOmM15Za8YNLWumS2XrynWUgaszy6JvQVxMjT/pW1ldz6uDedvj6y4dzKWPs7St2X3Z9TXR5t7guuwiRRTIpSkr56d0wBPC36msO0rbAewr+2+3m66tzsJF733rIew4YfPUc0sDPVfaBGtdBnpZdSRZn4rqUMAL8eY1mqYalZ4EblnGsnyB+KdqvU+uFZheQzAvmFv1+oZBW1F5dB2IdEuBXJa6i9iKGyEEc0C18QVt999m3x1lvuIAbiEZwJW95oTNwDywgKc6KUNvkkFZnQCtTVCXF4RVDc5CCOKS3TFLMno+B21VaAFuccWnLxVcBHOh3ztEiiiQk7CVZSxcSmdEUuMOOlUlmMuaGKXD7osLO/ejagC36nU+B3F1zk8crGWN96sb0IUQhKVVXUB8qP14KtmoVFAnPutrMfkhg7muyq/rVnylQG7ZRttgmFl9Z8DqGLJ7W1EwlzXjZQdB3KqxcEVB3K61WMB+7Jjf0PqY3soaW9dEiEFcUzXuvXnjfUKmLJ245LL+DRHM9XV/UBfRil7/P+BbT7guxegpkJPx8imgi/XdSE+/56HWmqtoYef+lTLFY+biYBDwPDtXxSwvMt7VF2I1g7u8cUAhUUDXv6EWhg9B3lhTF10e+zpm3/cCBXPiCwVy0o2ySRfaapLZ8imAG1pedq7GxCI7cGbUXTJD1uQliW25r0uUYWHrvql9JIO6tOCCvHRQN8tB3oxo2rCLG51qHHavzoLxOvfT+v6CpE6drxJwtilrcr9V16JUnRHXaOb+G8wtW7bY7t273Rai6FvgWQ4I6uo7oCsL5uocY6jxda66ym1fW7xg+NZDwAkF13+VYCOR8UsHZYXBXOL1WbNZruwjOatlUWAUqrxzPEvdKxvKGrPiMiPXtkGnrFy3mtSFUM59X/W8rwCpTRmGOG7VWXLb7q8tHsAjZrall533gDzFgG097PmGoM5D35SRiwU8VbdX+prMI7n/vH0PESjWPZbrOpUO4KoGP1UzRon9L2D/6q6cWzOOn/H6rMwckLE0QdGac0V8Dvi6Glc3g4rWwvKhLE32sURTQNdSqN1rfTdUgJXMcrkM4rKeV2fZB12/MhQFcrH5gwCOc9/wHos+A+O8fdeZhr9C2QpnqeoyMzgmcYbvpeh8VVmwPJoIZdpIz2HWrJbSTMbyBS6CuS6Cr6xxS2oMVhf67Io+qDMzY5/XmavsX14Z4ueFPA5XxkuBXMKO+Q1YWNznuhjj0VUwt3hoqqGU+wFbcYKTsg+s1jfrZDlcfjmQ7o6YzP50uXB1+lirumw6zjj5Fjh1fd5lIjED8RANrqxjNA3o8so6a4FEU32P4QJmL0Nape65CGzqjmNzRdeuDEWBXBVxpieUBah90uR8pQKf5M0672cg9UFbENAtbVvdoC/7MGh8M46P3Xd30zyLh4D5YQ+ZyZfug76Nq0uXxYdz5Lv0GnPruTorl/h5bn1/jcyyb+jzGnFNyqMG4TDKzvGsBXR9dDlsK10m35ck0bUrQ1Agl/ZVAGdkbI8b4T5OaT8miWCn7g05fdNcYrNxtr3deF1k5+IGb1Z9ncXAwbfsXB7XmdyQxHV8efp+4bIrlE8NyrHq8hxnNbp9bYT71sXPp/L4MPFRzNf6I+OiQC5hZXKF7dEGNaSKdZ2hTHShbMq3WaamuGqgu/4CwpesXCyvLC4DvPSx59Hd2mxjUXQ+0o/Fgd1J3RZhrIsnS1j67GLYpK4NEczVuQ7KZqKsOz6urjqvq37edA+QaQrkkmqssTXz3SybZiijYG3u5uMyt7uQecPN+HZ/Sl6jMn0u0uPUxpZt8T27VUcoGTtxRkGVHzS5yWFdBlFt3r/rzFyVAKxKGYeqAz5kDSV8CuTamPVgLikZmOSdk0SwtrTt4OouEA4+O+eMUVkTY9iqBHCx9HgdwP/64KrO+pSNq6JqeaN18DpfrDw+flYdk2p6HCOX5LrxKjKrXPTA6arrpu4Z0hUtCF6kTuPJReM4L3gaorHeIqM0xGxytdQJ3rqw04NlLvqoH1lZrNACuCbKFlbvkgK6yrrMUPQ+y22NsvQthKxUn+fb9/depu256XIJDZdcZ9WqTp5Tx7nLDGohbC0IPgxl5LriOjuXPL7vWaGeVL5xDx24zYLFQ8BihfM/xrq5ay2AgWbEnOEMnYtZA9OzU4beyC+z0mPC4xkafQoWXCicrRnuMsS+/136qtNNMnS+nysJyxGuC+CtJg2lIbMsrjM6HpkzTm6my1btn2s+jL/qsv7U2dfiocP/pDlf63ZPipYd6UudGQx9DHiKLNGCbEyGWOa+Zf0tq9THsslAQhefl/T56XNJkpW2SMFxxnJ+fUZyphoYCuSG1FXjVY1gABkBnNTjOqByffyu+dCNNMTroMH1WxaIuOxe5rPkect6j+ltPjU6fSqLj+qcn2Smuau6HtI1M9TwjvRxVIfHi+QaV8dWINe1vIZpepbHrvffxb4H0vaGrwCuY67rzdgCOtd8vS6ysocty5n+xj3UTFMVQzWUfWuQD/k39e2915Uey1klWE8+t8vAbtbpXLpFci3J+0k+SnIPycuj7RtJPknyMyT3kryP5DHRY7tIbol+Xkfy2cRr/i3a16MkL462byX5IMm/BbCH5J+QvC5Rhk+Q/Ejf71Vj5PK0GYtS1ijNezw9fqjKTJAzYuWGuGwAxtlQc8aXuuV6nOnYFAVJQ46xyytHx8Gm6wAutNkri8b8+dIAHfJ8+vKe20r/XYceUxrKNdDFWnF1hXR+RuBVAO81s++SXAfgP0jeEz22CcD7zezXSd4B4JcB7CjY1zKAnzWzV0luAnA7gHiylQsAnGNmz5DcCOBuAJ8keQSAq6LHe6WMnE+SgVs62KuatRhhZmN1ECed8i1wCr3++tC9sgrfriWPJm+pu5BvlSzIkGWqw9cMpi/l8qEMIQn1fIVa7hm2juTuxL/FjOcQwJ+SXALwLwA2ADgpeuwZM3s8+vkRABtLjncUgM+Q3APg7wGclXjsYTN7BgDM7FkAL5I8D8DPAXjMzF6s//bqUUbON100ZOsu0u2hqYaLbw3PMQi4foj4pM9ZHse05IDrBnOTjMgszFYqfs/UKlNeqLD8wAcAnAjgfDN7PeomeXT02PcTz3sTwDHRz2/gcILr6MRzPgrg2wDOjR5/NfHYK6nj3gLgGgA/DuDWsjfSBQVyZZat22+Lt68dLuvgaVe1Sh+kXwVwRu9FEelenJXzYXbSPENmwNanMuo1jz1047/JDIB5r21ryDW9+mzIug7ggNUTfMRCbLyXBaMhvRcf9Rm4+3AdzJAfAbAcBXE/A+CtFV7zLIDzATwM4H2pfT1nZj8geTWAoolNvgjgjzHJ4v1qk4LXpUBOvDP6DyJfupF5GujLSNWo9z41eFw19l0tzJz12rpl8envV6QvZiiSAAAHkUlEQVTsffn6WeTz7KJj0Paaz/oySH+jYZA8EpOM220A/pHkbgCPA3iqwstvBHAHyQ8CeCCx/VMA7iJ5BYAHMZ2FW2Fmr5F8EMBLZvZmw7dRiwK5oYU+Bqhnc0bsWN6MhZ37AUTnakzdKn0J4mJtgznV53w+ZuaSY/iS15Vn9XIMDZ+iRmDee/M1cCgL7kL/W4XOl3ozhus2qew6rfpex3ROAnA2gP82sxcAXJTznHPiH8zsxsTPTwGYSzzv49H2r6W2Xx9t3wVgV3LH0SQnFwK4oukbqEuTnVQRaiDRZ7al4b7LuoTsWN6MhZf2KUCQ8fBpApT5g5N/6XuahwuM+9I4jTVZp6vO47693zJZiy2LzALVez+R/A1MZpT8uKPjnwXgaQD3R8HfIJSRq6rrsXJ9C7nL3K61AEbY7c/X+qMultVlfcFQ5dzVDeZ8yeI5ztr5/g1/m/JpHI6Mke/XrIyXmd0E4CaHx/8KgLcNfVxl5OoIKTM3REarZuO/ys19JRs3psBiPSf/PMl0TPHpXPtUlqqUPW4tmd1JL/Dtu3RA5jKzFsL5kvELLbssEjIFcnX51ggvEq8912dDs8OG9xJtfDNV+pqF85XPQVFR2bou987jDv/zxcBfQvgYlJSVSUGcv3R+hqVgTmQY6lop05KN0qEzJCFmZPIkgzifvwAYWwa0C00Csz7Ooy9dLJNC62Y+ANeNVgUp4iN1sxTpnwK5JkJryNRpXLoM4mZFSHWniM/Zs6bavqcurx8fg7hYh/fA0Bp6bdaZ60No588V13+nWaVgTqRfCuSaCiGY6yoQSzdu0/vtaJHzuZs96kbWVrpu+F5X4r9f1TozliCuz/fRNEPncwCXlM4yN6zjZQ1s3xuB8QLCZWtPdbkene/nJAQ+d5MdmyZLcYhINRoj14bP3eW6kDe+Lm/mPmXwJnwP2opUGVM5liDOR6EEcbJKsjGa1TAtezzr+Xn7UcO3narnUOd5GAqYRdpRRq4tXzNzTYKqOg30vGxDw+zcqLJxY+AqWJvlLwNCDuJ6vAdmdc2quyDv0OIsXdPXZv0s1ZVlRUVExkKBXBd8DeZcaRLM1e3a5yvVg2Zc/d076hacq6x75eKhcDP7BXU92WCuHdDE5yOx/xC/tS8K5vIeU6DRToj1RESkDZq5/+AgeQDAKwBecF0WCdI6qO5Ifao30pTqjjSluiNNvdXMTnRdiKrIUwzY1sOeb3jEzLb0sOMgeZGRM7MTSe7WH0aaUN2RJlRvpCnVHWlKdUdEuqTJTkRERERERALjRUZORERERETG4vl7gRvW9bBjdU1O8CmQ2+66ABIs1R1pQvVGmlLdkaZUd2QmmNllrsswC7yY7ERERERERESq0xg5ERERERGRwDgP5EheRnIfyadJfsx1ecQvJE8j+SDJJ0nuJXldtP3HSH6J5Nei/3808Zrro/q0j+TPuyu9uEZyDcnHSP5T9LvqjZQieQLJO0k+Fd17LlLdkSpIfjT6rPovkreTPFp1R0T64jSQI7kGwF8DeA+AswC8n+RZLssk3nkDwO+a2U8CuBDAh6M68jEA95vZJgD3R78jeuwqAGcDuAzAp6J6JrPpOgBPJn5XvZEqPgngn83sTADnYlKHVHekEMkNAD4CYIuZnQNgDSZ1Q3VHRHrhOiN3AYCnzezrZvYagC8AuNxxmcQjZva8mT0a/XwQkwbVBkzqyeejp30ewHz08+UAvmBm3zezZwA8jUk9kxlD8lQAvwDglsRm1RspRPJ4AJcC+BsAMLPXzOwlqO5INUcCOIbkkQDeAuBbUN0RkZ64DuQ2APhm4vfnom0iU0huBHAegIcAnGRmzwOTYA/A+uhpqlMS+0sAvw/gB4ltqjdS5m0ADgD4bNQt9xaSx0J1R0qY2X4ANwL4BoDnAbxsZvdBdUdEeuI6kGPGNk2jKVNIrgVwF4DfNrPvFj01Y5vq1Iwh+YsAls3skaovydimejObjgTwUwA+bWbnAXgFUVe4HKo7AgCIxr5dDuB0AKcAOJbkQtFLMrap7ohIZa4DuecAnJb4/VRMuiGIrCB5FCZB3G1mdne0+dskT44ePxnAcrRddUoA4B0Afonks5h02X4nyR1QvZFyzwF4zswein6/E5PATnVHyrwbwDNmdsDMXgdwN4CLobojIj1xHcj9J4BNJE8n+UOYDPq9x3GZxCMkiclYlSfN7C8SD90D4Oro56sB/ENi+1Ukf5jk6QA2AXh4qPKKH8zsejM71cw2YnJfecDMFqB6IyXM7H8AfJPk5mjTuwB8Bao7Uu4bAC4k+Zbos+tdmIzrVt0RkV4c6fLgZvYGyd8EcC8mszvdamZ7XZZJvPMOAB8EsIfk49G2PwDwZwDuIPkhTD48rwAAM9tL8g5MGl5vAPiwmb05fLHFU6o3UsVvAbgt+oLx6wCuxeSLT9UdyWVmD5G8E8CjmNSFxwBsB7AWqjsi0gOaqTu2iIiIiIhISFx3rRQREREREZGaFMiJiIiIiIgERoGciIiIiIhIYBTIiYiIiIiIBEaBnIiIiIiISGAUyImIiIiIiARGgZyIiIiIiEhgFMiJiIiIiIgE5v8BNaMtQNom+T0AAAAASUVORK5CYII=
+"
+>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>While this example is quite trivial and could be solved without using <code>nd.apply</code>, the method is very flexible and can  efficiently map functions of any signature over arbitrary dimensions.</p>
+
+</div>
+</div>
+</div>
+    </div>
+  </div>
+</body>
+
+ 
+
+
+</html>

--- a/nd/change.py
+++ b/nd/change.py
@@ -1,6 +1,7 @@
 from .algorithm import Algorithm, wrap_algorithm
 from .io import disassemble_complex
 from .filters import BoxcarFilter
+from .utils import requires
 try:
     from . import _change
 except ImportError:
@@ -76,6 +77,7 @@ def _omnibus_change_detection(ds, alpha=0.01, ml=None, n=1, njobs=1):
     return change_arr
 
 
+@requires('gsl')
 class OmnibusTest(ChangeDetection):
     """
     OmnibusTest
@@ -103,7 +105,7 @@ class OmnibusTest(ChangeDetection):
     def __init__(self, ml=None, n=1, alpha=0.01, *args, **kwargs):
         if _change is None:
             raise ImportError(
-                'This algorithm requires libgsl to be installed.')
+                'This algorithm requires the _change extension to be built.')
         self.ml = ml
         self.n = n
         self.alpha = alpha

--- a/nd/change.py
+++ b/nd/change.py
@@ -1,7 +1,10 @@
 from .algorithm import Algorithm, wrap_algorithm
 from .io import disassemble_complex
 from .filters import BoxcarFilter
-from . import _change
+try:
+    from . import _change
+except ImportError:
+    _change = None
 import numpy as np
 import xarray as xr
 
@@ -98,6 +101,9 @@ class OmnibusTest(ChangeDetection):
     """
 
     def __init__(self, ml=None, n=1, alpha=0.01, *args, **kwargs):
+        if _change is None:
+            raise ImportError(
+                'This algorithm requires libgsl to be installed.')
         self.ml = ml
         self.n = n
         self.alpha = alpha

--- a/nd/testing.py
+++ b/nd/testing.py
@@ -13,22 +13,25 @@ import geopandas as gpd
 from numpy.testing import assert_almost_equal
 from nd.algorithm import Algorithm
 from nd.warp import _parse_crs
+from nd.utils import check_dependencies
 import hashlib
 import os
 from collections import OrderedDict
 
-# -------------------------------------------------------------------
-# Skip markers
-# -------------------------------------------------------------------
-try:
-    import nd._change
-except ImportError:
-    GSL = False
-else:
-    GSL = True
 
-requires_gsl = pytest.mark.skipif(not GSL, reason="This test requires libgsl")
-# -------------------------------------------------------------------
+def requires(dependency):
+    """Decorator to be used for skipping tests if the dependency
+    requirements are not met.
+    """
+    if isinstance(dependency, (list, tuple)):
+        missing = not all(
+            [check_dependencies[d] for d in dependency]
+        )
+    else:
+        missing = not check_dependencies[dependency]
+    return pytest.mark.skipif(
+        missing, reason="This test requires the following "
+                        "dependencies: {}".format(dependency))
 
 
 def generate_test_dataset(

--- a/nd/testing.py
+++ b/nd/testing.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -15,6 +16,19 @@ from nd.warp import _parse_crs
 import hashlib
 import os
 from collections import OrderedDict
+
+# -------------------------------------------------------------------
+# Skip markers
+# -------------------------------------------------------------------
+try:
+    import nd._change
+except ImportError:
+    GSL = False
+else:
+    GSL = True
+
+requires_gsl = pytest.mark.skipif(not GSL, reason="This test requires libgsl")
+# -------------------------------------------------------------------
 
 
 def generate_test_dataset(

--- a/nd/tests/test_change_common.py
+++ b/nd/tests/test_change_common.py
@@ -20,6 +20,10 @@ cd_classes = [_[1] for _ in change_detectors]
 
 @pytest.mark.parametrize('cd', cd_classes)
 def test_change_input_output(cd):
+    if cd._skip:
+        pytest.skip('The dependency requirements for this class are '
+                    'not fulfilled: {}'.format(cd._requires))
+
     instance = cd()
     result = instance.apply(ds)
 

--- a/nd/tests/test_change_omnibus.py
+++ b/nd/tests/test_change_omnibus.py
@@ -9,8 +9,10 @@ except ImportError:
 else:
     GSL = True
 
+requires_gsl = pytest.mark.skipif(not GSL, reason="This test requires libgsl")
 
-@pytest.mark.skipif(not GSL, rason="This test requires libgsl")
+
+@requires_gsl
 def test_change():
     ds1 = testing.generate_test_dataset(
         dims={'y': 5, 'x': 5, 'time': 10},

--- a/nd/tests/test_change_omnibus.py
+++ b/nd/tests/test_change_omnibus.py
@@ -3,7 +3,7 @@ from nd import testing
 from nd.change import OmnibusTest
 
 
-@testing.requires_gsl
+@testing.requires('gsl')
 def test_change():
     ds1 = testing.generate_test_dataset(
         dims={'y': 5, 'x': 5, 'time': 10},

--- a/nd/tests/test_change_omnibus.py
+++ b/nd/tests/test_change_omnibus.py
@@ -1,18 +1,9 @@
-import pytest
 import xarray as xr
 from nd import testing
 from nd.change import OmnibusTest
-try:
-    import nd._change
-except ImportError:
-    GSL = False
-else:
-    GSL = True
-
-requires_gsl = pytest.mark.skipif(not GSL, reason="This test requires libgsl")
 
 
-@requires_gsl
+@testing.requires_gsl
 def test_change():
     ds1 = testing.generate_test_dataset(
         dims={'y': 5, 'x': 5, 'time': 10},

--- a/nd/tests/test_change_omnibus.py
+++ b/nd/tests/test_change_omnibus.py
@@ -1,8 +1,16 @@
+import pytest
 import xarray as xr
 from nd import testing
 from nd.change import OmnibusTest
+try:
+    import nd._change
+except ImportError:
+    GSL = False
+else:
+    GSL = True
 
 
+@pytest.mark.skipif(not GSL, rason="This test requires libgsl")
 def test_change():
     ds1 = testing.generate_test_dataset(
         dims={'y': 5, 'x': 5, 'time': 10},

--- a/nd/tests/test_xarray_accessor.py
+++ b/nd/tests/test_xarray_accessor.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from numpy.testing import assert_equal
 from xarray.testing import assert_equal as xr_assert_equal
 from nd.testing import (generate_test_dataset, generate_test_dataarray,
-                        assert_equal_files, assert_equal_crs, requires_gsl)
+                        assert_equal_files, assert_equal_crs, requires)
 from nd import warp, filters, io, change, utils, visualize
 from nd._xarray import patch_doc
 from rasterio.crs import CRS
@@ -217,7 +217,7 @@ def test_accessor_nd_apply(generator):
 # Test change detection accessors
 # -------------------------------
 
-@requires_gsl
+@requires('gsl')
 def test_accessor_nd_omnibus():
     ds1 = generate_test_dataset(
         dims={'y': 5, 'x': 5, 'time': 10},

--- a/nd/tests/test_xarray_accessor.py
+++ b/nd/tests/test_xarray_accessor.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from numpy.testing import assert_equal
 from xarray.testing import assert_equal as xr_assert_equal
 from nd.testing import (generate_test_dataset, generate_test_dataarray,
-                        assert_equal_files, assert_equal_crs)
+                        assert_equal_files, assert_equal_crs, requires_gsl)
 from nd import warp, filters, io, change, utils, visualize
 from nd._xarray import patch_doc
 from rasterio.crs import CRS
@@ -217,6 +217,7 @@ def test_accessor_nd_apply(generator):
 # Test change detection accessors
 # -------------------------------
 
+@requires_gsl
 def test_accessor_nd_omnibus():
     ds1 = generate_test_dataset(
         dims={'y': 5, 'x': 5, 'time': 10},

--- a/nd/warp.py
+++ b/nd/warp.py
@@ -764,17 +764,22 @@ def _reproject(ds, src_crs=None, dst_crs=None, dst_transform=None,
             # that are defined over only one variable.
             #
             if dst_crs == src_crs and v not in ds.dims:
-                expanded = _expand_var_to_xy(ds.coords[v], ds.coords)
-                if ds.coords[v].dims == ('x',):
-                    result.coords[v] = (('y', 'x'), _reproject_da(
-                        expanded, (height, width)))
-                elif ds.coords[v].dims == ('y',):
-                    result.coords[v] = (('y', 'x'), _reproject_da(
-                        expanded, (height, width)))
 
-                # Remove redundant dimensions
-                coords = _collapse_coords(result.coords[v])
-                result.coords[v] = (coords.dims, coords)
+                if len(ds.coords[v].dims) == 0:
+                    result.coords[v] = (ds.coords[v].dims, ds.coords[v])
+
+                else:
+                    expanded = _expand_var_to_xy(ds.coords[v], ds.coords)
+                    if ds.coords[v].dims == ('x',):
+                        result.coords[v] = (('y', 'x'), _reproject_da(
+                            expanded, (height, width)))
+                    elif ds.coords[v].dims == ('y',):
+                        result.coords[v] = (('y', 'x'), _reproject_da(
+                            expanded, (height, width)))
+
+                    # Remove redundant dimensions
+                    coords = _collapse_coords(result.coords[v])
+                    result.coords[v] = (coords.dims, coords)
 
             if not set(ds.coords[v].dims).issuperset({'x', 'y'}):
                 continue

--- a/setup.py
+++ b/setup.py
@@ -76,19 +76,24 @@ change_include_dirs = ['.']
 cmdclass = {}
 
 extensions = [
-    Extension("nd._change", ["nd/_change" + ext],
-              libraries=change_libraries,
-              library_dirs=change_library_dirs,
-              include_dirs=change_include_dirs,
-              extra_compile_args=['-O3'],
-              extra_link_args=[],
-              ),
     Extension("nd._filters", ["nd/_filters" + ext],
               extra_compile_args=['-O3'],
               extra_link_args=[],
               ),
     Extension("nd._warp", ["nd/_warp" + ext]),
 ]
+if GSL:
+    # Only build the cython change module
+    # if libgsl is available
+    extensions.append(
+        Extension("nd._change", ["nd/_change" + ext],
+                  libraries=change_libraries,
+                  library_dirs=change_library_dirs,
+                  include_dirs=change_include_dirs,
+                  extra_compile_args=['-O3'],
+                  extra_link_args=[],
+                  )
+    )
 
 if USE_CYTHON:
     extensions = cythonize(

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,12 @@ if USE_CYTHON:
         extensions, compiler_directives=compiler_directives)
     cmdclass = {'build_ext': build_ext}
 
-if mock_install or not GSL:
+if mock_install:
     include_dirs = []
+elif not GSL:
+    include_dirs = [
+        numpy.get_include()
+    ]
 else:
     include_dirs = [
         numpy.get_include(),

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,19 @@ def get_gsl_lib_dir():
     return lib_gsl_dir
 
 
+# Check if libgsl is available
+try:
+    GSL_INC_DIR = get_gsl_include_dir()
+    GSL_LIB_DIR = get_gsl_lib_dir()
+    GSL = True
+except ImportError:
+    GSL = False
+
 change_libraries = ['gsl', 'gslcblas']
-if mock_install:
+if mock_install or not GSL:
     change_library_dirs = []
 else:
-    change_library_dirs = [get_gsl_lib_dir()]
+    change_library_dirs = [GSL_LIB_DIR]
 change_include_dirs = ['.']
 
 cmdclass = {}
@@ -87,12 +95,12 @@ if USE_CYTHON:
         extensions, compiler_directives=compiler_directives)
     cmdclass = {'build_ext': build_ext}
 
-if mock_install:
+if mock_install or not GSL:
     include_dirs = []
 else:
     include_dirs = [
         numpy.get_include(),
-        get_gsl_include_dir()
+        GSL_INC_DIR
     ]
 
 install_requires = [


### PR DESCRIPTION
`libgsl` is currently only used in `nd.change.OmnibusTest` and should therefore be an optional dependency.

An `ImportError` will be raised on instantiation of `OmnibusTest` if `libgsl` is missing.

Also fixes #56 